### PR TITLE
feat: investorProfile lib 레이어 — inferStyleKey + PRESETS

### DIFF
--- a/src/lib/investorProfile.test.ts
+++ b/src/lib/investorProfile.test.ts
@@ -27,20 +27,16 @@ describe('inferStyleKey', () => {
     expect(inferStyleKey([pos('국내주식', 0), pos('채권', 0)])).toBe('balanced')
   })
 
-  it('채권 50% → stable', () => {
-    expect(inferStyleKey([pos('채권', 50), pos('국내주식', 50)])).toBe('stable')
+  it('채권 50% → balanced (임계값 초과 아님)', () => {
+    expect(inferStyleKey([pos('채권', 50), pos('국내주식', 50)])).toBe('balanced')
   })
 
   it('채권 70% → stable', () => {
     expect(inferStyleKey([pos('채권', 70), pos('국내주식', 30)])).toBe('stable')
   })
 
-  it('주식 90%+, 해외 40%+ → aggressive', () => {
+  it('주식 90%+ → aggressive', () => {
     expect(inferStyleKey([pos('해외주식', 50), pos('국내주식', 45), pos('채권', 5)])).toBe('aggressive')
-  })
-
-  it('주식 90%+, 해외 30% → growth (해외 비중 부족)', () => {
-    expect(inferStyleKey([pos('국내주식', 60), pos('해외주식', 30), pos('채권', 10)])).toBe('growth')
   })
 
   it('주식 70% → growth', () => {
@@ -49,6 +45,26 @@ describe('inferStyleKey', () => {
 
   it('주식 50%, 채권 30% → balanced', () => {
     expect(inferStyleKey([pos('국내주식', 30), pos('해외주식', 20), pos('채권', 30), pos('기타', 20)])).toBe('balanced')
+  })
+
+  it('기타 비중이 높아도 주식/채권 비율로 판단', () => {
+    // 주식 40%, 채권 20%, 기타 40% → balanced
+    expect(inferStyleKey([pos('국내주식', 40), pos('채권', 20), pos('기타', 40)])).toBe('balanced')
+  })
+})
+
+describe('PRESETS round-trip', () => {
+  it('각 프리셋 target 배분이 자기 자신 StyleKey로 추론된다', () => {
+    const keys = ['stable', 'balanced', 'growth', 'aggressive'] as const
+    for (const key of keys) {
+      const t = PRESETS[key].target
+      const positions = [
+        pos('국내주식', t['국내주식']),
+        pos('해외주식', t['해외주식']),
+        pos('채권', t['채권']),
+      ]
+      expect(inferStyleKey(positions), `${key} round-trip`).toBe(key)
+    }
   })
 })
 

--- a/src/lib/investorProfile.test.ts
+++ b/src/lib/investorProfile.test.ts
@@ -1,0 +1,72 @@
+// src/lib/investorProfile.test.ts
+import { describe, it, expect } from 'vitest'
+import { inferStyleKey, PRESETS } from './investorProfile'
+import type { PortfolioPosition } from './types'
+
+function pos(assetClass: PortfolioPosition['assetClass'], value: number): PortfolioPosition {
+  return {
+    id: crypto.randomUUID(),
+    name: 'test',
+    code: null,
+    qty: 1,
+    value,
+    avgCost: value,
+    currentPrice: value,
+    assetClass,
+    sector: '기타',
+    sourceImage: 1,
+  }
+}
+
+describe('inferStyleKey', () => {
+  it('빈 배열 → balanced', () => {
+    expect(inferStyleKey([])).toBe('balanced')
+  })
+
+  it('전체 value=0 → balanced', () => {
+    expect(inferStyleKey([pos('국내주식', 0), pos('채권', 0)])).toBe('balanced')
+  })
+
+  it('채권 50% → stable', () => {
+    expect(inferStyleKey([pos('채권', 50), pos('국내주식', 50)])).toBe('stable')
+  })
+
+  it('채권 70% → stable', () => {
+    expect(inferStyleKey([pos('채권', 70), pos('국내주식', 30)])).toBe('stable')
+  })
+
+  it('주식 90%+, 해외 40%+ → aggressive', () => {
+    expect(inferStyleKey([pos('해외주식', 50), pos('국내주식', 45), pos('채권', 5)])).toBe('aggressive')
+  })
+
+  it('주식 90%+, 해외 30% → growth (해외 비중 부족)', () => {
+    expect(inferStyleKey([pos('국내주식', 60), pos('해외주식', 30), pos('채권', 10)])).toBe('growth')
+  })
+
+  it('주식 70% → growth', () => {
+    expect(inferStyleKey([pos('국내주식', 40), pos('해외주식', 30), pos('채권', 30)])).toBe('growth')
+  })
+
+  it('주식 50%, 채권 30% → balanced', () => {
+    expect(inferStyleKey([pos('국내주식', 30), pos('해외주식', 20), pos('채권', 30), pos('기타', 20)])).toBe('balanced')
+  })
+})
+
+describe('PRESETS', () => {
+  it('4개 프리셋 target 합계 모두 100', () => {
+    const keys = ['stable', 'balanced', 'growth', 'aggressive'] as const
+    for (const key of keys) {
+      const t = PRESETS[key].target
+      expect(t['국내주식'] + t['해외주식'] + t['채권']).toBe(100)
+    }
+  })
+
+  it('모든 프리셋에 label, emoji, desc, target이 있다', () => {
+    for (const preset of Object.values(PRESETS)) {
+      expect(preset.label).toBeTruthy()
+      expect(preset.emoji).toBeTruthy()
+      expect(preset.desc).toBeTruthy()
+      expect(preset.target).toBeTruthy()
+    }
+  })
+})

--- a/src/lib/investorProfile.ts
+++ b/src/lib/investorProfile.ts
@@ -1,0 +1,62 @@
+// src/lib/investorProfile.ts
+import type { PortfolioPosition, StyleKey, TargetAllocation } from './types'
+
+export interface Preset {
+  label: string
+  emoji: string
+  desc: string
+  target: TargetAllocation
+}
+
+export const PRESETS: Record<StyleKey, Preset> = {
+  stable: {
+    label: '안정형',
+    emoji: '🛡️',
+    desc: '원금 지키는 게 제일 중요해요',
+    target: { '국내주식': 20, '해외주식': 10, '채권': 70 },
+  },
+  balanced: {
+    label: '균형형',
+    emoji: '⚖️',
+    desc: '어느 정도 손실은 괜찮아요',
+    target: { '국내주식': 30, '해외주식': 20, '채권': 50 },
+  },
+  growth: {
+    label: '성장형',
+    emoji: '🚀',
+    desc: '장기적으로 크게 키울래요',
+    target: { '국내주식': 40, '해외주식': 30, '채권': 30 },
+  },
+  aggressive: {
+    label: '공격형',
+    emoji: '⚡',
+    desc: '리스크 감수하고 최대로',
+    target: { '국내주식': 55, '해외주식': 35, '채권': 10 },
+  },
+}
+
+export function inferStyleKey(positions: PortfolioPosition[]): StyleKey {
+  if (positions.length === 0) return 'balanced'
+
+  const total = positions.reduce((s, p) => s + p.value, 0)
+  if (total === 0) return 'balanced'
+
+  const bondValue = positions
+    .filter(p => p.assetClass === '채권')
+    .reduce((s, p) => s + p.value, 0)
+  const foreignValue = positions
+    .filter(p => p.assetClass === '해외주식')
+    .reduce((s, p) => s + p.value, 0)
+  const stockValue = positions
+    .filter(p => p.assetClass === '국내주식' || p.assetClass === '해외주식')
+    .reduce((s, p) => s + p.value, 0)
+
+  const bondPct = bondValue / total
+  const foreignPct = foreignValue / total
+  const stockPct = stockValue / total
+
+  if (bondPct >= 0.5) return 'stable'
+  if (stockPct >= 0.9 && foreignPct >= 0.4) return 'aggressive'
+  if (stockPct >= 0.7) return 'growth'
+  return 'balanced'
+}

--- a/src/lib/investorProfile.ts
+++ b/src/lib/investorProfile.ts
@@ -55,8 +55,13 @@ export function inferStyleKey(positions: PortfolioPosition[]): StyleKey {
   const foreignPct = foreignValue / total
   const stockPct = stockValue / total
 
-  if (bondPct >= 0.5) return 'stable'
-  if (stockPct >= 0.9 && foreignPct >= 0.4) return 'aggressive'
-  if (stockPct >= 0.7) return 'growth'
+  // 임계값은 각 프리셋 target이 자기 자신으로 round-trip되도록 설정
+  // stable(20/10/70): bond>60% → stable
+  // balanced(30/20/50): bond=50% → balanced
+  // growth(40/30/30): stock=70% → growth
+  // aggressive(55/35/10): stock=90% → aggressive
+  if (bondPct > 0.6) return 'stable'
+  if (stockPct >= 0.85) return 'aggressive'
+  if (stockPct >= 0.65) return 'growth'
   return 'balanced'
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -66,4 +66,13 @@ export const SESSION_KEYS = {
   CONFIRMED: 'pd_confirmed_positions', // 확인 완료 (PortfolioPosition[])
   TARGET: 'pd_target',                 // TargetAllocation
   DIAGNOSIS: 'pd_diagnosis',           // DiagnosisResult
+  INVESTOR_PROFILE: 'pd_investor_profile', // InvestorProfile
 } as const
+
+// 투자 성향 위저드
+export type StyleKey = 'stable' | 'balanced' | 'growth' | 'aggressive'
+
+export interface InvestorProfile {
+  currentStyle: StyleKey  // OCR 포트폴리오에서 추론
+  desiredStyle: StyleKey  // 유저가 프리셋 카드로 선택
+}


### PR DESCRIPTION
## Summary
- `StyleKey`, `InvestorProfile` 타입 추가 (`types.ts`)
- `PRESETS` 4개 정의: stable/balanced/growth/aggressive (각각 label/emoji/desc/target)
- `inferStyleKey(positions)`: 현재 포트폴리오 배분 비율 → StyleKey 자동 추론
- `SESSION_KEYS.INVESTOR_PROFILE` 추가

## Test plan
- [x] `pnpm verify` 통과 (44 tests)
- [x] inferStyleKey 경계값 8개 케이스
- [x] PRESETS 4개 target 합계 = 100 검증
- [x] 빈 배열 / value=0 fallback → balanced

closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)