### PR TITLE
feat: 투자 MBTI 결과 카드 + SNS 공유 버튼

### DIFF
--- a/src/app/diagnosis/page.module.css
+++ b/src/app/diagnosis/page.module.css
@@ -108,3 +108,89 @@
   color: var(--text-2);
 }
 .resetBtn:active { background: var(--border); }
+
+/* 투자 MBTI 카드 */
+.mbtiCard {
+  border-radius: var(--radius-card);
+  padding: 20px 18px;
+  border: 1.5px solid var(--border);
+  background: var(--surface);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.mbtiEyebrow {
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+
+.mbtiTop {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.mbtiEmoji { font-size: 36px; line-height: 1; }
+
+.mbtiCode {
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: -0.5px;
+  line-height: 1;
+}
+
+.mbtiName {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-2);
+  margin-top: 4px;
+}
+
+.mbtiTagline {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-1);
+  line-height: 1.5;
+}
+
+.mbtiDesc {
+  font-size: 13px;
+  color: var(--text-2);
+  line-height: 1.55;
+}
+
+/* 그룹별 포인트 컬러 */
+.mbtiGroup_analyst { border-color: var(--navy); }
+.mbtiGroup_analyst .mbtiCode { color: var(--navy); }
+
+.mbtiGroup_diplomat { border-color: #7c3aed; }
+.mbtiGroup_diplomat .mbtiCode { color: #7c3aed; }
+
+.mbtiGroup_sentinel { border-color: var(--green); }
+.mbtiGroup_sentinel .mbtiCode { color: var(--green); }
+
+.mbtiGroup_explorer { border-color: #ea580c; }
+.mbtiGroup_explorer .mbtiCode { color: #ea580c; }
+
+/* 공유 버튼 */
+.shareBtn {
+  align-self: flex-start;
+  margin-top: 4px;
+  background: none;
+  border: 1.5px solid var(--border-2);
+  border-radius: var(--radius-btn);
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-2);
+  transition: background 0.1s, color 0.1s;
+}
+.shareBtn:active { background: var(--bg); }
+.mbtiGroup_analyst .shareBtn { border-color: var(--navy); color: var(--navy); }
+.mbtiGroup_diplomat .shareBtn { border-color: #7c3aed; color: #7c3aed; }
+.mbtiGroup_sentinel .shareBtn { border-color: var(--green); color: var(--green); }
+.mbtiGroup_explorer .shareBtn { border-color: #ea580c; color: #ea580c; }

--- a/src/app/diagnosis/page.tsx
+++ b/src/app/diagnosis/page.tsx
@@ -7,13 +7,20 @@ import { AllocationBar } from '@/components/AllocationBar'
 import { ActionItem } from '@/components/ActionItem'
 import { DIAGNOSIS_DISCLAIMER_LINES } from '@/lib/disclaimers'
 import { getTargetAllocationErrorMessage } from '@/lib/targetAllocation'
+import { inferMbtiType, MBTI_PROFILES } from '@/lib/mbti'
 import { SESSION_KEYS } from '@/lib/types'
-import type { DiagnosisResult } from '@/lib/types'
+import type { DiagnosisResult, PortfolioPosition } from '@/lib/types'
 import styles from './page.module.css'
 
 export default function DiagnosisPage() {
   const router = useRouter()
   const [diagnosis, setDiagnosis] = useState<DiagnosisResult | null>(null)
+  const [positions] = useState<PortfolioPosition[]>(() => {
+    if (typeof window === 'undefined') return []
+    const raw = sessionStorage.getItem(SESSION_KEYS.CONFIRMED)
+    return raw ? (JSON.parse(raw) as PortfolioPosition[]) : []
+  })
+  const [copied, setCopied] = useState(false)
   const [explainOpen, setExplainOpen] = useState(false)
   const [explanation, setExplanation] = useState<string | null>(null)
   const [explainLoading, setExplainLoading] = useState(false)
@@ -45,6 +52,20 @@ export default function DiagnosisPage() {
       setExplainError(true)
     } finally {
       setExplainLoading(false)
+    }
+  }
+
+  const mbtiType = inferMbtiType(positions)
+  const mbtiProfile = MBTI_PROFILES[mbtiType]
+
+  async function handleShare() {
+    const text = `나의 투자 MBTI는 ${mbtiProfile.emoji} ${mbtiProfile.type} ${mbtiProfile.name}!\n포트폴리오 닥터에서 내 투자 성향을 분석해봤어요`
+    if (typeof navigator !== 'undefined' && navigator.share) {
+      try { await navigator.share({ title: '투자 MBTI', text }) } catch { /* 취소 */ }
+    } else if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
     }
   }
 
@@ -116,6 +137,27 @@ export default function DiagnosisPage() {
             ))}
           </div>
         )}
+
+        {/* 투자 MBTI 카드 */}
+        <div className={`${styles.mbtiCard} ${styles[`mbtiGroup_${mbtiProfile.group}`]}`}>
+          <div className={styles.mbtiEyebrow}>나의 투자 MBTI</div>
+          <div className={styles.mbtiTop}>
+            <span className={styles.mbtiEmoji} aria-hidden="true">{mbtiProfile.emoji}</span>
+            <div>
+              <div className={styles.mbtiCode}>{mbtiProfile.type}</div>
+              <div className={styles.mbtiName}>{mbtiProfile.name}</div>
+            </div>
+          </div>
+          <div className={styles.mbtiTagline}>{mbtiProfile.investorTagline}</div>
+          <div className={styles.mbtiDesc}>{mbtiProfile.desc}</div>
+          <button
+            className={styles.shareBtn}
+            onClick={handleShare}
+            aria-label="투자 MBTI 공유하기"
+          >
+            {copied ? '✓ 복사됨' : '공유하기'}
+          </button>
+        </div>
 
         <div className={styles.disclaimer} aria-label="진단 결과 유의사항">
           {DIAGNOSIS_DISCLAIMER_LINES.map(line => (


### PR DESCRIPTION
## Summary
- 진단 결과 하단에 MBTI 투자 성향 카드 추가
- `inferMbtiType(positions)` 호출 → emoji + 타입코드 + 이름 + 투자 태그라인 + 설명 표시
- 그룹별 포인트 컬러: analyst(navy) · diplomat(purple) · sentinel(green) · explorer(orange)
- 공유 버튼: Web Share API 지원 시 네이티브 공유, 미지원 시 클립보드 복사 (2초 피드백)

## Files Changed
- `src/app/diagnosis/page.tsx`
- `src/app/diagnosis/page.module.css`

## Test Results
60 tests passed (`pnpm verify` ✓)

## Closes
Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)