### PR TITLE
chore: sync Vercel mirror fork from org main

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -28,4 +28,4 @@ jobs:
           fi
 
           git remote add fork "https://x-access-token:${FORK_PUSH_TOKEN}@github.com/ksah3756/doctorFolio-mvp.git"
-          git push --force-with-lease fork HEAD:main
+          git push --force fork HEAD:main

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -1,0 +1,31 @@
+name: Sync fork for Vercel
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  sync-fork:
+    if: github.repository == 'doctorFolio/doctorFolio-mvp'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Push main to personal fork
+        env:
+          FORK_PUSH_TOKEN: ${{ secrets.FORK_PUSH_TOKEN }}
+        run: |
+          if [ -z "$FORK_PUSH_TOKEN" ]; then
+            echo "FORK_PUSH_TOKEN is required to push to the Vercel mirror fork." >&2
+            exit 1
+          fi
+
+          git remote add fork "https://x-access-token:${FORK_PUSH_TOKEN}@github.com/ksah3756/doctorFolio-mvp.git"
+          git push --force-with-lease fork HEAD:main


### PR DESCRIPTION
## Summary
- Add `.github/workflows/sync-fork.yml` to mirror org `main` pushes to the personal fork used by Vercel Hobby deployments
- Keep `doctorFolio/doctorFolio-mvp` as the source of truth while Vercel deploys from `ksah3756/doctorFolio-mvp`
- Include an explicit `FORK_PUSH_TOKEN` guard before pushing to the fork

## Required setup
- Add repository secret `FORK_PUSH_TOKEN` to `doctorFolio/doctorFolio-mvp`
- Token should be scoped to `ksah3756/doctorFolio-mvp` with `Contents: Read and write` and `Metadata: Read`

## Test plan
- [x] `pnpm verify`
- [ ] Configure `FORK_PUSH_TOKEN`
- [ ] Run `Sync fork for Vercel` via `workflow_dispatch` and confirm `ksah3756/doctorFolio-mvp@main` updates

## Context
Vercel is connected to the personal fork because the org private repo is not directly available in the current Hobby setup.