### PR TITLE
feat: 확인 화면에서 섹터 직접 수정 가능하도록 (#31)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Rules:
 |------|-------|-------------|
 | Decomposer | Claude | 파일 겹침 없는 독립 서브태스크로 분리, Track A/B 배분 |
 | Implementer (Track A) | Claude | 구현 → `pnpm verify` → Codex 리뷰 요청 |
-| Implementer (Track B) | Codex | 구현 → `pnpm verify` → Claude 리뷰 |
+| Implementer (Track B) | Codex | 구현 → `pnpm verify` → `discord-review-notify`로 완료+Claude 리뷰 요청 |
 | Reviewer (Track A) | Codex | `/codex review` 또는 `/codex challenge` |
 | Reviewer (Track B) | Claude | Codex 구현물 검토 |
 | Git Manager | Claude | 리뷰 통과 후 PR 생성 및 머지. 항상 Claude. |
@@ -32,7 +32,7 @@ Claude 구현 → pnpm verify → /codex review → 수정 → PR
 ```
 Decomposer(Claude)
     ├── Track A: Claude 구현 → pnpm verify → Codex 리뷰 → 수정
-    └── Track B: Codex 구현 → pnpm verify → Claude 리뷰 → 수정
+    └── Track B: Codex 구현 → pnpm verify → `discord-review-notify`로 Claude 리뷰 요청 → 수정
                     ↓ (양쪽 완료 후)
               Git Manager(Claude) → PR
 ```
@@ -40,6 +40,7 @@ Decomposer(Claude)
 - P1 발견 시 해당 트랙 구현자가 수정 후 재검토.
 - Track B 시작: `omc team 1:codex "..."` (tmux worktree에서 실행)
 - Role prompts: `prompts/planner.md`, `prompts/implementer.md`, `prompts/tester.md`, `prompts/reviewer.md`, `prompts/git-manager.md`
+- Codex worker 성공 종료 시 raw `transition-task-status ... to=completed` 대신 `discord-review-notify` 스크립트로 완료 전이와 Discord review 요청을 한 번에 처리한다. 실패 시에만 raw `to=failed` 전이를 사용한다.
 
 ## Work Unit & Worktree Workflow
 
@@ -91,7 +92,26 @@ P1 없으면 Git Manager(Claude)가 각각 PR 생성 및 순차 머지.
 
 ### Review Handoff (REVIEW-N.md 컨벤션)
 
-**완료 신호:** `pnpm verify` 통과 → `git commit` → Claude가 `git log main..HEAD`로 감지
+**완료 신호:** `pnpm verify` 통과 → `git commit` → `discord-review-notify` 스크립트로 task 완료 + Discord 리뷰 요청
+
+**리뷰 요청 웹훅 호출 플로우 (Codex worker 성공 종료 경로):**
+1. 워커 시작 직후 `omc team api claim-task ... --json` 실행 후 `claim_token`을 저장한다.
+2. 구현/수정 작업을 끝내고 `pnpm verify` 또는 fallback verify를 통과시킨다.
+3. 필요한 경우 `REVIEW-N.md`의 `## Implementer Response`를 갱신하고 커밋한다.
+4. 성공 종료는 raw `transition-task-status ... to=completed`를 직접 치지 말고 아래 스크립트로 처리한다.
+```bash
+bash ~/.codex/skills/discord-review-notify/scripts/complete-task-and-notify-discord-review.sh \
+  --team-name "<team_name>" \
+  --task-id "<task_id>" \
+  --claim-token "<claim_token>"
+```
+5. 위 스크립트가 `in_progress -> completed` 전이와 Discord webhook 멘션 전송을 함께 처리한다.
+6. 실패 시에만 raw `omc team api transition-task-status ... to=failed`를 사용한다.
+
+**환경 변수 전제:**
+- `DISCORD_WEBHOOK_URL`
+- `DISCORD_MENTION_USER_ID` 또는 `DISCORD_MENTION_ROLE_ID`
+- 위 값은 worker shell에서 바로 읽혀야 하며, OMC notifier 설정과 별개로 스크립트가 직접 사용한다.
 
 **리뷰어 작성 형식** (`REVIEW-1.md` → `REVIEW-2.md` 순서로 워크트리 루트에 작성):
 ```
@@ -117,7 +137,7 @@ p2_count: 1
 
 **Codex 재구현 트리거 (유저가 실행):**
 ```bash
-omc team 1:codex "Read REVIEW-{N}.md. Fix all unchecked P1 items. Run pnpm verify. If verify fails append failure output under '## Implementer Response' and note VERIFY_FAILED — do not commit. If passes, append what you fixed then commit."
+omc team 1:codex "Read REVIEW-{N}.md. Fix all unchecked P1 items. Run pnpm verify. If verify fails append failure output under '## Implementer Response' and note VERIFY_FAILED — do not commit. If passes, append what you fixed, commit, then use the discord-review-notify skill/script to complete the task and send the Claude review webhook mention. Do not call raw completed transition separately."
 ```
 
 **규칙:**
@@ -125,6 +145,7 @@ omc team 1:codex "Read REVIEW-{N}.md. Fix all unchecked P1 items. Run pnpm verif
 - 리뷰 담당자가 누구든 채팅만으로 끝내지 말고 worktree 루트의 `REVIEW-N.md`에 결과를 남긴다.
 - YAML `status` + `## Verdict` 는 해당 사이클의 실제 리뷰 담당자가 작성한다.
 - 구현 담당자는 `## Implementer Response` 섹션만 갱신한다.
+- Codex worker가 Claude 리뷰 요청이 필요한 성공 종료를 할 때는 `~/.codex/skills/discord-review-notify/scripts/complete-task-and-notify-discord-review.sh` 또는 동일 스킬 경로를 사용한다.
 - 3사이클 후에도 P1 남으면 `status: ESCALATED` → 유저에게 에스컬레이션
 - `REVIEW*.md`는 `.gitignore` 적용 (PR diff에 포함되지 않음)
 

--- a/src/app/confirm/page.tsx
+++ b/src/app/confirm/page.tsx
@@ -27,6 +27,19 @@ function readStoredTarget(): TargetAllocation {
   }
 }
 
+function readStoredPositions(): PortfolioPosition[] {
+  if (typeof window === 'undefined') return []
+
+  const raw = sessionStorage.getItem(SESSION_KEYS.RAW_POSITIONS)
+  if (!raw) return []
+
+  try {
+    return JSON.parse(raw) as PortfolioPosition[]
+  } catch {
+    return []
+  }
+}
+
 export default function ConfirmPage() {
   const router = useRouter()
   const [isDesktop, setIsDesktop] = useState(() =>
@@ -40,11 +53,10 @@ export default function ConfirmPage() {
     return () => mq.removeEventListener('change', handler)
   }, [])
 
-  const [positions, setPositions] = useState<PortfolioPosition[]>(() => {
-    if (typeof window === 'undefined') return []
-    const raw = sessionStorage.getItem(SESSION_KEYS.RAW_POSITIONS)
-    return raw ? (JSON.parse(raw) as PortfolioPosition[]) : []
-  })
+  const [positions, setPositions] = useState<PortfolioPosition[]>(() => readStoredPositions())
+  const [originalSectors] = useState<Record<string, string>>(() =>
+    Object.fromEntries(readStoredPositions().map(position => [position.id, position.sector]))
+  )
   const [loaded] = useState(() => {
     if (typeof window === 'undefined') return false
     return sessionStorage.getItem(SESSION_KEYS.RAW_POSITIONS) !== null
@@ -67,6 +79,16 @@ export default function ConfirmPage() {
 
   function handleAssetClassChange(id: string, assetClass: AssetClass) {
     setPositions(prev => prev.map(p => p.id === id ? { ...p, assetClass } : p))
+  }
+
+  function handleSectorChange(id: string, sector: string) {
+    const nextSector = sector || originalSectors[id] || '기타'
+
+    setPositions(prev => {
+      const nextPositions = prev.map(p => p.id === id ? { ...p, sector: nextSector } : p)
+      sessionStorage.setItem(SESSION_KEYS.RAW_POSITIONS, JSON.stringify(nextPositions))
+      return nextPositions
+    })
   }
 
   function handleFieldChange(id: string, field: 'value' | 'avgCost' | 'currentPrice', value: number) {
@@ -128,6 +150,7 @@ export default function ConfirmPage() {
                   isDuplicate={(nameCounts[p.name] ?? 0) > 1}
                   onDelete={handleDelete}
                   onAssetClassChange={handleAssetClassChange}
+                  onSectorChange={handleSectorChange}
                   onFieldChange={handleFieldChange}
                 />
               ))}
@@ -145,6 +168,7 @@ export default function ConfirmPage() {
               isDuplicate={(nameCounts[p.name] ?? 0) > 1}
               onDelete={handleDelete}
               onAssetClassChange={handleAssetClassChange}
+              onSectorChange={handleSectorChange}
               onFieldChange={handleFieldChange}
             />
           ))}

--- a/src/components/ConfirmCard.module.css
+++ b/src/components/ConfirmCard.module.css
@@ -118,15 +118,21 @@
   background-repeat: no-repeat;
   background-position: right 10px center;
 }
-.sector {
+.sectorInput {
+  flex: 1;
+  min-width: 0;
   font-size: 12px;
   font-weight: 600;
+  font-family: var(--font);
   color: var(--text-2);
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: var(--radius-input);
   padding: 9px 11px;
-  white-space: nowrap;
+  outline: none;
+}
+.sectorInput:focus {
+  border-color: var(--primary);
 }
 
 /* 768px+ 테이블 로우 */
@@ -174,7 +180,10 @@
   background-repeat: no-repeat;
   background-position: right 7px center;
 }
-.sectorSm { font-size: 12px; font-weight: 600; color: var(--text-2); white-space: nowrap; }
+.sectorInputSm {
+  min-width: 110px;
+  color: var(--text-2);
+}
 
 /* 상세보기 토글 */
 .toggle {

--- a/src/components/ConfirmCard.tsx
+++ b/src/components/ConfirmCard.tsx
@@ -13,20 +13,23 @@ interface Props {
   asRow?: boolean           // 768px+ 테이블 뷰용
   onDelete: (id: string) => void
   onAssetClassChange: (id: string, assetClass: AssetClass) => void
+  onSectorChange: (id: string, sector: string) => void
   onFieldChange: (id: string, field: EditableField, value: number) => void
 }
 
 const ASSET_CLASSES: AssetClass[] = ['국내주식', '해외주식', '채권', '기타']
 
-export function ConfirmCard({ position, pct, isDuplicate, asRow, onDelete, onAssetClassChange, onFieldChange }: Props) {
+export function ConfirmCard({ position, pct, isDuplicate, asRow, onDelete, onAssetClassChange, onSectorChange, onFieldChange }: Props) {
   const [expanded, setExpanded] = useState(false)
   const [editValues, setEditValues] = useState({
     value: String(Math.round(position.value)),
     avgCost: String(Math.round(position.avgCost)),
     currentPrice: String(Math.round(position.currentPrice)),
   })
+  const [sectorEdit, setSectorEdit] = useState({ draft: position.sector, base: position.sector })
 
   const fmt = (n: number) => Math.round(n).toLocaleString('ko-KR')
+  const sectorInput = sectorEdit.base === position.sector ? sectorEdit.draft : position.sector
 
   function handleBlur(field: EditableField) {
     const parsed = parseInt(editValues[field].replace(/,/g, ''), 10)
@@ -45,6 +48,20 @@ export function ConfirmCard({ position, pct, isDuplicate, asRow, onDelete, onAss
     }
   }
 
+  function handleSectorBlur() {
+    const nextSector = sectorInput.trim()
+    onSectorChange(position.id, nextSector)
+    setSectorEdit({ draft: nextSector || position.sector, base: position.sector })
+  }
+
+  function handleSectorKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') e.currentTarget.blur()
+    if (e.key === 'Escape') {
+      setSectorEdit({ draft: position.sector, base: position.sector })
+      e.currentTarget.blur()
+    }
+  }
+
   if (asRow) {
     return (
       <tr className={`${styles.tr} ${isDuplicate ? styles.trDup : ''}`}>
@@ -58,7 +75,17 @@ export function ConfirmCard({ position, pct, isDuplicate, asRow, onDelete, onAss
             {ASSET_CLASSES.map(ac => <option key={ac} value={ac}>{ac}</option>)}
           </select>
         </td>
-        <td className={styles.td}><span className={styles.sectorSm}>{position.sector}</span></td>
+        <td className={styles.td}>
+          <input
+            className={`${styles.tdInput} ${styles.sectorInputSm}`}
+            type="text"
+            value={sectorInput}
+            onChange={e => setSectorEdit({ draft: e.target.value, base: position.sector })}
+            onBlur={handleSectorBlur}
+            onKeyDown={handleSectorKeyDown}
+            aria-label="섹터 수정"
+          />
+        </td>
         <td className={styles.tdNum}>
           <input className={styles.tdInput} inputMode="numeric" value={editValues.value}
             onChange={e => setEditValues(prev => ({ ...prev, value: e.target.value }))}
@@ -163,7 +190,15 @@ export function ConfirmCard({ position, pct, isDuplicate, asRow, onDelete, onAss
               <option key={ac} value={ac}>{ac}</option>
             ))}
           </select>
-          <div className={styles.sector}>{position.sector}</div>
+          <input
+            className={styles.sectorInput}
+            type="text"
+            value={sectorInput}
+            onChange={e => setSectorEdit({ draft: e.target.value, base: position.sector })}
+            onBlur={handleSectorBlur}
+            onKeyDown={handleSectorKeyDown}
+            aria-label="섹터 수정"
+          />
         </div>
       </div>
 

--- a/src/components/ConfirmCard.tsx
+++ b/src/components/ConfirmCard.tsx
@@ -1,6 +1,6 @@
 // src/components/ConfirmCard.tsx
 'use client'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import type { PortfolioPosition, AssetClass } from '@/lib/types'
 import styles from './ConfirmCard.module.css'
 
@@ -21,6 +21,7 @@ const ASSET_CLASSES: AssetClass[] = ['국내주식', '해외주식', '채권', '
 
 export function ConfirmCard({ position, pct, isDuplicate, asRow, onDelete, onAssetClassChange, onSectorChange, onFieldChange }: Props) {
   const [expanded, setExpanded] = useState(false)
+  const cancelledSectorBlurRef = useRef(false)
   const [editValues, setEditValues] = useState({
     value: String(Math.round(position.value)),
     avgCost: String(Math.round(position.avgCost)),
@@ -49,6 +50,11 @@ export function ConfirmCard({ position, pct, isDuplicate, asRow, onDelete, onAss
   }
 
   function handleSectorBlur() {
+    if (cancelledSectorBlurRef.current) {
+      cancelledSectorBlurRef.current = false
+      return
+    }
+
     const nextSector = sectorInput.trim()
     onSectorChange(position.id, nextSector)
     setSectorEdit({ draft: nextSector || position.sector, base: position.sector })
@@ -57,6 +63,7 @@ export function ConfirmCard({ position, pct, isDuplicate, asRow, onDelete, onAss
   function handleSectorKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === 'Enter') e.currentTarget.blur()
     if (e.key === 'Escape') {
+      cancelledSectorBlurRef.current = true
       setSectorEdit({ draft: position.sector, base: position.sector })
       e.currentTarget.blur()
     }


### PR DESCRIPTION
## Summary

- `ConfirmCard` 카드뷰/테이블뷰 양쪽에서 sector를 `<input type="text">`로 교체, blur 시 반영
- `onSectorChange(id, sector)` 콜백 추가, 부모에서 sessionStorage 즉시 반영
- 빈 문자열 입력 시 원래 자동 분류값(`originalSectors`)으로 복원, 없으면 `'기타'`
- Escape 키로 편집 취소 시 저장되던 버그 수정 (`cancelledSectorBlurRef` 패턴)

## Test plan

- [ ] 카드뷰에서 sector 클릭 → 수정 → blur → 변경 반영 확인
- [ ] 테이블뷰에서 동일 동작 확인
- [ ] 빈 문자열 입력 후 blur → 원래 값으로 복원 확인
- [ ] Escape 입력 → 변경 취소 (저장 안 됨) 확인
- [ ] Enter 입력 → blur와 동일하게 반영 확인
- [ ] `pnpm verify` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)