### PR TITLE
chore: 병렬 Claude/Codex 분업 인프라 구축 및 개인정보 고지 추가

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,17 @@
+---
+name: Task
+about: 새 기능 / 버그픽스 / 리팩토링
+labels: ''
+---
+
+## 구현자 / 리뷰어
+- Implementer: <!-- claude | codex -->
+- Reviewer:    <!-- codex  | claude -->
+
+## 수용 기준
+- [ ] 
+
+## 수정 파일
+- `src/`
+
+<!-- 동시 진행 중인 이슈와 파일 겹침이 없는지 확인 후 등록하세요 -->

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env.local
 .next/
 node_modules/
+REVIEW*.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,60 @@ git branch -d feat/N-slug
 gh issue close N
 ```
 
+### 병렬 트랙 시작
+
+이슈를 파일 겹침 없는 쌍으로 고른다 (`track:claude` / `track:codex` 라벨 확인).
+
+```bash
+# Claude 트랙: 현재 디렉터리에서 작업 후 pnpm verify
+# Codex 트랙:
+cd ../worktrees/feat-N-slug
+omc team 1:codex "<이슈 제목 + 수용 기준 전문>"
+```
+
+양쪽 완료 후 cross-review:
+- Claude → Codex 워크트리 리뷰
+- Codex → Claude 워크트리 `/codex review`
+
+P1 없으면 Git Manager(Claude)가 각각 PR 생성 및 순차 머지.
+
+### Review Handoff (REVIEW-N.md 컨벤션)
+
+**완료 신호:** `pnpm verify` 통과 → `git commit` → Claude가 `git log main..HEAD`로 감지
+
+**Claude 리뷰 작성 형식** (`REVIEW-1.md` → `REVIEW-2.md` 순서로 워크트리 루트에 작성):
+```
+---
+cycle: 1
+branch: feat/N-slug
+status: NEEDS_REVISION  # NEEDS_REVISION | APPROVED | ESCALATED
+p1_count: 2
+p2_count: 1
+---
+
+## P1 (must fix)
+- [ ] ...
+
+## P2 (optional)
+- [ ] ...
+
+## Codex Response
+<!-- Codex가 P1 수정 후 이 섹션 채움 -->
+
+## Verdict: REVISE
+```
+
+**Codex 재구현 트리거 (유저가 실행):**
+```bash
+omc team 1:codex "Read REVIEW-{N}.md. Fix all unchecked P1 items. Run pnpm verify. If verify fails append failure output under '## Codex Response' and note VERIFY_FAILED — do not commit. If passes, append what you fixed then commit."
+```
+
+**규칙:**
+- YAML `status` + `## Verdict` 는 Claude만 작성
+- Codex는 `## Codex Response` 섹션만 추가
+- 3사이클 후에도 P1 남으면 `status: ESCALATED` → 유저에게 에스컬레이션
+- `REVIEW*.md`는 `.gitignore` 적용 (PR diff에 포함되지 않음)
+
 ### 파일 충돌 방지
 
 이슈 생성 시 수정 대상 파일을 명시한다. 동시 진행 중인 이슈가 같은 파일을 수정하면 하나가 머지될 때까지 대기.

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -52,6 +52,13 @@
 .zoneTitle { font-size: 16px; font-weight: 700; letter-spacing: -0.3px; }
 .zoneDesc { font-size: 13px; color: var(--text-2); line-height: 1.55; }
 
+.privacy {
+  font-size: 12px;
+  color: var(--text-3);
+  text-align: center;
+  margin-bottom: 16px;
+  line-height: 1.5;
+}
 .manual { font-size: 13px; color: var(--text-3); }
 .manual a { color: var(--text-2); text-decoration: underline; }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -140,6 +140,8 @@ export default function UploadPage() {
           onChange={e => e.target.files && handleFiles(e.target.files)}
         />
 
+        <p className={styles.privacy}>🔒 업로드한 이미지는 분석 후 즉시 삭제되며 서버에 저장되지 않습니다.</p>
+
         {error && <p className={styles.error}>⚠️ {error} — <a href="#" onClick={() => setError(null)}>다시 시도</a></p>}
 
         <p className={styles.manual}>또는 <a href="#">종목을 직접 입력하기</a></p>


### PR DESCRIPTION
## Summary
- GitHub 라벨 `track:claude` / `track:codex` 생성, 기존 이슈 #3 #4 #5 #8 에 라벨 부착
- `.github/ISSUE_TEMPLATE/task.md` 추가 — 이슈 생성 시 Implementer/Reviewer/수정파일 칸 자동 포함
- `AGENTS.md` 업데이트 — 병렬 트랙 시작 절차 + Review Handoff (REVIEW-N.md) 컨벤션
- `.gitignore` — `REVIEW*.md` 추가 (PR diff 오염 방지)
- 업로드 화면 이미지 미저장 개인정보 고지 문구 추가

## Review Handoff 흐름
1. Codex: `pnpm verify` 통과 → `git commit` (완료 신호)
2. Claude: `git log main..HEAD` 확인 → `REVIEW-1.md` 작성 (P1/P2)
3. User: `omc team 1:codex "Read REVIEW-1.md, fix P1, pnpm verify, commit"` 실행
4. 최대 3사이클, P1 미해결 시 ESCALATED

## Test plan
- [ ] `pnpm verify` 통과
- [ ] GitHub Issues에서 `track:claude` / `track:codex` 라벨 확인
- [ ] 이슈 생성 시 템플릿 자동 적용 확인
- [ ] 업로드 화면 개인정보 고지 문구 표시 확인

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)