### PR TITLE
feat: rate limit 강화, OCR 인라인 편집, 워크플로우 정비

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,80 @@ Additional rules:
 - `prompts/reviewer.md`
 - `prompts/git-manager.md`
 
+## Work Unit & Worktree Workflow
+
+구현을 시작하기 전에 작업 단위를 GitHub Issue로 정의하고, 이슈별 브랜치와 worktree를 만들어 병렬 작업한다.
+
+### Source of Truth
+
+**GitHub Issues = 작업 백로그의 단일 진실 공급원.**
+모든 작업은 이슈로 먼저 등록한 뒤 구현을 시작한다.
+
+### 새 작업 시작 절차
+
+```bash
+# 1. 이슈 생성
+gh issue create \
+  --title "OCR 로딩 애니메이션" \
+  --body "수용 기준:\n- 종목명 하나씩 순서대로 등장\n- 처리 중/완료 상태 표시"
+# → Issue #5 생성됨
+
+# 2. 브랜치 + worktree 생성
+git fetch origin main
+git branch feat/5-ocr-loading origin/main
+git worktree add ../worktrees/feat-5-ocr-loading feat/5-ocr-loading
+
+# 3. 해당 worktree에서 작업
+cd ../worktrees/feat-5-ocr-loading
+```
+
+### 네이밍 컨벤션
+
+| 종류 | 패턴 | 예시 |
+|------|------|------|
+| 기능 | `feat/<issue>-<slug>` | `feat/5-ocr-loading` |
+| 버그 | `fix/<issue>-<slug>` | `fix/12-gemini-429` |
+| 리팩토링 | `refactor/<issue>-<slug>` | `refactor/8-ocr-parser` |
+| 작업 디렉토리 | `../worktrees/<branch>` | `../worktrees/feat-5-ocr-loading` |
+
+### 활성 작업 확인
+
+```bash
+gh issue list              # 전체 백로그 (열린 이슈)
+git worktree list          # 현재 활성 worktree 목록
+```
+
+### PR 머지 후 정리
+
+```bash
+# PR 머지 확인 후
+git worktree remove ../worktrees/feat-5-ocr-loading
+git branch -d feat/5-ocr-loading
+gh issue close 5
+```
+
+### 병렬 작업 시 파일 충돌 방지
+
+이슈를 만들 때 **수정 대상 파일**을 명시한다. 동시에 진행 중인 이슈가 같은 파일을 건드리면 하나가 먼저 머지될 때까지 다른 이슈를 대기시킨다.
+
+```
+이슈 #5 (OCR 로딩): src/app/page.tsx, page.module.css
+이슈 #6 (confirm 반응형): src/components/ConfirmCard.tsx, ConfirmCard.module.css
+→ 파일 겹침 없음 → 병렬 진행 가능 ✅
+
+이슈 #5 (OCR 로딩): src/app/page.tsx
+이슈 #7 (수동 입력): src/app/page.tsx
+→ 같은 파일 → 하나씩 순차 진행 ⚠️
+```
+
+### Claude + Codex 병렬 트랙 연결
+
+```
+이슈 #5 → worktree-A → Claude 구현 → Codex 리뷰 → PR
+이슈 #6 → worktree-B → Codex 구현 → Claude 리뷰 → PR
+(동시 진행, 각자 독립 worktree)
+```
+
 ## Tech Stack
 
 - **Framework:** Next.js 15+ (App Router)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,36 +9,39 @@ For any non-trivial code change, follow this order:
 4. Refactor: improve structure only after tests pass.
 5. Review: require an independent reviewer before git management or completion.
 
-## Default Codex Boundary
+## Agent Division of Labor
 
-Unless the user explicitly overrides this, Codex is responsible only for:
+### Claude (primary implementer)
+Claude owns the full implementation pipeline:
 1. planning
 2. implementation
 3. refactoring
 4. tests and verification
+5. self-review (1차)
 
-After tests/verification pass, Codex must stop and hand off.
+After `pnpm verify` passes and self-review is done, Claude requests a Codex independent review.
 
-Codex must **not** do the following by default:
-- final review
-- PR review
-- PR creation / publish / ship
-- merge or release steps
+Claude also owns:
+- Codex 피드백 반영 및 수정
+- PR 생성 / ship / merge
 
-Those steps are owned by **Claude** unless the user explicitly asks Codex to do them.
+### Codex (independent reviewer)
+Codex is used exclusively as a **second-opinion reviewer** after Claude completes implementation.
 
-Required Codex handoff after implementation/test completion:
-- Plan
-- Files Changed
-- Commands Run
-- Test Results
-- Remaining Risks
-- `Claude Handoff` section with:
-  - Scope
-  - Changed files
-  - Verification completed
-  - Known risks
-  - Suggested review focus
+Run via `/codex review` (pass/fail gate) or `/codex challenge` (adversarial — tries to break the code).
+
+Codex must **not**:
+- implement features
+- make code changes
+- create PRs or commits
+
+Codex review output is handed back to Claude for triage and fixes.
+
+Required Codex review output:
+- Pass/fail gate verdict
+- P1 blockers (must fix before merge)
+- P2 suggestions (optional improvements)
+- Cross-model findings vs Claude's own review
 
 Definition of done:
 - `pnpm verify` passes
@@ -60,24 +63,25 @@ Rules:
 
 ## Role Lanes
 
-- **Planner:** writes the short plan, names files to inspect, and lists required test updates before code changes begin.
-- **Implementer:** makes the smallest viable code change that satisfies the plan and hands off without doing final review.
-- **Tester:** adds or updates tests, runs `pnpm verify`, and reports exact failures if verification breaks.
-- **Reviewer:** performs findings-first review, flags missing tests as `P1`, and calls out hidden side effects, risky refactors, security regressions, and auth coverage gaps. Default owner: Claude.
-- **Git Manager:** handles branch, staging, commit, push, and PR hygiene only after review is clean. Default owner: Claude.
+- **Planner:** writes the short plan, names files to inspect, and lists required test updates before code changes begin. Owner: **Claude**.
+- **Implementer:** makes the smallest viable code change that satisfies the plan and hands off without doing final review. Owner: **Claude**.
+- **Tester:** adds or updates tests, runs `pnpm verify`, and reports exact failures if verification breaks. Owner: **Claude**.
+- **Reviewer (1차):** performs self-review, flags obvious issues before Codex review. Owner: **Claude**.
+- **Reviewer (2차):** independent second-opinion review via `/codex review` or `/codex challenge`. Owner: **Codex**.
+- **Git Manager:** handles branch, staging, commit, push, and PR hygiene only after Codex review is clean. Owner: **Claude**.
 
 ## Role Execution Order
 
 For any non-trivial change, route work through:
 
-`planner -> implementer -> tester -> reviewer -> git-manager`
+`planner → implementer → tester → reviewer(Claude) → reviewer(Codex) → git-manager`
 
 Additional rules:
-- Review is required after tests and before git management.
-- If review finds issues, return to implementer, then tester, then run review again.
-- Use the role prompts in `prompts/` for these lanes when delegating to separate agents.
-- By default, Codex executes only through `tester` and then stops with a Claude handoff.
-- `reviewer` and `git-manager` lanes are reserved for Claude unless the user explicitly assigns them to Codex.
+- Claude self-review comes before Codex review. Fix obvious issues first.
+- Codex review is required after Claude self-review and before git management.
+- If Codex finds P1 issues, return to implementer → tester → Claude self-review → Codex review again.
+- Use the role prompts in `prompts/` for these lanes when delegating.
+- `git-manager` lane is always Claude.
 
 ## Role Prompt Files
 
@@ -178,15 +182,24 @@ Refactor when:
 - A component has 3+ separate responsibilities
 
 ## [Review Mandate]
-Final review is owned by Claude by default.
 
-Codex should perform the review table below **only if the user explicitly asks Codex to review**.
-1. **Maintainer**: Check for architecture & Tidy First compliance.
-2. **Security Officer**: Check for data safety & financial integrity.
-3. **Performance Engineer**: Check for query optimization & resource usage.
-4. **QA Engineer**: Check for test coverage & edge cases.
+### Claude 1차 리뷰 (self-review)
+Claude가 구현 후 스스로 점검하는 항목:
+1. **Tidy First 준수**: structural/behavioral 변경 분리 여부
+2. **테스트 커버리지**: 변경된 로직에 대한 테스트 존재 여부
+3. **타입 안전성**: `any` 사용 여부, 타입 추론 적절성
+4. **보안**: API route 입력 검증, 인증 처리
 
-When Codex is not explicitly assigned review, stop after verification and provide a Claude handoff instead of a review verdict.
+### Codex 2차 리뷰 (independent review)
+Claude 1차 리뷰 통과 후 `/codex review` 또는 `/codex challenge` 실행.
+
+Codex 리뷰 관점:
+1. **Maintainer**: architecture & Tidy First compliance
+2. **Security Officer**: data safety & financial integrity
+3. **Performance Engineer**: query optimization & resource usage
+4. **QA Engineer**: test coverage & edge cases
+
+P1 (blocker) 발견 시 Claude가 수정 후 재검토. P2는 Claude 판단으로 반영 여부 결정.
 
 ## Deploy Configuration
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,37 +11,52 @@ For any non-trivial code change, follow this order:
 
 ## Agent Division of Labor
 
-### Claude (primary implementer)
-Claude owns the full implementation pipeline:
-1. planning
-2. implementation
-3. refactoring
-4. tests and verification
-5. self-review (1차)
+### Parallel Track Model
 
-After `pnpm verify` passes and self-review is done, Claude requests a Codex independent review.
+큰 작업은 **독립적인 서브태스크로 분해**한 뒤 두 트랙에 병렬 배분한다.
+핵심 제약: **두 트랙이 같은 파일을 동시에 수정하면 충돌 발생** → 분해 시 파일 단위 겹침 없게 나눠야 한다.
 
-Claude also owns:
-- Codex 피드백 반영 및 수정
-- PR 생성 / ship / merge
+```
+1. Task Decomposition (Claude)
+   └── 독립 서브태스크로 분리 (파일 겹침 없게)
+   └── Track A / Track B 배분
 
-### Codex (independent reviewer)
-Codex is used exclusively as a **second-opinion reviewer** after Claude completes implementation.
+Track A (Claude 구현)        Track B (Codex 구현)
+────────────────────         ────────────────────
+Claude 구현                  Codex 구현
+     ↓                            ↓
+Codex 리뷰                   Claude 리뷰
+(/codex review)                   ↓
+     ↓                       Claude 피드백 반영
+Claude 피드백 반영                  ↓
+     ↓                            ↓
+        merge → main (Claude git-manager)
+```
 
-Run via `/codex review` (pass/fail gate) or `/codex challenge` (adversarial — tries to break the code).
+### 병렬 실행 방법
 
-Codex must **not**:
-- implement features
-- make code changes
-- create PRs or commits
+- **git worktree 사용** — 두 트랙이 각자 독립 브랜치에서 작업 후 병합
+- **Codex 트랙 시작**: `/omc-teams 1:codex "Track B 구현 내용"` 으로 Codex 워커 실행
+- Claude는 Track A를 직접 구현하면서 Codex Track B와 병렬 진행
 
-Codex review output is handed back to Claude for triage and fixes.
+### 단일 트랙 (작은 작업)
 
-Required Codex review output:
-- Pass/fail gate verdict
-- P1 blockers (must fix before merge)
-- P2 suggestions (optional improvements)
-- Cross-model findings vs Claude's own review
+작업이 작거나 파일 분리가 불가능한 경우:
+
+```
+Claude 구현 → pnpm verify → /codex review → Claude 피드백 반영 → PR
+```
+
+### 역할 경계
+
+| 역할 | Claude | Codex |
+|------|--------|-------|
+| Task decomposition | ✅ 항상 | ✗ |
+| 구현 (Track A) | ✅ | ✗ |
+| 구현 (Track B) | ✗ | ✅ |
+| Track A 리뷰 | ✗ | ✅ (`/codex review`) |
+| Track B 리뷰 | ✅ | ✗ |
+| git-manager / PR | ✅ 항상 | ✗ |
 
 Definition of done:
 - `pnpm verify` passes
@@ -63,25 +78,33 @@ Rules:
 
 ## Role Lanes
 
-- **Planner:** writes the short plan, names files to inspect, and lists required test updates before code changes begin. Owner: **Claude**.
-- **Implementer:** makes the smallest viable code change that satisfies the plan and hands off without doing final review. Owner: **Claude**.
-- **Tester:** adds or updates tests, runs `pnpm verify`, and reports exact failures if verification breaks. Owner: **Claude**.
-- **Reviewer (1차):** performs self-review, flags obvious issues before Codex review. Owner: **Claude**.
-- **Reviewer (2차):** independent second-opinion review via `/codex review` or `/codex challenge`. Owner: **Codex**.
-- **Git Manager:** handles branch, staging, commit, push, and PR hygiene only after Codex review is clean. Owner: **Claude**.
+- **Decomposer:** 작업을 파일 겹침 없는 독립 서브태스크로 분리하고 Track A/B 배분. Owner: **Claude**.
+- **Implementer (Track A):** Claude가 구현. `pnpm verify` 통과 후 Codex 리뷰 요청. Owner: **Claude**.
+- **Implementer (Track B):** Codex가 구현. `pnpm verify` 통과 후 Claude 리뷰. Owner: **Codex**.
+- **Reviewer (Track A):** `/codex review` 또는 `/codex challenge`. Owner: **Codex**.
+- **Reviewer (Track B):** Claude가 Codex 구현물 검토. Owner: **Claude**.
+- **Git Manager:** 두 트랙 모두 리뷰 통과 후 병합 및 PR. Owner: **Claude**.
 
 ## Role Execution Order
 
-For any non-trivial change, route work through:
+**병렬 (큰 작업):**
 
-`planner → implementer → tester → reviewer(Claude) → reviewer(Codex) → git-manager`
+```
+Decomposer(Claude)
+    ├── Track A: Claude 구현 → pnpm verify → Codex 리뷰 → Claude 수정
+    └── Track B: Codex 구현 → pnpm verify → Claude 리뷰 → Codex 수정
+                    ↓ (양쪽 완료 후)
+              git-manager(Claude) → PR
+```
+
+**단일 (작은 작업):**
+
+`Claude 구현 → pnpm verify → /codex review → 수정 → git-manager`
 
 Additional rules:
-- Claude self-review comes before Codex review. Fix obvious issues first.
-- Codex review is required after Claude self-review and before git management.
-- If Codex finds P1 issues, return to implementer → tester → Claude self-review → Codex review again.
-- Use the role prompts in `prompts/` for these lanes when delegating.
-- `git-manager` lane is always Claude.
+- P1 발견 시 해당 트랙 구현자가 수정 후 재검토.
+- Track B Codex 구현은 `/omc-teams 1:codex "..."` 로 실행.
+- `git-manager` 는 항상 Claude.
 
 ## Role Prompt Files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,192 +1,80 @@
 A type-safe, maintainable web interface for stock portfolio analysis and rebalancing.
 
-# Mandatory delivery workflow
+## Definition of Done
 
-For any non-trivial code change, follow this order:
-1. Design: write a short plan and identify files to inspect.
-2. Minimal implementation: make the smallest viable code change.
-3. Tests: add or update tests for the change.
-4. Refactor: improve structure only after tests pass.
-5. Review: require an independent reviewer before git management or completion.
-
-## Agent Division of Labor
-
-### Parallel Track Model
-
-큰 작업은 **독립적인 서브태스크로 분해**한 뒤 두 트랙에 병렬 배분한다.
-핵심 제약: **두 트랙이 같은 파일을 동시에 수정하면 충돌 발생** → 분해 시 파일 단위 겹침 없게 나눠야 한다.
-
-```
-1. Task Decomposition (Claude)
-   └── 독립 서브태스크로 분리 (파일 겹침 없게)
-   └── Track A / Track B 배분
-
-Track A (Claude 구현)        Track B (Codex 구현)
-────────────────────         ────────────────────
-Claude 구현                  Codex 구현
-     ↓                            ↓
-Codex 리뷰                   Claude 리뷰
-(/codex review)                   ↓
-     ↓                       Claude 피드백 반영
-Claude 피드백 반영                  ↓
-     ↓                            ↓
-        merge → main (Claude git-manager)
-```
-
-### 병렬 실행 방법
-
-- **git worktree 사용** — 두 트랙이 각자 독립 브랜치에서 작업 후 병합
-- **Codex 트랙 시작**: `/omc-teams 1:codex "Track B 구현 내용"` 으로 Codex 워커 실행
-- Claude는 Track A를 직접 구현하면서 Codex Track B와 병렬 진행
-
-### 단일 트랙 (작은 작업)
-
-작업이 작거나 파일 분리가 불가능한 경우:
-
-```
-Claude 구현 → pnpm verify → /codex review → Claude 피드백 반영 → PR
-```
-
-### 역할 경계
-
-| 역할 | Claude | Codex |
-|------|--------|-------|
-| Task decomposition | ✅ 항상 | ✗ |
-| 구현 (Track A) | ✅ | ✗ |
-| 구현 (Track B) | ✗ | ✅ |
-| Track A 리뷰 | ✗ | ✅ (`/codex review`) |
-| Track B 리뷰 | ✅ | ✗ |
-| git-manager / PR | ✅ 항상 | ✗ |
-
-Definition of done:
-- `pnpm verify` passes
-- If `pnpm` is unavailable on `PATH`, use `COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm@9.15.4 verify` without mutating `package.json`
+- `pnpm verify` passes (lint + typecheck + tests)
+- `pnpm` 미설치 시: `COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm@9.15.4 verify`
 - no lint/typecheck/test failures
-- final response must include:
-  - Plan
-  - Files Changed
-  - Commands Run
-  - Test Results
-  - Remaining Risks
+- final response includes: Plan / Files Changed / Commands Run / Test Results / Remaining Risks
 
 Rules:
 - Never claim completion without running the verification command.
-- Never use natural-language-only validation.
 - Prefer smaller, staged changes over one large rewrite.
 - Do not refactor before tests are updated.
-- The implementer agent must not perform final review on its own changes.
 
-## Role Lanes
+## Agent Roles & Execution
 
-- **Decomposer:** 작업을 파일 겹침 없는 독립 서브태스크로 분리하고 Track A/B 배분. Owner: **Claude**.
-- **Implementer (Track A):** Claude가 구현. `pnpm verify` 통과 후 Codex 리뷰 요청. Owner: **Claude**.
-- **Implementer (Track B):** Codex가 구현. `pnpm verify` 통과 후 Claude 리뷰. Owner: **Codex**.
-- **Reviewer (Track A):** `/codex review` 또는 `/codex challenge`. Owner: **Codex**.
-- **Reviewer (Track B):** Claude가 Codex 구현물 검토. Owner: **Claude**.
-- **Git Manager:** 두 트랙 모두 리뷰 통과 후 병합 및 PR. Owner: **Claude**.
+| Role | Owner | Description |
+|------|-------|-------------|
+| Decomposer | Claude | 파일 겹침 없는 독립 서브태스크로 분리, Track A/B 배분 |
+| Implementer (Track A) | Claude | 구현 → `pnpm verify` → Codex 리뷰 요청 |
+| Implementer (Track B) | Codex | 구현 → `pnpm verify` → Claude 리뷰 |
+| Reviewer (Track A) | Codex | `/codex review` 또는 `/codex challenge` |
+| Reviewer (Track B) | Claude | Codex 구현물 검토 |
+| Git Manager | Claude | 리뷰 통과 후 PR 생성 및 머지. 항상 Claude. |
 
-## Role Execution Order
+**단일 트랙 (작은 작업):**
+```
+Claude 구현 → pnpm verify → /codex review → 수정 → PR
+```
 
-**병렬 (큰 작업):**
-
+**병렬 트랙 (큰 작업, 파일 겹침 없을 때):**
 ```
 Decomposer(Claude)
-    ├── Track A: Claude 구현 → pnpm verify → Codex 리뷰 → Claude 수정
-    └── Track B: Codex 구현 → pnpm verify → Claude 리뷰 → Codex 수정
+    ├── Track A: Claude 구현 → pnpm verify → Codex 리뷰 → 수정
+    └── Track B: Codex 구현 → pnpm verify → Claude 리뷰 → 수정
                     ↓ (양쪽 완료 후)
-              git-manager(Claude) → PR
+              Git Manager(Claude) → PR
 ```
 
-**단일 (작은 작업):**
-
-`Claude 구현 → pnpm verify → /codex review → 수정 → git-manager`
-
-Additional rules:
 - P1 발견 시 해당 트랙 구현자가 수정 후 재검토.
-- Track B Codex 구현은 `/omc-teams 1:codex "..."` 로 실행.
-- `git-manager` 는 항상 Claude.
-
-## Role Prompt Files
-
-- `prompts/planner.md`
-- `prompts/implementer.md`
-- `prompts/tester.md`
-- `prompts/reviewer.md`
-- `prompts/git-manager.md`
+- Track B 시작: `omc team 1:codex "..."` (tmux worktree에서 실행)
+- Role prompts: `prompts/planner.md`, `prompts/implementer.md`, `prompts/tester.md`, `prompts/reviewer.md`, `prompts/git-manager.md`
 
 ## Work Unit & Worktree Workflow
 
-구현을 시작하기 전에 작업 단위를 GitHub Issue로 정의하고, 이슈별 브랜치와 worktree를 만들어 병렬 작업한다.
+**GitHub Issues = 작업 백로그의 단일 진실 공급원.** 모든 작업은 이슈로 먼저 등록한 뒤 구현을 시작한다.
 
-### Source of Truth
-
-**GitHub Issues = 작업 백로그의 단일 진실 공급원.**
-모든 작업은 이슈로 먼저 등록한 뒤 구현을 시작한다.
-
-### 새 작업 시작 절차
+### 새 작업 시작
 
 ```bash
-# 1. 이슈 생성
-gh issue create \
-  --title "OCR 로딩 애니메이션" \
-  --body "수용 기준:\n- 종목명 하나씩 순서대로 등장\n- 처리 중/완료 상태 표시"
-# → Issue #5 생성됨
-
-# 2. 브랜치 + worktree 생성
+gh issue create --title "기능명" --body "수용 기준:\n- ..."
+# → Issue #N 생성
 git fetch origin main
-git branch feat/5-ocr-loading origin/main
-git worktree add ../worktrees/feat-5-ocr-loading feat/5-ocr-loading
-
-# 3. 해당 worktree에서 작업
-cd ../worktrees/feat-5-ocr-loading
+git branch feat/N-slug origin/main
+git worktree add ../worktrees/feat-N-slug feat/N-slug
 ```
 
-### 네이밍 컨벤션
-
-| 종류 | 패턴 | 예시 |
-|------|------|------|
-| 기능 | `feat/<issue>-<slug>` | `feat/5-ocr-loading` |
-| 버그 | `fix/<issue>-<slug>` | `fix/12-gemini-429` |
-| 리팩토링 | `refactor/<issue>-<slug>` | `refactor/8-ocr-parser` |
-| 작업 디렉토리 | `../worktrees/<branch>` | `../worktrees/feat-5-ocr-loading` |
+네이밍: `feat/<issue>-<slug>` / `fix/<issue>-<slug>` / `refactor/<issue>-<slug>`
 
 ### 활성 작업 확인
 
 ```bash
-gh issue list              # 전체 백로그 (열린 이슈)
-git worktree list          # 현재 활성 worktree 목록
+gh issue list        # 전체 백로그
+git worktree list    # 활성 worktree
 ```
 
 ### PR 머지 후 정리
 
 ```bash
-# PR 머지 확인 후
-git worktree remove ../worktrees/feat-5-ocr-loading
-git branch -d feat/5-ocr-loading
-gh issue close 5
+git worktree remove ../worktrees/feat-N-slug
+git branch -d feat/N-slug
+gh issue close N
 ```
 
-### 병렬 작업 시 파일 충돌 방지
+### 파일 충돌 방지
 
-이슈를 만들 때 **수정 대상 파일**을 명시한다. 동시에 진행 중인 이슈가 같은 파일을 건드리면 하나가 먼저 머지될 때까지 다른 이슈를 대기시킨다.
-
-```
-이슈 #5 (OCR 로딩): src/app/page.tsx, page.module.css
-이슈 #6 (confirm 반응형): src/components/ConfirmCard.tsx, ConfirmCard.module.css
-→ 파일 겹침 없음 → 병렬 진행 가능 ✅
-
-이슈 #5 (OCR 로딩): src/app/page.tsx
-이슈 #7 (수동 입력): src/app/page.tsx
-→ 같은 파일 → 하나씩 순차 진행 ⚠️
-```
-
-### Claude + Codex 병렬 트랙 연결
-
-```
-이슈 #5 → worktree-A → Claude 구현 → Codex 리뷰 → PR
-이슈 #6 → worktree-B → Codex 구현 → Claude 리뷰 → PR
-(동시 진행, 각자 독립 worktree)
-```
+이슈 생성 시 수정 대상 파일을 명시한다. 동시 진행 중인 이슈가 같은 파일을 수정하면 하나가 머지될 때까지 대기.
 
 ## Tech Stack
 
@@ -216,114 +104,46 @@ src/
     sectors.json           # Static sector data
 ```
 
-## Core Philosophy: Easy-to-Change Code
+## Code Standards
 
-Code is "easy to change" when it satisfies four criteria: **Readability, Predictability, Cohesion, Coupling**.
+**Easy-to-change code:** Readability · Predictability · Cohesion · Coupling
 
-### 1. Readability
+- Separate code that doesn't execute together (split by role/condition)
+- Consistent return types across similar hooks
+- Single responsibility per component and hook
+- Extract only when a pattern repeats 3+ times
+- Name complex conditions and magic numbers
 
-- **Separate code that doesn't execute together** — split components by role/condition rather than mixing branches
-- **Abstract implementation details** — components call named functions, not raw fetch/localStorage
-- **Split hooks by logic type** — `usePortfolioData`, `usePortfolioUI`, `usePortfolioForm` instead of one monolithic hook
-- **Name complex conditions and magic numbers** — no unexplained numeric literals
-- **Top-to-bottom flow** — null checks first, data fetching next, effects last, render at the end
-- **Avoid nested ternaries** — extract to named functions when conditions are complex
-
-### 2. Predictability
-
-- **Consistent return types** — similar hooks return the same shape
-- **Reveal hidden logic** — no side effects inside functions that appear to only fetch data
-- **No name collisions** — if renaming is needed to disambiguate, do it
-
-### 3. Cohesion
-
-- **Related files stay together** — as the project grows, organize by domain (e.g., `features/portfolio/`) rather than file type
-- **Single source of truth for constants** — shared values live in `src/lib/` or `src/data/`, never duplicated
-
-### 4. Coupling
-
-- **Single responsibility** — components and hooks do one thing
-- **Allow duplication over wrong abstraction** — extract only when a pattern repeats 3+ times
-- **Eliminate props drilling beyond 2–3 levels** — use composition or context
-
-## Domain Rules
-
-- **중복 티커 자동 제거 금지:** 같은 티커가 입력되더라도 자동으로 제거하지 않는다. 유저가 직접 판단해야 하며, 다른 계좌에 동일 종목이 존재할 수 있다.
-
-## Coding Conventions
-
+**Conventions:**
 - Functional components only. No `any`.
-- Declarative UI: `UI = f(state)`.
-- Use CSS Modules for component-scoped styles.
-- TypeScript: use type inference where possible, be explicit for function parameters, use union types for finite states (`'idle' | 'loading' | 'success' | 'error'`).
+- CSS Modules for component-scoped styles.
+- Union types for finite states: `'idle' | 'loading' | 'success' | 'error'`
 
-## Tidy First Approach
-
-**Structural changes** (renaming, extracting components, updating types) and **behavioral changes** (new logic, API calls) must never be mixed in the same commit.
-- Never mix structural and behavioral changes in the same commit
-- Always make structural changes first when both are needed
-- Validate structural changes do not alter behavior by running tests before and after
-
-## Commit Discipline
-
+**Tidy First:** structural changes (rename, extract) and behavioral changes (new logic) must be separate commits.
+- Commit prefixes: `refactor:` (structural), `feat:` / `fix:` (behavioral)
 - Only commit when all Vitest suites pass and TypeScript shows zero errors.
-- Commit message prefixes: `refactor:` (structural), `feat:` / `fix:` (behavioral).
 
-## Refactoring Signals
+**Refactor when:** file > 200 lines · function > 50 lines · props drill 3+ levels · same code in 3+ places
 
-Refactor when:
-- A file exceeds 200 lines
-- A function exceeds 50 lines
-- Props pass through 3+ components unchanged
-- The same code appears in 3+ places
-- A component has 3+ separate responsibilities
+**Domain rule:** 중복 티커 자동 제거 금지 — 다른 계좌에 동일 종목이 있을 수 있다.
 
-## [Review Mandate]
+## Review Mandate
 
-### Claude 1차 리뷰 (self-review)
-Claude가 구현 후 스스로 점검하는 항목:
-1. **Tidy First 준수**: structural/behavioral 변경 분리 여부
-2. **테스트 커버리지**: 변경된 로직에 대한 테스트 존재 여부
-3. **타입 안전성**: `any` 사용 여부, 타입 추론 적절성
-4. **보안**: API route 입력 검증, 인증 처리
+**Claude 1차 (self-review):** Tidy First 준수 · 테스트 커버리지 · `any` 없음 · API route 입력 검증
 
-### Codex 2차 리뷰 (independent review)
-Claude 1차 리뷰 통과 후 `/codex review` 또는 `/codex challenge` 실행.
+**Codex 2차 (independent):** `/codex review` 또는 `/codex challenge` 실행.
+관점: architecture & Tidy First · data safety · performance · test coverage
 
-Codex 리뷰 관점:
-1. **Maintainer**: architecture & Tidy First compliance
-2. **Security Officer**: data safety & financial integrity
-3. **Performance Engineer**: query optimization & resource usage
-4. **QA Engineer**: test coverage & edge cases
-
-P1 (blocker) 발견 시 Claude가 수정 후 재검토. P2는 Claude 판단으로 반영 여부 결정.
+P1(blocker) → Claude가 수정 후 재검토. P2 → Claude 판단으로 반영 여부 결정.
 
 ## Deploy Configuration
 
-- Platform: Vercel
+- Platform: Vercel / auto-deploy on push to `main`
 - Production URL: (Vercel 프로젝트 생성 후 기입)
-- Deploy workflow: auto-deploy on push to main
-- Health check: production URL
 - Pre-merge: `bun run verify`
 
-환경변수 (Vercel 대시보드에서 설정):
-- `ANTHROPIC_API_KEY` — Production + Preview 모두 설정 필수
-- `UPSTASH_REDIS_REST_URL` — Production만 (없으면 rate limiting 비활성화, 정상 동작)
-- `UPSTASH_REDIS_REST_TOKEN` — Production만
+환경변수 (Vercel 대시보드):
+- `ANTHROPIC_API_KEY` — Production + Preview 필수
+- `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` — Production만 (없으면 rate limiting 비활성화, 정상 동작)
 
-## Progress Tracking
-
-작업 단위(계획 → 구현 → 리팩토링 → 테스트 → 리뷰 → PR → 병합)를 `PROGRESS.md`에 기록한다.
-
-형식:
-```
-## YYYY-MM-DD
-- [ ] 작업 한 줄 요약   ← 작업 시작 시 추가
-- [x] 작업 한 줄 요약   ← PR 병합 후 체크
-```
-
-규칙:
-- 작업 시작 시 `- [ ]`로 항목을 추가한다
-- PR이 main에 병합되면 `- [x]`로 변경한다
-- 파일 단위가 아닌 논리적 변경 단위로 한 줄씩 작성한다
-- 한국어로 작성한다
+백로그는 GitHub Issues로 관리. 진행 이력은 `PROGRESS.md` 참고.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,273 @@
+# 포트폴리오 닥터 — Design System
+
+> Stitch 및 구현 참조용 단일 디자인 문서.
+> 모든 결정은 `/plan-design-review` 세션에서 확정됨 (2026-04-05).
+
+---
+
+## 제품 분류
+
+**APP UI** — 의사 리포트 느낌. 마케팅 랜딩 페이지 아님.
+타겟: 모바일 MTS 유저 (375px 기준 설계, 768px+ 확장).
+
+---
+
+## 색상 시스템
+
+메인 브랜드 컬러: `#1A237E` (딥 네이비)
+
+```css
+:root {
+  /* 브랜드 */
+  --navy:         #1A237E;  /* 메인 브랜드, CTA, 헤드라인 */
+  --navy-dark:    #121858;  /* 호버, 눌림 상태 */
+  --navy-mid:     #3949AB;  /* 보조 강조, 링크 */
+  --navy-tint:    #E8EAF6;  /* 연한 배지 배경, 하이라이트 */
+
+  /* 레이아웃 */
+  --bg:           #F4F6FF;  /* 전체 배경 (네이비 틴트) */
+  --surface:      #FFFFFF;  /* 카드, 패널 */
+  --border:       #E0E4F0;  /* 기본 선 */
+  --border-2:     #C7CEEA;  /* 강조 선, 입력 테두리 */
+
+  /* 텍스트 */
+  --text-1:       #111827;  /* 본문 primary */
+  --text-2:       #4B5563;  /* secondary */
+  --text-3:       #9CA3AF;  /* tertiary, 레이블 */
+
+  /* 시맨틱 (변경 없음 — 네이비와 자연 대비) */
+  --amber:        #D97706;  /* 개선 필요 (주의) */
+  --amber-bg:     #FFFBEB;
+  --amber-border: #FDE68A;
+
+  --green:        #059669;  /* 양호, 매수 */
+  --green-bg:     #ECFDF5;
+
+  --red:          #DC2626;  /* 심각, 매도 */
+  --red-bg:       #FEF2F2;
+}
+```
+
+### 컬러 사용 규칙
+
+| 요소 | 색상 |
+|------|------|
+| 로고, 브랜드 텍스트 | `--navy` |
+| Primary CTA 버튼 | `--navy` (배경) / white (텍스트) |
+| 진단 대형 숫자 (N가지) | `--navy` |
+| 문제 카드 번호 (01/02/03) | `--text-3` |
+| 문제 카드 왼쪽 선 | `--red` (심각) / `--amber` (주의) |
+| 배분 막대 — 과초과 | `--red` |
+| 배분 막대 — 부족 | `--amber` |
+| 배분 막대 — 목표선 | `--navy` |
+| 확인 화면 헤더 배경 | `--navy` (텍스트 white) |
+| 인라인 에러 텍스트 | `--red` |
+| 섹션 레이블 | `--text-3` |
+
+**금지:** 네이비 그라디언트. `--navy`를 배경 전체에 깔기. 텍스트에 `--navy-tint` 사용.
+
+---
+
+## 타이포그래피
+
+```
+폰트: Pretendard Variable
+CDN:  https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css
+```
+
+| 용도 | Size | Weight | 기타 |
+|------|------|--------|------|
+| 대형 헤드라인 (진단 숫자) | 42px | 800 | letter-spacing: -2px |
+| 화면 헤드라인 | 28–30px | 800 | letter-spacing: -0.8px |
+| 섹션 제목 | 19px | 800 | letter-spacing: -0.5px |
+| 카드 제목 | 17–18px | 800 | letter-spacing: -0.4px |
+| 종목명 | 16px | 700 | letter-spacing: -0.3px |
+| 본문 | 14px | 400–500 | line-height: 1.6 |
+| 설명 | 13px | 400 | color: --text-2 |
+| 레이블/배지 | 10–12px | 700 | letter-spacing: 0.08–0.14em, uppercase |
+| 금액 숫자 | — | — | font-variant-numeric: tabular-nums |
+
+**금지:** Inter, Arial, system-ui 기본 스택.
+
+---
+
+## 레이아웃
+
+```
+모바일 기본: 375px, padding 16–24px
+데스크탑 컨테이너: max-width 440px, 가운데 정렬
+border-radius 기준: 카드 14px, 버튼 12px, 배지 20px, 인풋 8px
+```
+
+### 반응형
+
+| 화면 | 375px | 768px+ |
+|------|-------|--------|
+| 업로드 | 전체 너비 | max-width 440px 중앙 |
+| 확인 | ConfirmCard 리스트 | 전체 컬럼 테이블 전환 |
+| 진단 | 수직 스택 카드 | 동일 (max-width 440px) |
+| 하단 CTA | `position: fixed`, safe-area 대응 | 인라인 버튼 |
+
+---
+
+## 화면 플로우
+
+```
+업로드 (/) → OCR 로딩 → 확인 (/confirm) → 진단 (/diagnosis)
+```
+
+### 정보 계층
+
+**업로드 (`/`)**
+1. 업로드 존 (가장 크게, 압도적 중심)
+2. 보조 문구 — "키움·삼성·미래에셋 MTS 지원"
+3. 수동 입력 링크 (작게, 하단)
+- 브랜드: 상단 좌측 "포트폴리오·닥터" 텍스트 로고
+
+**확인 (`/confirm`)**
+1. 상단 배너 "이렇게 인식했어요"
+2. ConfirmCard 리스트
+3. 하단 고정 CTA "진단 시작"
+
+**진단 (`/diagnosis`)**
+1. "최적화할 수 있는 N가지가 있습니다" 헤드라인
+2. 현재 vs 목표 배분 미니 막대 차트
+3. ProblemCard ×N (01/02/03)
+4. 권장 조치 섹션
+5. "왜 이 조언인가요?" 토글 (기본 접힘)
+6. "다시 진단하기" 링크 (하단)
+
+---
+
+## 컴포넌트
+
+### ConfirmCard
+
+```
+배경: --surface
+border: 1px --border
+border-radius: 14px
+
+[종목명 700 16px]  [⚠ 중복 배지 — 같은 티커 여러 줄일 때만]  [✕ 삭제 44px]
+
+2×2 그리드 (border 1px --border 구분선):
+  ┌──────────────┬──────────────┐
+  │ 보유금액      │ 비중          │
+  │ 2,418,500    │ 24.2%        │
+  ├──────────────┼──────────────┤
+  │ 평균단가      │ 현재가        │
+  │ 604,625      │ 604,625      │
+  └──────────────┴──────────────┘
+  셀 레이블: 10px 700 uppercase --text-3
+  셀 값: 14px 700 tabular-nums (평균단가/현재가는 13px 600 --text-2)
+
+[자산군 드롭다운 — 네이티브 select]  [섹터 읽기전용 텍스트]
+
+▾ 상세보기 (탭하면 펼쳐짐)
+  수량 / 출처(이미지 N)
+```
+
+**⚠ 중복 배지 동작:**
+- 자동 제거 금지. 같은 티커가 여러 계좌(일반/ISA)에 있을 수 있음.
+- 배지는 경고만. 삭제는 유저가 판단.
+- 안내 배너: "서로 다른 계좌라면 그대로 두세요. 같은 계좌를 두 번 올렸다면 하나를 삭제해주세요."
+
+### ProblemCard
+
+```
+배경: --surface
+border: 1px --border
+border-radius: 14px
+padding: 18px 20px 18px 22px
+border-left: 3px solid (--red 심각 | --amber 주의)
+
+[번호] 01 · 자산 편중   — 10px 800 uppercase --text-3
+[제목] 국내주식에 너무 쏠려 있습니다  — 17px 800
+[수치] 81%  →  40% 목표
+        ↑ 36px 800 tabular-nums (--red or --amber)
+             ↑ 18px 700 --text-2
+[설명] 13px --text-2 line-height 1.6
+```
+
+### ActionItem
+
+```
+배경: --surface (카드 컨테이너)
+border: 1px --border
+border-radius: 14px
+각 항목 border-top: 1px --border
+
+[매도 배지]  [종목명 14px 700]  [N주 / 약 N원]
+ └ 10px 800 uppercase
+   매도: --red-bg / --red
+   매수: --green-bg / --green
+```
+
+### AllocationBar (배분 막대 차트)
+
+```
+트랙: height 7px, --border, border-radius 4px
+채움: 자산군별 색상 (국내 --red 초과시, 해외 --amber 부족시)
+목표선: width 2px, rgba(17,17,17,.35), 해당 % 위치에 수직선
+레이블: 11px 700 --text-3, width 44px
+수치: 12px 700 tabular-nums --text-2, width 30px
+```
+
+### OCR 로딩 애니메이션
+
+```
+종목명 하나씩 순서대로 등장 (opacity 0→1, translateY 5px→0, 0.25s)
+체크 상태: 대기(border --border-2) → 처리중(spinning amber border) → 완료(--green fill + checkmark)
+하단: 프로그레스 바 (height 2px --text-1) + "이미지 N 처리 중 (N/M)"
+```
+
+---
+
+## 인터랙션 상태
+
+| 기능 | 로딩 | 빈 상태 | 에러 | 성공 |
+|------|------|---------|------|------|
+| OCR 처리 | 종목명 체크 애니메이션 | — | "인식 실패: 주식잔고 화면이 맞나요? [다시 시도]" | 확인 화면으로 이동 |
+| 업로드 | — | 점선 박스 "MTS 주식잔고 캡처를 올려주세요" | 5MB 초과 인라인 오류 | 썸네일 표시 |
+| 목표 배분 합계 | — | 기본값 40/30/30 | "합계: N% (100%여야 합니다)" 인라인 빨강 | — |
+| 진단 엔진 | "분석 중..." (< 1초) | ✓ + "포트폴리오가 양호합니다" + 현재 배분 차트 | — | ProblemCard 표시 |
+| Claude 설명 토글 | "설명 불러오는 중..." (2–3초) | — | "불러오지 못했습니다 [다시 시도]" | 설명 텍스트 인라인 |
+
+---
+
+## Copy 원칙
+
+- "문제" → "최적화할 수 있는 것" / "개선 포인트"
+- 확인 화면: "자산군만 확인해주세요. 나머지는 수정 안 해도 됩니다."
+- 액션 추천: "고려해볼 수 있습니다" (투자자문업 미등록 준수)
+- 세금: "단순 참고용. 실제 세금은 증권사/세무사 확인 필요."
+- 면책: "이 서비스는 투자자문업 등록 서비스가 아닙니다. 최종 투자 결정은 본인 책임입니다."
+- 기준일: "캡처 시점 기준 데이터. 실제 주문 시 시세를 다시 확인해주세요."
+
+---
+
+## 접근성
+
+- 터치 타겟: 최소 44×44px (삭제 버튼, 토글 등)
+- 색상 대비: WCAG AA (--text-2 #555 on #FFF = 7.0:1 ✓)
+- 색상만으로 상태 표현 금지: 배지는 아이콘 + 텍스트 병행
+- 드롭다운: 네이티브 `<select>` (스크린리더 호환)
+- 진단 카드: `role="article"`, `aria-label="진단 항목 1"`
+- iOS: `padding-bottom: env(safe-area-inset-bottom)` for fixed CTA
+
+---
+
+## 금지 패턴
+
+- ❌ 3컬럼 아이콘+제목+설명 그리드
+- ❌ 보라/파란/인디고 그라디언트
+- ❌ 모든 요소 동일한 큰 border-radius
+- ❌ 장식용 blob, SVG wave divider
+- ❌ "환영합니다", "강력한", "혁신적인" copy
+- ❌ Inter, Arial, system-ui 폰트
+
+---
+
+## 참조 구현
+
+`prototype.html` — 4개 화면 작동 프로토타입 (실제 데이터 기반)

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,3 +15,7 @@
 - [x] Vitest 단위 테스트 9개 추가 (`ocr.test.ts`, `explain.test.ts`, `sectors.test.ts`)
 - [x] OCR 응답 파싱을 malformed JSON/비정상 수량에 대해 방어적으로 보강
 - [x] Vitest 회귀 테스트 2개 추가 (`ocr.test.ts`)
+
+## 2026-04-06
+- [ ] OCR 실패 시 빈 500 대신 원인별 오류 메시지를 반환하도록 보강
+- [ ] OCR 필드 매핑을 평가금액·매입가·현재가 기준으로 재정렬

--- a/prompts/git-manager.md
+++ b/prompts/git-manager.md
@@ -1,0 +1,20 @@
+# Git Manager
+
+You are the git manager for this repository.
+
+Your responsibilities:
+- Manage branch hygiene, staging, commits, push, and PR setup
+- Stage only the intended files for the approved change
+- Keep commit and PR text aligned with repository conventions
+
+Rules:
+- Only proceed after review is clean and `pnpm verify` passes
+- If `pnpm` is unavailable on `PATH`, accept `COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm@9.15.4 verify` as the same completion gate
+- Do not make product code changes unless explicitly asked
+- Preserve unrelated user changes in the worktree
+
+Output contract:
+- Branch status
+- Files staged
+- Commit or PR actions taken
+- Any remaining manual follow-up

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -1,0 +1,23 @@
+# Planner
+
+You are the planner for this repository.
+
+Your responsibilities:
+- Understand the request and restate the goal
+- Produce a short implementation plan before any code changes
+- List affected files or likely file targets
+- Identify tests that must be added or updated
+- Call out risks, assumptions, and open questions that materially affect the plan
+
+Rules:
+- Follow the repository workflow: plan -> minimal implementation -> tests -> refactor -> review
+- Prefer the smallest plan that can safely satisfy the request
+- Do not edit code
+- Do not perform final review
+
+Output contract:
+- Goal
+- Plan
+- Files
+- Tests
+- Risks

--- a/prompts/tester.md
+++ b/prompts/tester.md
@@ -1,0 +1,21 @@
+# Tester
+
+You are the tester for this repository.
+
+Your responsibilities:
+- Add or update tests for the implemented behavior
+- Run targeted verification first when useful, then run `pnpm verify`
+- If `pnpm` is unavailable on `PATH`, run `COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm@9.15.4 verify` instead
+- Report exact failures, probable causes, and the narrowest next fix if verification fails
+
+Rules:
+- Follow the repository workflow: plan -> minimal implementation -> tests -> refactor -> review
+- Update tests before any refactor pass proceeds
+- Treat missing tests for changed behavior as a release blocker
+- Do not do broad product refactors
+
+Output contract:
+- Tests added or updated
+- Commands run
+- Results
+- Remaining gaps

--- a/src/app/api/ocr/route.ts
+++ b/src/app/api/ocr/route.ts
@@ -1,62 +1,52 @@
 // src/app/api/ocr/route.ts
 import { NextRequest, NextResponse } from 'next/server'
 import Anthropic from '@anthropic-ai/sdk'
-import { normalizeOcrItems, parseOcrResponse } from '@/lib/ocr'
+import { buildOcrPrompt, getOcrErrorDetails, normalizeOcrItems, parseOcrResponse } from '@/lib/ocr'
 import type { PortfolioPosition } from '@/lib/types'
 
 const client = new Anthropic()
 
-const PROMPT = `다음 증권사 MTS 보유 종목 화면에서 모든 보유 종목 정보를 추출해줘.
-
-추출할 필드:
-- name: 종목명
-- code: 종목코드 (6자리 숫자 or 알파벳 티커, 없으면 null)
-- qty: 보유수량 (정수)
-- value: 보유금액/평가금액/현재금액/보유평가금액 (원화 숫자만, 콤마/₩/원 제거)
-- avgCost: 평균단가/매입단가/취득단가 (원화 숫자만, 콤마/₩/원 제거, 없으면 null)
-
-규칙:
-- 필드가 화면에 없으면 null
-- 금액은 숫자만 (콤마, ₩, 원 모두 제거)
-- JSON 배열만 반환, 다른 텍스트 없음
-
-형식: [{"name":"삼성전자","code":"005930","qty":50,"value":2000000,"avgCost":38000}]`
-
 export async function POST(req: NextRequest) {
-  const formData = await req.formData()
-  const images = formData.getAll('images') as File[]
+  try {
+    const formData = await req.formData()
+    const images = formData.getAll('images') as File[]
 
-  if (images.length === 0) {
-    return NextResponse.json({ error: '이미지가 없습니다' }, { status: 400 })
+    if (images.length === 0) {
+      return NextResponse.json({ error: '이미지가 없습니다' }, { status: 400 })
+    }
+    if (images.length > 5) {
+      return NextResponse.json({ error: '최대 5장까지 업로드 가능합니다' }, { status: 400 })
+    }
+
+    const allPositions: PortfolioPosition[] = []
+
+    for (let i = 0; i < images.length; i++) {
+      const file = images[i]
+      const bytes = await file.arrayBuffer()
+      const base64 = Buffer.from(bytes).toString('base64')
+      const mediaType = (file.type || 'image/jpeg') as 'image/jpeg' | 'image/png' | 'image/webp'
+
+      const response = await client.messages.create({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 2048,
+        messages: [{
+          role: 'user',
+          content: [
+            { type: 'image', source: { type: 'base64', media_type: mediaType, data: base64 } },
+            { type: 'text', text: buildOcrPrompt() },
+          ],
+        }],
+      })
+
+      const text = response.content[0].type === 'text' ? response.content[0].text : ''
+      const rawItems = parseOcrResponse(text)
+      allPositions.push(...normalizeOcrItems(rawItems, i + 1))
+    }
+
+    return NextResponse.json(allPositions)
+  } catch (error) {
+    const { status, message } = getOcrErrorDetails(error)
+    console.error('OCR route failed', error)
+    return NextResponse.json({ error: message }, { status })
   }
-  if (images.length > 5) {
-    return NextResponse.json({ error: '최대 5장까지 업로드 가능합니다' }, { status: 400 })
-  }
-
-  const allPositions: PortfolioPosition[] = []
-
-  for (let i = 0; i < images.length; i++) {
-    const file = images[i]
-    const bytes = await file.arrayBuffer()
-    const base64 = Buffer.from(bytes).toString('base64')
-    const mediaType = (file.type || 'image/jpeg') as 'image/jpeg' | 'image/png' | 'image/webp'
-
-    const response = await client.messages.create({
-      model: 'claude-haiku-4-5-20251001',
-      max_tokens: 2048,
-      messages: [{
-        role: 'user',
-        content: [
-          { type: 'image', source: { type: 'base64', media_type: mediaType, data: base64 } },
-          { type: 'text', text: PROMPT },
-        ],
-      }],
-    })
-
-    const text = response.content[0].type === 'text' ? response.content[0].text : ''
-    const rawItems = parseOcrResponse(text)
-    allPositions.push(...normalizeOcrItems(rawItems, i + 1))
-  }
-
-  return NextResponse.json(allPositions)
 }

--- a/src/app/confirm/page.tsx
+++ b/src/app/confirm/page.tsx
@@ -37,6 +37,10 @@ export default function ConfirmPage() {
     setPositions(prev => prev.map(p => p.id === id ? { ...p, assetClass } : p))
   }
 
+  function handleFieldChange(id: string, field: 'value' | 'avgCost' | 'currentPrice', value: number) {
+    setPositions(prev => prev.map(p => p.id === id ? { ...p, [field]: value } : p))
+  }
+
   function handleStart() {
     sessionStorage.setItem(SESSION_KEYS.CONFIRMED, JSON.stringify(positions))
     sessionStorage.setItem(SESSION_KEYS.TARGET, JSON.stringify(DEFAULT_TARGET))
@@ -57,7 +61,7 @@ export default function ConfirmPage() {
           <span className={styles.title}>이렇게 인식했어요</span>
           <span className={styles.count}>{positions.length}종목</span>
         </div>
-        <p className={styles.hint}>자산군만 확인해주세요. 나머지는 수정 안 해도 됩니다.</p>
+        <p className={styles.hint}>자산군을 확인하고, 금액이 잘못 인식됐으면 눌러서 수정하세요.</p>
       </div>
 
       <div className={styles.scroll}>
@@ -69,6 +73,7 @@ export default function ConfirmPage() {
             isDuplicate={(nameCounts[p.name] ?? 0) > 1}
             onDelete={handleDelete}
             onAssetClassChange={handleAssetClassChange}
+            onFieldChange={handleFieldChange}
           />
         ))}
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { SESSION_KEYS } from '@/lib/types'
+import { parseOcrErrorResponse } from '@/lib/ocr'
 import styles from './page.module.css'
 
 type LoadingStep = { name: string; done: boolean; active: boolean }
@@ -52,8 +53,7 @@ export default function UploadPage() {
     try {
       const res = await fetch('/api/ocr', { method: 'POST', body: formData })
       if (!res.ok) {
-        const err = await res.json()
-        throw new Error(err.error ?? '인식 실패')
+        throw new Error(parseOcrErrorResponse(await res.text()))
       }
       const positions = await res.json()
 

--- a/src/components/ConfirmCard.module.css
+++ b/src/components/ConfirmCard.module.css
@@ -81,6 +81,24 @@
   font-variant-numeric: tabular-nums;
   letter-spacing: -0.3px;
 }
+.cellInput {
+  width: 100%;
+  font-size: 14px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.3px;
+  font-family: var(--font);
+  background: none;
+  border: none;
+  border-bottom: 1px solid transparent;
+  padding: 0;
+  color: var(--text-1);
+  outline: none;
+  min-width: 0;
+}
+.cellInput:focus {
+  border-bottom-color: var(--primary);
+}
 .secondary { font-size: 13px; font-weight: 600; color: var(--text-2); }
 
 /* 자산군 + 섹터 */

--- a/src/components/ConfirmCard.tsx
+++ b/src/components/ConfirmCard.tsx
@@ -4,20 +4,45 @@ import { useState } from 'react'
 import type { PortfolioPosition, AssetClass } from '@/lib/types'
 import styles from './ConfirmCard.module.css'
 
+type EditableField = 'value' | 'avgCost' | 'currentPrice'
+
 interface Props {
   position: PortfolioPosition
   pct: number               // 전체 포트폴리오 중 비중 (%)
   isDuplicate: boolean
   onDelete: (id: string) => void
   onAssetClassChange: (id: string, assetClass: AssetClass) => void
+  onFieldChange: (id: string, field: EditableField, value: number) => void
 }
 
 const ASSET_CLASSES: AssetClass[] = ['국내주식', '해외주식', '채권', '기타']
 
-export function ConfirmCard({ position, pct, isDuplicate, onDelete, onAssetClassChange }: Props) {
+export function ConfirmCard({ position, pct, isDuplicate, onDelete, onAssetClassChange, onFieldChange }: Props) {
   const [expanded, setExpanded] = useState(false)
+  const [editValues, setEditValues] = useState({
+    value: String(Math.round(position.value)),
+    avgCost: String(Math.round(position.avgCost)),
+    currentPrice: String(Math.round(position.currentPrice)),
+  })
 
   const fmt = (n: number) => Math.round(n).toLocaleString('ko-KR')
+
+  function handleBlur(field: EditableField) {
+    const parsed = parseInt(editValues[field].replace(/,/g, ''), 10)
+    if (!isNaN(parsed) && parsed >= 0) {
+      onFieldChange(position.id, field, parsed)
+    } else {
+      setEditValues(prev => ({ ...prev, [field]: String(Math.round(position[field])) }))
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>, field: EditableField) {
+    if (e.key === 'Enter') e.currentTarget.blur()
+    if (e.key === 'Escape') {
+      setEditValues(prev => ({ ...prev, [field]: String(Math.round(position[field])) }))
+      e.currentTarget.blur()
+    }
+  }
 
   return (
     <div className={styles.card}>
@@ -45,19 +70,43 @@ export function ConfirmCard({ position, pct, isDuplicate, onDelete, onAssetClass
         <div className={styles.grid}>
           <div className={styles.cell}>
             <div className={styles.cellLabel}>보유금액</div>
-            <div className={styles.cellVal}>{fmt(position.value)}</div>
+            <input
+              className={styles.cellInput}
+              inputMode="numeric"
+              value={editValues.value}
+              onChange={e => setEditValues(prev => ({ ...prev, value: e.target.value }))}
+              onBlur={() => handleBlur('value')}
+              onKeyDown={e => handleKeyDown(e, 'value')}
+              aria-label="보유금액 수정"
+            />
           </div>
           <div className={styles.cell}>
             <div className={styles.cellLabel}>비중</div>
             <div className={styles.cellVal}>{pct.toFixed(1)}%</div>
           </div>
           <div className={styles.cell}>
-            <div className={styles.cellLabel}>평균단가</div>
-            <div className={`${styles.cellVal} ${styles.secondary}`}>{fmt(position.avgCost)}</div>
+            <div className={styles.cellLabel}>매입가</div>
+            <input
+              className={`${styles.cellInput} ${styles.secondary}`}
+              inputMode="numeric"
+              value={editValues.avgCost}
+              onChange={e => setEditValues(prev => ({ ...prev, avgCost: e.target.value }))}
+              onBlur={() => handleBlur('avgCost')}
+              onKeyDown={e => handleKeyDown(e, 'avgCost')}
+              aria-label="매입가 수정"
+            />
           </div>
           <div className={styles.cell}>
             <div className={styles.cellLabel}>현재가</div>
-            <div className={`${styles.cellVal} ${styles.secondary}`}>{fmt(position.currentPrice)}</div>
+            <input
+              className={`${styles.cellInput} ${styles.secondary}`}
+              inputMode="numeric"
+              value={editValues.currentPrice}
+              onChange={e => setEditValues(prev => ({ ...prev, currentPrice: e.target.value }))}
+              onBlur={() => handleBlur('currentPrice')}
+              onKeyDown={e => handleKeyDown(e, 'currentPrice')}
+              aria-label="현재가 수정"
+            />
           </div>
         </div>
 

--- a/src/lib/ocr.test.ts
+++ b/src/lib/ocr.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { normalizeOcrItems, parseOcrResponse } from './ocr'
+import { buildOcrPrompt, getOcrErrorDetails, normalizeOcrItems, parseOcrErrorResponse, parseOcrResponse } from './ocr'
 
 describe('parseOcrResponse', () => {
   it('extracts the JSON array from a Claude text response', () => {
-    const items = parseOcrResponse('분석 결과\n[{"name":"삼성전자","code":"005930","qty":2,"value":120000,"avgCost":50000}]')
+    const items = parseOcrResponse('분석 결과\n[{"name":"삼성전자","code":"005930","qty":2,"value":120000,"avgCost":50000,"currentPrice":60000}]')
 
     expect(items).toEqual([
-      { name: '삼성전자', code: '005930', qty: 2, value: 120000, avgCost: 50000 },
+      { name: '삼성전자', code: '005930', qty: 2, value: 120000, avgCost: 50000, currentPrice: 60000 },
     ])
   })
 
@@ -23,9 +23,9 @@ describe('normalizeOcrItems', () => {
   it('fills defaults and classifies positions', () => {
     const positions = normalizeOcrItems(
       [
-        { name: '삼성전자', code: '005930', qty: null, value: 120000, avgCost: null },
-        { name: 'TIGER 미국S&P500', code: null, qty: 4, value: 400000, avgCost: 90000 },
-        { name: '', code: '000000', qty: 1, value: 1000, avgCost: 1000 },
+        { name: '삼성전자', code: '005930', qty: null, value: 120000, avgCost: null, currentPrice: null },
+        { name: 'TIGER 미국S&P500', code: null, qty: 4, value: 400000, avgCost: 90000, currentPrice: 100000 },
+        { name: '', code: '000000', qty: 1, value: 1000, avgCost: 1000, currentPrice: 1000 },
       ],
       2,
       () => 'fixed-id',
@@ -36,6 +36,7 @@ describe('normalizeOcrItems', () => {
       id: 'fixed-id',
       name: '삼성전자',
       qty: 1,
+      value: 120000,
       avgCost: 120000,
       currentPrice: 120000,
       assetClass: '국내주식',
@@ -45,6 +46,7 @@ describe('normalizeOcrItems', () => {
     expect(positions[1]).toMatchObject({
       name: 'TIGER 미국S&P500',
       qty: 4,
+      value: 400000,
       avgCost: 90000,
       currentPrice: 100000,
       assetClass: '해외주식',
@@ -55,8 +57,8 @@ describe('normalizeOcrItems', () => {
   it('skips zero-value rows and normalizes non-positive quantities to 1', () => {
     const positions = normalizeOcrItems(
       [
-        { name: '삼성전자', code: '005930', qty: 0, value: 100000, avgCost: null },
-        { name: '현금', code: null, qty: -3, value: 0, avgCost: null },
+        { name: '삼성전자', code: '005930', qty: 0, value: 100000, avgCost: null, currentPrice: null },
+        { name: '현금', code: null, qty: -3, value: 0, avgCost: null, currentPrice: null },
       ],
       1,
       () => 'safe-id',
@@ -66,8 +68,92 @@ describe('normalizeOcrItems', () => {
     expect(positions[0]).toMatchObject({
       id: 'safe-id',
       qty: 1,
+      value: 100000,
       avgCost: 100000,
       currentPrice: 100000,
     })
+  })
+
+  it('prefers parsed currentPrice and recomputes value when the OCR total is inconsistent', () => {
+    const [position] = normalizeOcrItems(
+      [
+        { name: 'SK하이닉스', code: '000660', qty: 4, value: 2418500, avgCost: 270375, currentPrice: 875000 },
+      ],
+      1,
+      () => 'ocr-fix',
+    )
+
+    expect(position).toMatchObject({
+      id: 'ocr-fix',
+      qty: 4,
+      value: 3500000,
+      avgCost: 270375,
+      currentPrice: 875000,
+    })
+  })
+
+  it('derives total value from currentPrice when OCR returns a non-positive total', () => {
+    const [position] = normalizeOcrItems(
+      [
+        { name: 'TIGER 구리실물', code: null, qty: 20, value: -1600, avgCost: 15470, currentPrice: 15390 },
+      ],
+      1,
+      () => 'derived-total',
+    )
+
+    expect(position).toMatchObject({
+      id: 'derived-total',
+      qty: 20,
+      value: 307800,
+      avgCost: 15470,
+      currentPrice: 15390,
+    })
+  })
+})
+
+describe('parseOcrErrorResponse', () => {
+  it('extracts the error field from a JSON response body', () => {
+    expect(parseOcrErrorResponse('{"error":"OCR API 크레딧이 부족합니다."}')).toBe('OCR API 크레딧이 부족합니다.')
+  })
+
+  it('falls back when the response body is empty', () => {
+    expect(parseOcrErrorResponse('   ', '기본 오류')).toBe('기본 오류')
+  })
+
+  it('returns raw text when the error response is not JSON', () => {
+    expect(parseOcrErrorResponse('일시적인 오류')).toBe('일시적인 오류')
+  })
+})
+
+describe('getOcrErrorDetails', () => {
+  it('maps Anthropic credit exhaustion to a user-friendly message', () => {
+    expect(getOcrErrorDetails({
+      status: 400,
+      error: { message: 'Your credit balance is too low to access the Anthropic API.' },
+    })).toEqual({
+      status: 503,
+      message: 'OCR API 크레딧이 부족합니다. Anthropic 결제 상태를 확인해 주세요.',
+    })
+  })
+
+  it('falls back to a generic OCR error for unknown failures', () => {
+    expect(getOcrErrorDetails(new Error('boom'))).toEqual({
+      status: 502,
+      message: 'OCR 분석 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+    })
+  })
+})
+
+describe('buildOcrPrompt', () => {
+  it('explicitly requests 매입가, 현재가, 평가금액 and bans 손익/수익률 values', () => {
+    const prompt = buildOcrPrompt()
+
+    expect(prompt).toContain('value: 평가금액/보유금액/보유평가금액 "총액"')
+    expect(prompt).toContain('avgCost: 매입가/평균단가/매입단가 "1주당 단가"')
+    expect(prompt).toContain('currentPrice: 현재가 "1주당 단가"')
+    expect(prompt).toContain('"평가손익", "손익", "수익률", "%" 열의 숫자는 절대 사용하지 마')
+    expect(prompt).toContain('"qty × currentPrice ≈ value" 관계가 성립하도록 읽어줘')
+    expect(prompt).toContain('첫 번째 블록 = 손익/수익률 → 항상 무시')
+    expect(prompt).toContain('{"name":"TIGER 미국S&P500","qty":24,"value":589680,"avgCost":24892,"currentPrice":24570}')
   })
 })

--- a/src/lib/ocr.ts
+++ b/src/lib/ocr.ts
@@ -7,6 +7,12 @@ export type OcrRaw = {
   qty: number | null
   value: number | null
   avgCost: number | null
+  currentPrice: number | null
+}
+
+type OcrErrorDetails = {
+  status: number
+  message: string
 }
 
 export function parseOcrResponse(text: string): OcrRaw[] {
@@ -20,18 +26,128 @@ export function parseOcrResponse(text: string): OcrRaw[] {
   }
 }
 
+export function buildOcrPrompt(): string {
+  return `다음 증권사 MTS 보유 종목 화면에서 모든 보유 종목 정보를 추출해줘.
+
+추출할 필드:
+- name: 종목명
+- code: 종목코드 (6자리 숫자 or 알파벳 티커, 없으면 null)
+- qty: 보유수량 (정수)
+- value: 평가금액/보유금액/보유평가금액 "총액" (원화 숫자만)
+- avgCost: 매입가/평균단가/매입단가 "1주당 단가" (원화 숫자만, 없으면 null)
+- currentPrice: 현재가 "1주당 단가" (원화 숫자만, 없으면 null)
+
+중요 규칙:
+- value는 반드시 "평가금액/보유금액/보유평가금액" 열의 총액만 사용
+- avgCost는 반드시 "매입가/매입단가/평균단가" 열의 1주당 단가만 사용
+- currentPrice는 반드시 "현재가" 열의 1주당 단가만 사용
+- "평가손익", "손익", "수익률", "%" 열의 숫자는 절대 사용하지 마
+- "qty × currentPrice ≈ value" 관계가 성립하도록 읽어줘
+- 표가 2줄 숫자 구조라면 보통:
+  - 손익/수익률 열: 무조건 무시
+  - 잔고수량/보유 수량 열: 윗줄=qty
+  - 평가금액/보유금액 열: 아랫줄=value
+  - 매입가/매입단가 열: 윗줄=avgCost
+  - 현재가 열: 아랫줄=currentPrice
+- 종목명 오른쪽에 숫자 블록이 3개라면:
+  - 첫 번째 블록 = 손익/수익률 → 항상 무시
+  - 두 번째 블록 = qty / value
+  - 세 번째 블록 = avgCost / currentPrice
+- 헤더가 "평가손익/수익률 | 잔고수량/평가금액 | 매입가/현재가" 또는
+  "평가손익/수익률 | 보유/평가금액 | 매입단가/현재가" 형태면 위 규칙을 그대로 적용해
+- 값이 헷갈리면 손익/수익률 숫자를 쓰지 말고 null로 남겨
+- qty가 1이면 value와 currentPrice가 같을 수 있다
+- 필드가 화면에 없으면 null
+- 콤마, ₩, 원, %는 제거하고 숫자만 반환
+- JSON 배열만 반환, 다른 텍스트 없음
+
+예시:
+- {"name":"SK하이닉스","qty":4,"value":3500000,"avgCost":270375,"currentPrice":875000}
+- {"name":"현대차","qty":7,"value":3304000,"avgCost":271242,"currentPrice":472000}
+- {"name":"SK하이닉스","qty":1,"value":876000,"avgCost":260000,"currentPrice":876000}
+- {"name":"TIGER 미국S&P500","qty":24,"value":589680,"avgCost":24892,"currentPrice":24570}
+형식: [{"name":"삼성전자","code":"005930","qty":3,"value":557400,"avgCost":170400,"currentPrice":185800}]`
+}
+
+export function parseOcrErrorResponse(text: string, fallback = '인식 실패'): string {
+  const trimmed = text.trim()
+  if (!trimmed) return fallback
+
+  try {
+    const parsed = JSON.parse(trimmed) as { error?: unknown }
+    return typeof parsed.error === 'string' && parsed.error.trim() ? parsed.error : fallback
+  } catch {
+    return trimmed
+  }
+}
+
+export function getOcrErrorDetails(error: unknown): OcrErrorDetails {
+  const fallback: OcrErrorDetails = {
+    status: 502,
+    message: 'OCR 분석 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+  }
+
+  if (!error || typeof error !== 'object') {
+    return fallback
+  }
+
+  const apiError = error as {
+    status?: number
+    error?: { message?: string }
+    message?: string
+  }
+
+  const message = apiError.error?.message ?? apiError.message ?? ''
+
+  if (message.includes('credit balance is too low')) {
+    return {
+      status: 503,
+      message: 'OCR API 크레딧이 부족합니다. Anthropic 결제 상태를 확인해 주세요.',
+    }
+  }
+
+  if (apiError.status === 401) {
+    return {
+      status: 502,
+      message: 'OCR API 인증에 실패했습니다. ANTHROPIC_API_KEY를 확인해 주세요.',
+    }
+  }
+
+  if (apiError.status === 429) {
+    return {
+      status: 429,
+      message: 'OCR 요청이 잠시 많습니다. 잠시 후 다시 시도해 주세요.',
+    }
+  }
+
+  return fallback
+}
+
 export function normalizeOcrItems(
   rawItems: OcrRaw[],
   sourceImage: number,
   createId: () => string = () => crypto.randomUUID(),
 ): PortfolioPosition[] {
   return rawItems.flatMap(raw => {
-    if (!raw.name || !raw.value) return []
+    if (!raw.name) return []
 
     const qty = raw.qty && raw.qty > 0 ? raw.qty : 1
-    const value = raw.value
-    const avgCost = raw.avgCost ?? value / qty
-    const currentPrice = value / qty
+    const parsedCurrentPrice = raw.currentPrice && raw.currentPrice > 0 ? raw.currentPrice : null
+    const fallbackValue = parsedCurrentPrice ? parsedCurrentPrice * qty : null
+    const valueCandidate = raw.value && raw.value > 0 ? raw.value : null
+
+    let value = valueCandidate ?? fallbackValue
+    const currentPrice = parsedCurrentPrice ?? (value ? value / qty : null)
+
+    if (currentPrice && value) {
+      const derivedValue = currentPrice * qty
+      const driftRatio = Math.abs(value - derivedValue) / Math.max(value, derivedValue)
+      if (driftRatio > 0.2) value = derivedValue
+    }
+
+    if (!value || !currentPrice) return []
+
+    const avgCost = raw.avgCost && raw.avgCost > 0 ? raw.avgCost : currentPrice
     const { sector, assetClass } = autoClassify(raw.name, raw.code)
 
     return [{

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,9 +7,9 @@ export interface PortfolioPosition {
   name: string          // 종목명
   code: string | null   // 종목코드 (6자리 숫자 or "AAPL"), OCR 못 찾으면 null
   qty: number           // 보유수량
-  value: number         // 보유금액 (원)
-  avgCost: number       // 평균단가 (원)
-  currentPrice: number  // 현재가 = value / qty (역산)
+  value: number         // 평가금액/보유금액 총액 (원)
+  avgCost: number       // 매입가/평균단가 (1주당 원가)
+  currentPrice: number  // 현재가 (1주당), OCR 직파싱 후 필요 시 보정
   assetClass: AssetClass
   sector: string        // "반도체", "자동차", "채권 ETF" 등
   sourceImage: number   // 어느 이미지에서 추출됐는지 (1-based)


### PR DESCRIPTION
## Summary

- Gemini PR Review 429 오류 fallback 처리 (워크플로우 실패 방지)
- OCR 결과 보유금액·매입가·현재가 인라인 편집 기능
- AGENTS.md: Claude/Codex 병렬 트랙 역할 분담, Work Unit & Worktree Workflow, 330줄 → 149줄 축약
- CI/CD: eslint 의존성, Gemini review 권한 정비

## Test plan

- [ ] `pnpm verify` 통과 확인
- [ ] OCR 업로드 후 confirm 화면에서 보유금액/매입가/현재가 탭 편집 → blur 시 저장 확인
- [ ] Gemini 429 발생 시 워크플로우 실패 없이 fallback 코멘트 게시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)