### PR TITLE
feat: confirm 화면 768px+ 테이블 뷰 (#3)

### DIFF
--- a/src/app/confirm/page.module.css
+++ b/src/app/confirm/page.module.css
@@ -42,3 +42,34 @@
   font-size: 14px;
   line-height: 1.6;
 }
+
+/* 768px+ 테이블 뷰 */
+.tableWrap { display: none; }
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+.thead tr { border-bottom: 2px solid var(--border); }
+.th {
+  padding: 10px 12px 10px 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  text-align: left;
+  white-space: nowrap;
+}
+.thNum { text-align: right; }
+
+@media (min-width: 768px) {
+  .scroll { display: none; }
+  .tableWrap {
+    display: block;
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px 32px 108px;
+  }
+}

--- a/src/app/confirm/page.tsx
+++ b/src/app/confirm/page.tsx
@@ -64,6 +64,39 @@ export default function ConfirmPage() {
         <p className={styles.hint}>자산군을 확인하고, 금액이 잘못 인식됐으면 눌러서 수정하세요.</p>
       </div>
 
+      {/* 768px+ 테이블 뷰 */}
+      <div className={styles.tableWrap}>
+        <table className={styles.table}>
+          <thead>
+            <tr className={styles.thead}>
+              <th className={styles.th}>종목명</th>
+              <th className={styles.th}>자산군</th>
+              <th className={styles.th}>섹터</th>
+              <th className={`${styles.th} ${styles.thNum}`}>보유금액</th>
+              <th className={`${styles.th} ${styles.thNum}`}>비중</th>
+              <th className={`${styles.th} ${styles.thNum}`}>매입가</th>
+              <th className={`${styles.th} ${styles.thNum}`}>현재가</th>
+              <th className={styles.th}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {positions.map(p => (
+              <ConfirmCard
+                key={p.id}
+                asRow
+                position={p}
+                pct={totalValue > 0 ? Math.round((p.value / totalValue) * 1000) / 10 : 0}
+                isDuplicate={(nameCounts[p.name] ?? 0) > 1}
+                onDelete={handleDelete}
+                onAssetClassChange={handleAssetClassChange}
+                onFieldChange={handleFieldChange}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* 모바일 카드 뷰 */}
       <div className={styles.scroll}>
         {positions.map(p => (
           <ConfirmCard

--- a/src/app/confirm/page.tsx
+++ b/src/app/confirm/page.tsx
@@ -9,6 +9,17 @@ import styles from './page.module.css'
 
 export default function ConfirmPage() {
   const router = useRouter()
+  const [isDesktop, setIsDesktop] = useState(() =>
+    typeof window !== 'undefined' && window.matchMedia('(min-width: 768px)').matches
+  )
+
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 768px)')
+    const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+
   const [positions, setPositions] = useState<PortfolioPosition[]>(() => {
     if (typeof window === 'undefined') return []
     const raw = sessionStorage.getItem(SESSION_KEYS.RAW_POSITIONS)
@@ -64,51 +75,52 @@ export default function ConfirmPage() {
         <p className={styles.hint}>자산군을 확인하고, 금액이 잘못 인식됐으면 눌러서 수정하세요.</p>
       </div>
 
-      {/* 768px+ 테이블 뷰 */}
-      <div className={styles.tableWrap}>
-        <table className={styles.table}>
-          <thead>
-            <tr className={styles.thead}>
-              <th className={styles.th}>종목명</th>
-              <th className={styles.th}>자산군</th>
-              <th className={styles.th}>섹터</th>
-              <th className={`${styles.th} ${styles.thNum}`}>보유금액</th>
-              <th className={`${styles.th} ${styles.thNum}`}>비중</th>
-              <th className={`${styles.th} ${styles.thNum}`}>매입가</th>
-              <th className={`${styles.th} ${styles.thNum}`}>현재가</th>
-              <th className={styles.th}></th>
-            </tr>
-          </thead>
-          <tbody>
-            {positions.map(p => (
-              <ConfirmCard
-                key={p.id}
-                asRow
-                position={p}
-                pct={totalValue > 0 ? Math.round((p.value / totalValue) * 1000) / 10 : 0}
-                isDuplicate={(nameCounts[p.name] ?? 0) > 1}
-                onDelete={handleDelete}
-                onAssetClassChange={handleAssetClassChange}
-                onFieldChange={handleFieldChange}
-              />
-            ))}
-          </tbody>
-        </table>
-      </div>
-
-      {/* 모바일 카드 뷰 */}
-      <div className={styles.scroll}>
-        {positions.map(p => (
-          <ConfirmCard
-            key={p.id}
-            position={p}
-            pct={totalValue > 0 ? Math.round((p.value / totalValue) * 1000) / 10 : 0}
-            isDuplicate={(nameCounts[p.name] ?? 0) > 1}
-            onDelete={handleDelete}
-            onAssetClassChange={handleAssetClassChange}
-            onFieldChange={handleFieldChange}
-          />
-        ))}
+      {isDesktop ? (
+        /* 768px+ 테이블 뷰 */
+        <div className={styles.tableWrap}>
+          <table className={styles.table}>
+            <thead>
+              <tr className={styles.thead}>
+                <th className={styles.th}>종목명</th>
+                <th className={styles.th}>자산군</th>
+                <th className={styles.th}>섹터</th>
+                <th className={`${styles.th} ${styles.thNum}`}>보유금액</th>
+                <th className={`${styles.th} ${styles.thNum}`}>비중</th>
+                <th className={`${styles.th} ${styles.thNum}`}>매입가</th>
+                <th className={`${styles.th} ${styles.thNum}`}>현재가</th>
+                <th className={styles.th}></th>
+              </tr>
+            </thead>
+            <tbody>
+              {positions.map(p => (
+                <ConfirmCard
+                  key={p.id}
+                  asRow
+                  position={p}
+                  pct={totalValue > 0 ? Math.round((p.value / totalValue) * 1000) / 10 : 0}
+                  isDuplicate={(nameCounts[p.name] ?? 0) > 1}
+                  onDelete={handleDelete}
+                  onAssetClassChange={handleAssetClassChange}
+                  onFieldChange={handleFieldChange}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        /* 모바일 카드 뷰 */
+        <div className={styles.scroll}>
+          {positions.map(p => (
+            <ConfirmCard
+              key={p.id}
+              position={p}
+              pct={totalValue > 0 ? Math.round((p.value / totalValue) * 1000) / 10 : 0}
+              isDuplicate={(nameCounts[p.name] ?? 0) > 1}
+              onDelete={handleDelete}
+              onAssetClassChange={handleAssetClassChange}
+              onFieldChange={handleFieldChange}
+            />
+          ))}
 
         {hasDuplicates && (
           <div className={styles.dupNotice}>
@@ -127,6 +139,7 @@ export default function ConfirmPage() {
           </div>
         )}
       </div>
+      )}
 
       {positions.length > 0 && (
         <div className="fixed-cta">

--- a/src/components/ConfirmCard.module.css
+++ b/src/components/ConfirmCard.module.css
@@ -129,6 +129,53 @@
   white-space: nowrap;
 }
 
+/* 768px+ 테이블 로우 */
+.tr { border-bottom: 1px solid var(--border); }
+.tr:last-child { border-bottom: none; }
+.trDup { background: var(--amber-bg); }
+
+.tdName {
+  padding: 12px 16px 12px 0;
+  min-width: 120px;
+}
+.td { padding: 12px 12px 12px 0; vertical-align: middle; }
+.tdNum { padding: 12px 12px 12px 0; vertical-align: middle; font-variant-numeric: tabular-nums; }
+.tdPct { color: var(--text-2); font-size: 13px; white-space: nowrap; }
+.tdAction { padding: 12px 0; vertical-align: middle; }
+.tdNameInner { display: flex; align-items: center; gap: 6px; }
+
+.tdInput {
+  width: 100%;
+  min-width: 70px;
+  font-size: 13px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font);
+  background: none;
+  border: none;
+  border-bottom: 1px solid transparent;
+  padding: 0;
+  color: var(--text-1);
+  outline: none;
+}
+.tdInput:focus { border-bottom-color: var(--primary); }
+
+.selectSm {
+  font-family: var(--font);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 5px 22px 5px 7px;
+  border: 1px solid var(--border-2);
+  border-radius: var(--radius-input);
+  background: var(--bg);
+  color: var(--text-1);
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%239CA3AF' stroke-width='2.5'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 7px center;
+}
+.sectorSm { font-size: 12px; font-weight: 600; color: var(--text-2); white-space: nowrap; }
+
 /* 상세보기 토글 */
 .toggle {
   width: 100%;

--- a/src/components/ConfirmCard.tsx
+++ b/src/components/ConfirmCard.tsx
@@ -10,6 +10,7 @@ interface Props {
   position: PortfolioPosition
   pct: number               // 전체 포트폴리오 중 비중 (%)
   isDuplicate: boolean
+  asRow?: boolean           // 768px+ 테이블 뷰용
   onDelete: (id: string) => void
   onAssetClassChange: (id: string, assetClass: AssetClass) => void
   onFieldChange: (id: string, field: EditableField, value: number) => void
@@ -17,7 +18,7 @@ interface Props {
 
 const ASSET_CLASSES: AssetClass[] = ['국내주식', '해외주식', '채권', '기타']
 
-export function ConfirmCard({ position, pct, isDuplicate, onDelete, onAssetClassChange, onFieldChange }: Props) {
+export function ConfirmCard({ position, pct, isDuplicate, asRow, onDelete, onAssetClassChange, onFieldChange }: Props) {
   const [expanded, setExpanded] = useState(false)
   const [editValues, setEditValues] = useState({
     value: String(Math.round(position.value)),
@@ -42,6 +43,46 @@ export function ConfirmCard({ position, pct, isDuplicate, onDelete, onAssetClass
       setEditValues(prev => ({ ...prev, [field]: String(Math.round(position[field])) }))
       e.currentTarget.blur()
     }
+  }
+
+  if (asRow) {
+    return (
+      <tr className={`${styles.tr} ${isDuplicate ? styles.trDup : ''}`}>
+        <td className={styles.tdName}>
+          <span className={styles.name}>{position.name}</span>
+          {isDuplicate && <span className={styles.dupBadge} aria-label="같은 종목이 여러 줄 있습니다">⚠ 중복</span>}
+        </td>
+        <td className={styles.td}>
+          <select className={styles.selectSm} value={position.assetClass}
+            onChange={e => onAssetClassChange(position.id, e.target.value as AssetClass)}>
+            {ASSET_CLASSES.map(ac => <option key={ac} value={ac}>{ac}</option>)}
+          </select>
+        </td>
+        <td className={styles.td}><span className={styles.sectorSm}>{position.sector}</span></td>
+        <td className={styles.tdNum}>
+          <input className={styles.tdInput} inputMode="numeric" value={editValues.value}
+            onChange={e => setEditValues(prev => ({ ...prev, value: e.target.value }))}
+            onBlur={() => handleBlur('value')} onKeyDown={e => handleKeyDown(e, 'value')}
+            aria-label="보유금액 수정" />
+        </td>
+        <td className={`${styles.tdNum} ${styles.tdPct}`}>{pct.toFixed(1)}%</td>
+        <td className={styles.tdNum}>
+          <input className={`${styles.tdInput} ${styles.secondary}`} inputMode="numeric" value={editValues.avgCost}
+            onChange={e => setEditValues(prev => ({ ...prev, avgCost: e.target.value }))}
+            onBlur={() => handleBlur('avgCost')} onKeyDown={e => handleKeyDown(e, 'avgCost')}
+            aria-label="매입가 수정" />
+        </td>
+        <td className={styles.tdNum}>
+          <input className={`${styles.tdInput} ${styles.secondary}`} inputMode="numeric" value={editValues.currentPrice}
+            onChange={e => setEditValues(prev => ({ ...prev, currentPrice: e.target.value }))}
+            onBlur={() => handleBlur('currentPrice')} onKeyDown={e => handleKeyDown(e, 'currentPrice')}
+            aria-label="현재가 수정" />
+        </td>
+        <td className={styles.tdAction}>
+          <button className={styles.deleteBtn} onClick={() => onDelete(position.id)} aria-label={`${position.name} 삭제`}>✕</button>
+        </td>
+      </tr>
+    )
   }
 
   return (


### PR DESCRIPTION
## Summary
- 768px 이상에서 ConfirmCard 리스트 → 전체 컬럼 테이블로 전환
- 모바일(375px) 기존 카드 뷰 유지
- ConfirmCard에 \`asRow\` prop 추가 — \`<tr>/<td>\` 렌더링
- \`matchMedia\` lazy initializer로 뷰 분기 — 이중 mount 상태 불일치 방지
- \`useEffect\`로 resize 이벤트 구독

## Test plan
- [ ] \`pnpm verify\` 통과
- [ ] 375px 카드 뷰 표시 확인
- [ ] 768px+ 테이블 뷰 표시 확인
- [ ] 테이블에서 값 수정 → 진단 시작 정상 동작 확인

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)