### PR TITLE
feat: 라우팅 /style + confirm 목표 배분 슬라이더

### DIFF
--- a/src/app/confirm/page.module.css
+++ b/src/app/confirm/page.module.css
@@ -43,6 +43,102 @@
   line-height: 1.6;
 }
 
+.targetSection {
+  padding: 0 16px 108px;
+}
+
+.targetHeader {
+  margin-bottom: 12px;
+}
+
+.targetTitle {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: var(--text-1);
+}
+
+.targetHint {
+  margin: 6px 0 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-2);
+}
+
+.sliderList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sliderRow {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: #fff;
+}
+
+.sliderMeta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.sliderLabel {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text-1);
+}
+
+.sliderValue {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--navy);
+}
+
+.slider {
+  width: 100%;
+  accent-color: var(--navy);
+}
+
+.targetSummary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 12px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  font-size: 14px;
+}
+
+.targetSummaryValid {
+  background: #ecfdf3;
+  color: #166534;
+}
+
+.targetSummaryInvalid {
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.targetSummaryLabel {
+  font-weight: 600;
+}
+
+.targetSummaryValue {
+  font-size: 16px;
+}
+
+.targetSummaryMessage {
+  margin-left: auto;
+  text-align: right;
+}
+
 /* 768px+ 테이블 뷰 */
 .tableWrap { display: none; }
 
@@ -70,6 +166,10 @@
     display: block;
     flex: 1;
     overflow-y: auto;
-    padding: 16px 32px 108px;
+    padding: 16px 32px 24px;
+  }
+
+  .targetSection {
+    padding: 0 32px 108px;
   }
 }

--- a/src/app/confirm/page.tsx
+++ b/src/app/confirm/page.tsx
@@ -4,8 +4,28 @@ import { useRouter } from 'next/navigation'
 import { ConfirmCard } from '@/components/ConfirmCard'
 import { runDiagnosis } from '@/lib/engine'
 import { DEFAULT_TARGET, SESSION_KEYS } from '@/lib/types'
-import type { PortfolioPosition, AssetClass } from '@/lib/types'
+import type { PortfolioPosition, AssetClass, TargetAllocation } from '@/lib/types'
 import styles from './page.module.css'
+
+const TARGET_FIELDS: Array<keyof TargetAllocation> = ['국내주식', '해외주식', '채권']
+
+function readStoredTarget(): TargetAllocation {
+  if (typeof window === 'undefined') return { ...DEFAULT_TARGET }
+
+  const raw = sessionStorage.getItem(SESSION_KEYS.TARGET)
+  if (!raw) return { ...DEFAULT_TARGET }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<Record<keyof TargetAllocation, unknown>>
+    return {
+      '국내주식': typeof parsed['국내주식'] === 'number' ? parsed['국내주식'] : DEFAULT_TARGET['국내주식'],
+      '해외주식': typeof parsed['해외주식'] === 'number' ? parsed['해외주식'] : DEFAULT_TARGET['해외주식'],
+      '채권': typeof parsed['채권'] === 'number' ? parsed['채권'] : DEFAULT_TARGET['채권'],
+    }
+  } catch {
+    return { ...DEFAULT_TARGET }
+  }
+}
 
 export default function ConfirmPage() {
   const router = useRouter()
@@ -29,6 +49,7 @@ export default function ConfirmPage() {
     if (typeof window === 'undefined') return false
     return sessionStorage.getItem(SESSION_KEYS.RAW_POSITIONS) !== null
   })
+  const [target, setTarget] = useState<TargetAllocation>(() => readStoredTarget())
 
   useEffect(() => {
     if (!loaded) router.replace('/')
@@ -52,10 +73,14 @@ export default function ConfirmPage() {
     setPositions(prev => prev.map(p => p.id === id ? { ...p, [field]: value } : p))
   }
 
+  function handleTargetChange(assetClass: keyof TargetAllocation, value: number) {
+    setTarget(prev => ({ ...prev, [assetClass]: value }))
+  }
+
   function handleStart() {
     sessionStorage.setItem(SESSION_KEYS.CONFIRMED, JSON.stringify(positions))
-    sessionStorage.setItem(SESSION_KEYS.TARGET, JSON.stringify(DEFAULT_TARGET))
-    const diagnosis = runDiagnosis(positions, DEFAULT_TARGET)
+    sessionStorage.setItem(SESSION_KEYS.TARGET, JSON.stringify(target))
+    const diagnosis = runDiagnosis(positions, target)
     sessionStorage.setItem(SESSION_KEYS.DIAGNOSIS, JSON.stringify(diagnosis))
     router.push('/diagnosis')
   }
@@ -63,6 +88,8 @@ export default function ConfirmPage() {
   if (!loaded) return null
 
   const hasDuplicates = Object.values(nameCounts).some(c => c > 1)
+  const targetSum = TARGET_FIELDS.reduce((sum, assetClass) => sum + target[assetClass], 0)
+  const isTargetBalanced = targetSum === 100
 
   return (
     <div className={styles.wrap}>
@@ -139,6 +166,47 @@ export default function ConfirmPage() {
           </div>
         )}
       </div>
+      )}
+
+      {positions.length > 0 && (
+        <section className={styles.targetSection}>
+          <div className={styles.targetHeader}>
+            <h2 className={styles.targetTitle}>목표 배분 조정</h2>
+            <p className={styles.targetHint}>원하는 비중으로 슬라이더를 조정한 뒤 진단을 시작하세요.</p>
+          </div>
+
+          <div className={styles.sliderList}>
+            {TARGET_FIELDS.map(assetClass => (
+              <label key={assetClass} className={styles.sliderRow}>
+                <div className={styles.sliderMeta}>
+                  <span className={styles.sliderLabel}>{assetClass}</span>
+                  <span className={styles.sliderValue}>{target[assetClass]}%</span>
+                </div>
+                <input
+                  className={styles.slider}
+                  type="range"
+                  min={0}
+                  max={100}
+                  step={5}
+                  value={target[assetClass]}
+                  onChange={e => handleTargetChange(assetClass, Number(e.target.value))}
+                />
+              </label>
+            ))}
+          </div>
+
+          <div
+            className={`${styles.targetSummary} ${
+              isTargetBalanced ? styles.targetSummaryValid : styles.targetSummaryInvalid
+            }`}
+          >
+            <span className={styles.targetSummaryLabel}>합계</span>
+            <strong className={styles.targetSummaryValue}>{targetSum}%</strong>
+            <span className={styles.targetSummaryMessage}>
+              {isTargetBalanced ? '합계가 100%입니다.' : '합계가 100%가 되도록 조정해주세요.'}
+            </span>
+          </div>
+        </section>
       )}
 
       {positions.length > 0 && (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -72,7 +72,7 @@ export default function UploadPage() {
       setSteps(prev => prev.map(s => ({ ...s, active: false, done: true })))
       sessionStorage.setItem(SESSION_KEYS.RAW_POSITIONS, JSON.stringify(positions))
       await new Promise(r => setTimeout(r, 400))
-      router.push('/confirm')
+      router.push('/style')
     } catch (e) {
       setError((e as Error).message)
       setLoading(false)


### PR DESCRIPTION
## Summary
- `page.tsx`: OCR 완료 후 `/confirm` → `/style` 라우팅 변경
- `confirm/page.tsx`: `SESSION_KEYS.TARGET` 읽어 슬라이더 초기화 (없으면 `DEFAULT_TARGET`)
- 슬라이더 3개 (국내주식/해외주식/채권, step=5) + 합계 표시 (100% 초록 / 그 외 빨강)
- 진단 시작 시 수정된 TARGET 저장 후 `runDiagnosis` 실행

## Files Changed
- `src/app/page.tsx`
- `src/app/confirm/page.tsx`
- `src/app/confirm/page.module.css`

## Test Results
45 tests passed (`pnpm verify` ✓)

## Closes
Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)