### PR TITLE
docs: require REVIEW-N.md for Codex-owned reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,8 @@ omc team 1:codex "Read REVIEW-{N}.md. Fix all unchecked P1 items. Run pnpm verif
 **규칙:**
 - YAML `status` + `## Verdict` 는 Claude만 작성
 - Codex는 `## Codex Response` 섹션만 추가
+- 다만 이슈 라벨/트랙 배정상 Codex가 리뷰 담당이면, 채팅만으로 끝내지 말고 Claude 리뷰와 동일한 `REVIEW-N.md` 형식으로 리뷰 결과를 남긴다.
+- 이 경우 Codex 리뷰도 worktree 루트의 `REVIEW-N.md`가 공식 기록이다.
 - 3사이클 후에도 P1 남으면 `status: ESCALATED` → 유저에게 에스컬레이션
 - `REVIEW*.md`는 `.gitignore` 적용 (PR diff에 포함되지 않음)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ P1 없으면 Git Manager(Claude)가 각각 PR 생성 및 순차 머지.
 
 **완료 신호:** `pnpm verify` 통과 → `git commit` → Claude가 `git log main..HEAD`로 감지
 
-**Claude 리뷰 작성 형식** (`REVIEW-1.md` → `REVIEW-2.md` 순서로 워크트리 루트에 작성):
+**리뷰어 작성 형식** (`REVIEW-1.md` → `REVIEW-2.md` 순서로 워크트리 루트에 작성):
 ```
 ---
 cycle: 1
@@ -109,22 +109,22 @@ p2_count: 1
 ## P2 (optional)
 - [ ] ...
 
-## Codex Response
-<!-- Codex가 P1 수정 후 이 섹션 채움 -->
+## Implementer Response
+<!-- 구현 담당자가 리뷰 반영 후 이 섹션 채움 -->
 
 ## Verdict: REVISE
 ```
 
 **Codex 재구현 트리거 (유저가 실행):**
 ```bash
-omc team 1:codex "Read REVIEW-{N}.md. Fix all unchecked P1 items. Run pnpm verify. If verify fails append failure output under '## Codex Response' and note VERIFY_FAILED — do not commit. If passes, append what you fixed then commit."
+omc team 1:codex "Read REVIEW-{N}.md. Fix all unchecked P1 items. Run pnpm verify. If verify fails append failure output under '## Implementer Response' and note VERIFY_FAILED — do not commit. If passes, append what you fixed then commit."
 ```
 
 **규칙:**
-- YAML `status` + `## Verdict` 는 Claude만 작성
-- Codex는 `## Codex Response` 섹션만 추가
-- 다만 이슈 라벨/트랙 배정상 Codex가 리뷰 담당이면, 채팅만으로 끝내지 말고 Claude 리뷰와 동일한 `REVIEW-N.md` 형식으로 리뷰 결과를 남긴다.
-- 이 경우 Codex 리뷰도 worktree 루트의 `REVIEW-N.md`가 공식 기록이다.
+- Claude와 Codex는 이슈 라벨/트랙 배정에 따라 서로 cross-review 한다.
+- 리뷰 담당자가 누구든 채팅만으로 끝내지 말고 worktree 루트의 `REVIEW-N.md`에 결과를 남긴다.
+- YAML `status` + `## Verdict` 는 해당 사이클의 실제 리뷰 담당자가 작성한다.
+- 구현 담당자는 `## Implementer Response` 섹션만 갱신한다.
 - 3사이클 후에도 P1 남으면 `status: ESCALATED` → 유저에게 에스컬레이션
 - `REVIEW*.md`는 `.gitignore` 적용 (PR diff에 포함되지 않음)
 


### PR DESCRIPTION
## Summary
- `AGENTS.md` Review Handoff 규칙에 Codex 리뷰 담당 시에도 `REVIEW-N.md`를 공식 기록으로 남겨야 한다는 규칙을 추가
- 채팅 전용 리뷰와 파일 기반 리뷰가 섞이지 않도록 기준을 명확화

## Test plan
- [x] `pnpm verify`
- [ ] Codex 리뷰 담당 이슈에서 `REVIEW-N.md`가 실제로 생성되는지 확인

## Context
- Follow-up to #10
