### PR TITLE
feat: /style page — investor style wizard step 1

### DIFF
--- a/src/app/style/page.module.css
+++ b/src/app/style/page.module.css
@@ -1,0 +1,156 @@
+/* src/app/style/page.module.css */
+.wrap { display: flex; flex-direction: column; min-height: 100dvh; }
+
+/* 네이비 헤더 */
+.header {
+  background: var(--navy);
+  padding: 20px 20px 28px;
+}
+
+.eyebrow {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,.5);
+  margin-bottom: 12px;
+}
+
+.bigLabel {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 36px;
+  font-weight: 800;
+  letter-spacing: -1.5px;
+  line-height: 1;
+  color: #fff;
+  margin-bottom: 10px;
+}
+
+.emoji { font-size: 32px; line-height: 1; }
+
+.desc {
+  font-size: 14px;
+  font-weight: 500;
+  color: rgba(255,255,255,.7);
+  line-height: 1.5;
+}
+
+/* 바디 */
+.body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 20px 0 40px;
+}
+
+.sectionLabel {
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  padding: 0 20px 12px;
+}
+
+/* 동일성향 배너 */
+.sameBanner {
+  margin: 0 20px 12px;
+  background: var(--green-bg);
+  border: 1px solid #A7F3D0;
+  border-radius: var(--radius-card);
+  padding: 12px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--green);
+}
+
+/* 카드 가로 스크롤 트랙 */
+.cardTrack {
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+  padding: 4px 20px 8px;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+.cardTrack::-webkit-scrollbar { display: none; }
+
+/* 프리셋 카드 */
+.card {
+  flex: 0 0 min(220px, 72vw);
+  scroll-snap-align: start;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 20px 18px;
+  background: var(--surface);
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-card);
+  text-align: left;
+  cursor: pointer;
+  position: relative;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.card:active { opacity: 0.85; }
+
+.cardSelected {
+  border: 2px solid var(--navy);
+  box-shadow: 0 0 0 3px rgba(26,35,126,.08);
+}
+
+/* 체크마크 */
+.check {
+  position: absolute;
+  top: 12px;
+  right: 14px;
+  font-size: 14px;
+  font-weight: 800;
+  color: var(--navy);
+  line-height: 1;
+}
+
+.cardEmoji { font-size: 28px; line-height: 1; margin-bottom: 4px; }
+
+.cardLabel {
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: -0.3px;
+  color: var(--text-1);
+}
+
+.cardDesc {
+  font-size: 13px;
+  color: var(--text-2);
+  line-height: 1.45;
+}
+
+.cardAlloc {
+  font-size: 11px;
+  color: var(--text-3);
+  margin-top: 6px;
+  letter-spacing: 0.01em;
+}
+
+/* CTA */
+.cta {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  padding: 20px 20px 0;
+}
+
+.skipBtn {
+  background: none;
+  border: none;
+  font-size: 13px;
+  color: var(--text-3);
+  text-decoration: underline;
+  padding: 4px;
+}
+.skipBtn:active { color: var(--text-2); }

--- a/src/app/style/page.tsx
+++ b/src/app/style/page.tsx
@@ -1,0 +1,141 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { PRESETS, inferStyleKey } from '@/lib/investorProfile'
+import { DEFAULT_TARGET, SESSION_KEYS } from '@/lib/types'
+import type { StyleKey, PortfolioPosition } from '@/lib/types'
+import styles from './page.module.css'
+
+const STYLE_KEYS: StyleKey[] = ['stable', 'balanced', 'growth', 'aggressive']
+
+function getAllocationDesc(positions: PortfolioPosition[]): string {
+  const total = positions.reduce((s, p) => s + p.value, 0)
+  if (total === 0) return '포트폴리오를 분석했어요'
+
+  const stockValue = positions
+    .filter(p => p.assetClass === '국내주식' || p.assetClass === '해외주식')
+    .reduce((s, p) => s + p.value, 0)
+  const bondValue = positions
+    .filter(p => p.assetClass === '채권')
+    .reduce((s, p) => s + p.value, 0)
+
+  const stockPct = Math.round((stockValue / total) * 100)
+  const bondPct = Math.round((bondValue / total) * 100)
+
+  if (bondPct >= 60) return `채권 비중 ${bondPct}%, 안정 위주로 운용 중이에요`
+  if (stockPct >= 85) return `주식 비중 ${stockPct}%, 공격적으로 투자 중이에요`
+  if (stockPct >= 65) return `주식 비중 ${stockPct}%, 성장 중심으로 투자 중이에요`
+  return `주식 ${stockPct}% · 채권 ${bondPct}%, 균형 있게 투자 중이에요`
+}
+
+export default function StylePage() {
+  const router = useRouter()
+  const [positions] = useState<PortfolioPosition[]>(() => {
+    if (typeof window === 'undefined') return []
+    const raw = sessionStorage.getItem(SESSION_KEYS.RAW_POSITIONS)
+    return raw ? (JSON.parse(raw) as PortfolioPosition[]) : []
+  })
+  const [loaded] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return sessionStorage.getItem(SESSION_KEYS.RAW_POSITIONS) !== null
+  })
+  const [selected, setSelected] = useState<StyleKey | null>(null)
+
+  useEffect(() => {
+    if (!loaded) router.replace('/')
+  }, [loaded, router])
+
+  if (!loaded) return null
+
+  const currentStyle = inferStyleKey(positions)
+  const currentPreset = PRESETS[currentStyle]
+  const allocationDesc = getAllocationDesc(positions)
+  const isSameStyle = selected === currentStyle
+
+  function handleNext() {
+    if (!selected) return
+    sessionStorage.setItem(SESSION_KEYS.TARGET, JSON.stringify(PRESETS[selected].target))
+    sessionStorage.setItem(
+      SESSION_KEYS.INVESTOR_PROFILE,
+      JSON.stringify({ currentStyle, desiredStyle: selected }),
+    )
+    router.push('/confirm')
+  }
+
+  function handleSkip() {
+    sessionStorage.setItem(SESSION_KEYS.TARGET, JSON.stringify(DEFAULT_TARGET))
+    router.push('/confirm')
+  }
+
+  return (
+    <div className={styles.wrap}>
+      <nav className="nav">
+        <span className="logo">포트폴리오<em>·</em>닥터</span>
+        <span className="nav-step">1 / 2</span>
+      </nav>
+
+      {/* 네이비 헤더 — 현재 성향 */}
+      <div className={styles.header}>
+        <div className={styles.eyebrow}>포트폴리오 분석 결과</div>
+        <div className={styles.bigLabel}>
+          <span className={styles.emoji}>{currentPreset.emoji}</span>
+          {currentPreset.label}
+        </div>
+        <div className={styles.desc}>{allocationDesc}</div>
+      </div>
+
+      {/* 바디 — 목표 성향 선택 */}
+      <div className={styles.body}>
+        <div className={styles.sectionLabel}>앞으로 어떻게 투자하고 싶으세요?</div>
+
+        {isSameStyle && (
+          <div className={styles.sameBanner} role="status">
+            지금 투자 방향이 목표와 일치해요 👍
+          </div>
+        )}
+
+        <div
+          className={styles.cardTrack}
+          role="radiogroup"
+          aria-label="투자 성향 선택"
+        >
+          {STYLE_KEYS.map(key => {
+            const p = PRESETS[key]
+            const isSelected = selected === key
+            return (
+              <button
+                key={key}
+                role="radio"
+                aria-checked={isSelected}
+                aria-label={`${p.label}: ${p.desc}. 국내 ${p.target['국내주식']}, 해외 ${p.target['해외주식']}, 채권 ${p.target['채권']}`}
+                className={`${styles.card} ${isSelected ? styles.cardSelected : ''}`}
+                onClick={() => setSelected(key)}
+              >
+                {isSelected && <span className={styles.check} aria-hidden="true">✓</span>}
+                <span className={styles.cardEmoji}>{p.emoji}</span>
+                <span className={styles.cardLabel}>{p.label}</span>
+                <span className={styles.cardDesc}>{p.desc}</span>
+                <span className={styles.cardAlloc}>
+                  국내 {p.target['국내주식']} · 해외 {p.target['해외주식']} · 채권 {p.target['채권']}
+                </span>
+              </button>
+            )
+          })}
+        </div>
+
+        <div className={styles.cta}>
+          <button
+            className="btn-primary"
+            disabled={!selected}
+            onClick={handleNext}
+          >
+            다음 →
+          </button>
+          <button className={styles.skipBtn} onClick={handleSkip}>
+            건너뛰기 (기본값 사용)
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- OCR 후 현재 투자 성향 자동 추론 → 네이비 헤더에 표시
- 4가지 프리셋 카드 (안정/균형/성장/공격) 가로 스크롤 선택
- 선택 시 `TARGET` + `INVESTOR_PROFILE` 저장 후 `/confirm`으로 이동
- 동일 성향 선택 시 녹색 확인 배너 표시
- Aria: radiogroup + radio + aria-checked

## Files Changed
- `src/app/style/page.tsx` (신규)
- `src/app/style/page.module.css` (신규)

## Test Results
45 tests passed, 0 failures (`pnpm verify` ✓)

## Closes
Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)