### PR TITLE
fix: stage clean output for Vercel fork mirror

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -27,12 +27,23 @@ jobs:
             exit 1
           fi
 
+      - name: Create mirror output
+        run: |
+          mkdir output
+          rsync -a ./ output/ \
+            --exclude output \
+            --exclude .git \
+            --exclude .vercel \
+            --exclude node_modules \
+            --exclude .next \
+            --exclude 'REVIEW*.md'
+
       - name: Push main to personal fork
         uses: cpina/github-action-push-to-another-repository@main
         env:
           API_TOKEN_GITHUB: ${{ secrets.FORK_PUSH_TOKEN }}
         with:
-          source-directory: '.'
+          source-directory: output
           destination-github-username: ksah3756
           destination-repository-name: doctorFolio-mvp
           user-email: github-actions[bot]@users.noreply.github.com


### PR DESCRIPTION
## Summary
- Create a clean `output/` staging directory before invoking `cpina/github-action-push-to-another-repository`
- Exclude `.git`, `.vercel`, `node_modules`, `.next`, and `REVIEW*.md` from the mirror payload
- Keep the fork mirror action focused on repository contents instead of copying source checkout metadata

## Test plan
- [x] `pnpm verify`
- [ ] Re-run `Sync fork for Vercel` after this PR lands and confirm the private fork updates

## Context
Follow-up to #19. The previous `source-directory: '.'` copied `.git` metadata into the mirror action workspace, and the push attempted to use `github-actions[bot]` credentials.