### PR TITLE
feat: ConfirmCard 섹터 수정 UI를 드롭다운으로 변경 (#37)

### DIFF
--- a/.claude/skills/review-handoff/SKILL.md
+++ b/.claude/skills/review-handoff/SKILL.md
@@ -21,7 +21,12 @@ Branch: feat/N-slug
 ```bash
 omc team 1:codex "Read REVIEW-{N}.md. Fix all unchecked P1 items. Run pnpm verify. If verify fails append failure output under '## Implementer Response' and note VERIFY_FAILED — do not commit. If passes, append what you fixed, commit, then use the discord-review-notify skill/script to complete the task and send the Claude review webhook mention. Do not call raw completed transition separately."
 ```
-4. **p1_count = 0 (APPROVED)** → PR 생성
+4. **p1_count = 0 (APPROVED)** → PR 생성 + Discord 알림:
+```
+✅ APPROVED — {branch}
+PR: {pr_url}
+이상 없음. 머지해도 됩니다.
+```
 
 ## REVIEW-N.md 작성 형식
 

--- a/src/components/ConfirmCard.module.css
+++ b/src/components/ConfirmCard.module.css
@@ -118,20 +118,15 @@
   background-repeat: no-repeat;
   background-position: right 10px center;
 }
-.sectorInput {
+.sectorSelect {
   flex: 1;
   min-width: 0;
   font-size: 12px;
   font-weight: 600;
   font-family: var(--font);
   color: var(--text-2);
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-input);
-  padding: 9px 11px;
-  outline: none;
 }
-.sectorInput:focus {
+.sectorSelect:focus {
   border-color: var(--primary);
 }
 
@@ -180,7 +175,7 @@
   background-repeat: no-repeat;
   background-position: right 7px center;
 }
-.sectorInputSm {
+.sectorSelectSm {
   min-width: 110px;
   color: var(--text-2);
 }

--- a/src/components/ConfirmCard.tsx
+++ b/src/components/ConfirmCard.tsx
@@ -1,7 +1,8 @@
 // src/components/ConfirmCard.tsx
 'use client'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import type { PortfolioPosition, AssetClass } from '@/lib/types'
+import { SECTOR_LABELS } from '@/lib/sectors'
 import styles from './ConfirmCard.module.css'
 
 type EditableField = 'value' | 'avgCost' | 'currentPrice'
@@ -21,16 +22,14 @@ const ASSET_CLASSES: AssetClass[] = ['국내주식', '해외주식', '채권', '
 
 export function ConfirmCard({ position, pct, isDuplicate, asRow, onDelete, onAssetClassChange, onSectorChange, onFieldChange }: Props) {
   const [expanded, setExpanded] = useState(false)
-  const cancelledSectorBlurRef = useRef(false)
   const [editValues, setEditValues] = useState({
     value: String(Math.round(position.value)),
     avgCost: String(Math.round(position.avgCost)),
     currentPrice: String(Math.round(position.currentPrice)),
   })
-  const [sectorEdit, setSectorEdit] = useState({ draft: position.sector, base: position.sector })
-
-  const fmt = (n: number) => Math.round(n).toLocaleString('ko-KR')
-  const sectorInput = sectorEdit.base === position.sector ? sectorEdit.draft : position.sector
+  const selectedSector = SECTOR_LABELS.some(label => label === position.sector)
+    ? position.sector
+    : '기타'
 
   function handleBlur(field: EditableField) {
     const parsed = parseInt(editValues[field].replace(/,/g, ''), 10)
@@ -49,26 +48,6 @@ export function ConfirmCard({ position, pct, isDuplicate, asRow, onDelete, onAss
     }
   }
 
-  function handleSectorBlur() {
-    if (cancelledSectorBlurRef.current) {
-      cancelledSectorBlurRef.current = false
-      return
-    }
-
-    const nextSector = sectorInput.trim()
-    onSectorChange(position.id, nextSector)
-    setSectorEdit({ draft: nextSector || position.sector, base: position.sector })
-  }
-
-  function handleSectorKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-    if (e.key === 'Enter') e.currentTarget.blur()
-    if (e.key === 'Escape') {
-      cancelledSectorBlurRef.current = true
-      setSectorEdit({ draft: position.sector, base: position.sector })
-      e.currentTarget.blur()
-    }
-  }
-
   if (asRow) {
     return (
       <tr className={`${styles.tr} ${isDuplicate ? styles.trDup : ''}`}>
@@ -83,15 +62,16 @@ export function ConfirmCard({ position, pct, isDuplicate, asRow, onDelete, onAss
           </select>
         </td>
         <td className={styles.td}>
-          <input
-            className={`${styles.tdInput} ${styles.sectorInputSm}`}
-            type="text"
-            value={sectorInput}
-            onChange={e => setSectorEdit({ draft: e.target.value, base: position.sector })}
-            onBlur={handleSectorBlur}
-            onKeyDown={handleSectorKeyDown}
+          <select
+            className={`${styles.selectSm} ${styles.sectorSelectSm}`}
+            value={selectedSector}
+            onChange={e => onSectorChange(position.id, e.target.value)}
             aria-label="섹터 수정"
-          />
+          >
+            {SECTOR_LABELS.map(sector => (
+              <option key={sector} value={sector}>{sector}</option>
+            ))}
+          </select>
         </td>
         <td className={styles.tdNum}>
           <input className={styles.tdInput} inputMode="numeric" value={editValues.value}
@@ -197,15 +177,16 @@ export function ConfirmCard({ position, pct, isDuplicate, asRow, onDelete, onAss
               <option key={ac} value={ac}>{ac}</option>
             ))}
           </select>
-          <input
-            className={styles.sectorInput}
-            type="text"
-            value={sectorInput}
-            onChange={e => setSectorEdit({ draft: e.target.value, base: position.sector })}
-            onBlur={handleSectorBlur}
-            onKeyDown={handleSectorKeyDown}
+          <select
+            className={`${styles.select} ${styles.sectorSelect}`}
+            value={selectedSector}
+            onChange={e => onSectorChange(position.id, e.target.value)}
             aria-label="섹터 수정"
-          />
+          >
+            {SECTOR_LABELS.map(sector => (
+              <option key={sector} value={sector}>{sector}</option>
+            ))}
+          </select>
         </div>
       </div>
 

--- a/src/lib/sectors.test.ts
+++ b/src/lib/sectors.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, it } from 'vitest'
-import { autoClassify } from './sectors'
+import { autoClassify, SECTOR_LABELS } from './sectors'
 
 describe('autoClassify', () => {
+  it('exports the shared sector dropdown labels', () => {
+    expect(SECTOR_LABELS).toHaveLength(30)
+    expect(SECTOR_LABELS).toEqual([
+      '에너지', '소재', '자본재', '전문서비스', '운수', '자동차', '내구소비재', '소비자서비스',
+      '소매유통', '필수소비재유통', '식음료', '생활용품', '의료기기/서비스', '제약/바이오',
+      '은행', '금융서비스', '보험', '소프트웨어', '하드웨어', '반도체',
+      '통신', '미디어/엔터', '유틸리티', '리츠', '부동산',
+      '미국ETF', '국내ETF', '채권ETF', '원자재ETF', '기타',
+    ])
+  })
+
   it('uses the static sector DB for known stock names', () => {
     expect(autoClassify('삼성전자', '005930')).toEqual({
       sector: '반도체',

--- a/src/lib/sectors.ts
+++ b/src/lib/sectors.ts
@@ -4,6 +4,14 @@ import sectorData from '../data/sectors.json'
 type Classification = { sector: string; assetClass: AssetClass }
 type SectorEntry = Classification
 
+export const SECTOR_LABELS = [
+  '에너지', '소재', '자본재', '전문서비스', '운수', '자동차', '내구소비재', '소비자서비스',
+  '소매유통', '필수소비재유통', '식음료', '생활용품', '의료기기/서비스', '제약/바이오',
+  '은행', '금융서비스', '보험', '소프트웨어', '하드웨어', '반도체',
+  '통신', '미디어/엔터', '유틸리티', '리츠', '부동산',
+  '미국ETF', '국내ETF', '채권ETF', '원자재ETF', '기타',
+] as const
+
 const db = new Map(
   Object.entries(sectorData as Record<string, SectorEntry>).map(([name, entry]) => [
     normalizeLookupName(name),


### PR DESCRIPTION
## Summary

- `SECTOR_LABELS` 상수를 `sectors.ts`에서 export (GICS 25개 + ETF 4개 + 기타, 총 30개)
- ConfirmCard 섹터 수정 UI: `<input type="text">` → `<select>` 드롭다운으로 교체
- 카드 뷰 + 테이블 뷰(`asRow`) 모두 반영
- `sectorEdit` state / `handleSectorBlur` / `handleSectorKeyDown` 제거로 코드 단순화

## Test plan

- [x] `pnpm verify` 통과 (64 tests)
- [x] OCR 고정 라벨 외 값은 `'기타'`로 자동 fallback

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)