### PR TITLE
feat: 보유 현금 수동 입력 (#40)

### DIFF
--- a/src/app/confirm/page.module.css
+++ b/src/app/confirm/page.module.css
@@ -15,6 +15,76 @@
 .count { font-size: 13px; font-weight: 600; color: rgba(255,255,255,.55); }
 .hint { font-size: 13px; color: rgba(255,255,255,.75); line-height: 1.5; }
 
+.cashSection {
+  padding: 16px;
+}
+
+.cashHeader {
+  margin-bottom: 12px;
+}
+
+.cashTitle {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: var(--text-1);
+}
+
+.cashHint {
+  margin: 6px 0 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-2);
+}
+
+.cashInputWrap {
+  display: block;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: #fff;
+}
+
+.cashLabel {
+  display: block;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-1);
+}
+
+.cashInputRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.cashInput {
+  width: 100%;
+  min-width: 0;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text-1);
+  background: #fff;
+}
+
+.cashInput:focus {
+  outline: none;
+  border-color: var(--navy);
+  box-shadow: 0 0 0 3px rgba(15, 23, 42, 0.08);
+}
+
+.cashUnit {
+  flex-shrink: 0;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-2);
+}
+
 .scroll {
   flex: 1;
   overflow-y: auto;
@@ -167,6 +237,10 @@
     flex: 1;
     overflow-y: auto;
     padding: 16px 32px 24px;
+  }
+
+  .cashSection {
+    padding: 20px 32px 0;
   }
 
   .targetSection {

--- a/src/app/confirm/page.tsx
+++ b/src/app/confirm/page.tsx
@@ -8,6 +8,36 @@ import type { PortfolioPosition, AssetClass, TargetAllocation } from '@/lib/type
 import styles from './page.module.css'
 
 const TARGET_FIELDS: Array<keyof TargetAllocation> = ['국내주식', '해외주식', '채권']
+const CASH_POSITION_ID = 'manual-cash-position'
+
+function readStoredCash(): string {
+  if (typeof window === 'undefined') return ''
+
+  const raw = sessionStorage.getItem(SESSION_KEYS.CASH)
+  return raw && /^\d+$/.test(raw) ? raw : ''
+}
+
+function parseCashAmount(value: string): number {
+  const digits = value.replace(/\D/g, '')
+  if (!digits) return 0
+
+  return Number(digits)
+}
+
+function createCashPosition(value: number): PortfolioPosition {
+  return {
+    id: CASH_POSITION_ID,
+    name: '현금',
+    code: null,
+    qty: 0,
+    value,
+    avgCost: 0,
+    currentPrice: 0,
+    assetClass: '기타',
+    sector: '기타',
+    sourceImage: 0,
+  }
+}
 
 function readStoredTarget(): TargetAllocation {
   if (typeof window === 'undefined') return { ...DEFAULT_TARGET }
@@ -62,26 +92,60 @@ export default function ConfirmPage() {
     return sessionStorage.getItem(SESSION_KEYS.RAW_POSITIONS) !== null
   })
   const [target, setTarget] = useState<TargetAllocation>(() => readStoredTarget())
+  const [cashInput, setCashInput] = useState(() => readStoredCash())
+
+  const cashAmount = parseCashAmount(cashInput)
+  const cashPosition = cashAmount > 0 ? createCashPosition(cashAmount) : null
+  const displayedPositions = cashPosition ? [...positions, cashPosition] : positions
 
   useEffect(() => {
     if (!loaded) router.replace('/')
   }, [loaded, router])
 
-  const totalValue = positions.reduce((s, p) => s + p.value, 0)
+  const totalValue = displayedPositions.reduce((sum, position) => sum + position.value, 0)
 
   // 중복 티커 감지
   const nameCounts: Record<string, number> = {}
-  for (const p of positions) nameCounts[p.name] = (nameCounts[p.name] ?? 0) + 1
+  for (const position of displayedPositions) {
+    nameCounts[position.name] = (nameCounts[position.name] ?? 0) + 1
+  }
+
+  function persistCashInput(nextValue: string) {
+    if (nextValue) {
+      sessionStorage.setItem(SESSION_KEYS.CASH, nextValue)
+      return
+    }
+
+    sessionStorage.removeItem(SESSION_KEYS.CASH)
+  }
+
+  function handleCashChange(value: string) {
+    const digits = value.replace(/\D/g, '')
+    setCashInput(digits)
+    persistCashInput(digits)
+  }
+
+  function clearCash() {
+    setCashInput('')
+    persistCashInput('')
+  }
 
   function handleDelete(id: string) {
+    if (id === CASH_POSITION_ID) {
+      clearCash()
+      return
+    }
+
     setPositions(prev => prev.filter(p => p.id !== id))
   }
 
   function handleAssetClassChange(id: string, assetClass: AssetClass) {
+    if (id === CASH_POSITION_ID) return
     setPositions(prev => prev.map(p => p.id === id ? { ...p, assetClass } : p))
   }
 
   function handleSectorChange(id: string, sector: string) {
+    if (id === CASH_POSITION_ID) return
     const nextSector = sector || originalSectors[id] || '기타'
 
     setPositions(prev => {
@@ -92,6 +156,11 @@ export default function ConfirmPage() {
   }
 
   function handleFieldChange(id: string, field: 'value' | 'avgCost' | 'currentPrice', value: number) {
+    if (id === CASH_POSITION_ID) {
+      if (field === 'value') handleCashChange(String(value))
+      return
+    }
+
     setPositions(prev => prev.map(p => p.id === id ? { ...p, [field]: value } : p))
   }
 
@@ -100,9 +169,9 @@ export default function ConfirmPage() {
   }
 
   function handleStart() {
-    sessionStorage.setItem(SESSION_KEYS.CONFIRMED, JSON.stringify(positions))
+    sessionStorage.setItem(SESSION_KEYS.CONFIRMED, JSON.stringify(displayedPositions))
     sessionStorage.setItem(SESSION_KEYS.TARGET, JSON.stringify(target))
-    const diagnosis = runDiagnosis(positions, target)
+    const diagnosis = runDiagnosis(displayedPositions, target)
     sessionStorage.setItem(SESSION_KEYS.DIAGNOSIS, JSON.stringify(diagnosis))
     router.push('/diagnosis')
   }
@@ -119,10 +188,31 @@ export default function ConfirmPage() {
       <div className={styles.header}>
         <div className={styles.headerTop}>
           <span className={styles.title}>이렇게 인식했어요</span>
-          <span className={styles.count}>{positions.length}종목</span>
+          <span className={styles.count}>{displayedPositions.length}종목</span>
         </div>
         <p className={styles.hint}>자산군을 확인하고, 금액이 잘못 인식됐으면 눌러서 수정하세요.</p>
       </div>
+
+      <section className={styles.cashSection}>
+        <div className={styles.cashHeader}>
+          <h2 className={styles.cashTitle}>보유 현금</h2>
+          <p className={styles.cashHint}>진단에 포함할 현금이 있으면 직접 입력하세요.</p>
+        </div>
+        <label className={styles.cashInputWrap}>
+          <span className={styles.cashLabel}>보유 현금</span>
+          <div className={styles.cashInputRow}>
+            <input
+              className={styles.cashInput}
+              inputMode="numeric"
+              value={cashInput}
+              onChange={e => handleCashChange(e.target.value)}
+              placeholder="0"
+              aria-label="보유 현금 입력"
+            />
+            <span className={styles.cashUnit}>원</span>
+          </div>
+        </label>
+      </section>
 
       {isDesktop ? (
         /* 768px+ 테이블 뷰 */
@@ -141,9 +231,9 @@ export default function ConfirmPage() {
               </tr>
             </thead>
             <tbody>
-              {positions.map(p => (
+              {displayedPositions.map(p => (
                 <ConfirmCard
-                  key={p.id}
+                  key={p.id === CASH_POSITION_ID ? `${p.id}-${p.value}` : p.id}
                   asRow
                   position={p}
                   pct={totalValue > 0 ? Math.round((p.value / totalValue) * 1000) / 10 : 0}
@@ -160,9 +250,9 @@ export default function ConfirmPage() {
       ) : (
         /* 모바일 카드 뷰 */
         <div className={styles.scroll}>
-          {positions.map(p => (
+          {displayedPositions.map(p => (
             <ConfirmCard
-              key={p.id}
+              key={p.id === CASH_POSITION_ID ? `${p.id}-${p.value}` : p.id}
               position={p}
               pct={totalValue > 0 ? Math.round((p.value / totalValue) * 1000) / 10 : 0}
               isDuplicate={(nameCounts[p.name] ?? 0) > 1}
@@ -180,7 +270,7 @@ export default function ConfirmPage() {
           </div>
         )}
 
-        {positions.length === 0 && (
+        {displayedPositions.length === 0 && (
           <div className={styles.empty}>
             <p>인식된 종목이 없습니다.</p>
             <p>주식잔고 화면을 캡처했는지 확인해주세요.</p>
@@ -192,7 +282,7 @@ export default function ConfirmPage() {
       </div>
       )}
 
-      {positions.length > 0 && (
+      {displayedPositions.length > 0 && (
         <section className={styles.targetSection}>
           <div className={styles.targetHeader}>
             <h2 className={styles.targetTitle}>목표 배분 조정</h2>
@@ -233,7 +323,7 @@ export default function ConfirmPage() {
         </section>
       )}
 
-      {positions.length > 0 && (
+      {displayedPositions.length > 0 && (
         <div className="fixed-cta">
           <button className="btn-primary" onClick={handleStart}>진단 시작</button>
         </div>

--- a/src/components/AllocationBar.test.ts
+++ b/src/components/AllocationBar.test.ts
@@ -1,0 +1,17 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { AllocationBar } from './AllocationBar'
+
+describe('AllocationBar', () => {
+  it('채권·기타 행에 기타 비중을 합산해 표시한다', () => {
+    const html = renderToStaticMarkup(
+      createElement(AllocationBar, {
+        current: { '국내주식': 40, '해외주식': 30, '채권': 10, '기타': 20 },
+        target: { '국내주식': 40, '해외주식': 30, '채권': 30 },
+      })
+    )
+
+    expect(html).toMatch(/채권·기타.*?>30%<\/div>/)
+  })
+})

--- a/src/components/AllocationBar.tsx
+++ b/src/components/AllocationBar.tsx
@@ -7,17 +7,17 @@ interface Props {
   target: TargetAllocation
 }
 
-const ROWS: { key: keyof TargetAllocation; label: string }[] = [
-  { key: '국내주식', label: '국내주식' },
-  { key: '해외주식', label: '해외주식' },
-  { key: '채권',     label: '채권·기타' },
+const ROWS: { key: keyof TargetAllocation; label: string; currentKeys: AssetClass[] }[] = [
+  { key: '국내주식', label: '국내주식', currentKeys: ['국내주식'] },
+  { key: '해외주식', label: '해외주식', currentKeys: ['해외주식'] },
+  { key: '채권', label: '채권·기타', currentKeys: ['채권', '기타'] },
 ]
 
 export function AllocationBar({ current, target }: Props) {
   return (
     <div className={styles.wrap}>
-      {ROWS.map(({ key, label }) => {
-        const cur = current[key] ?? 0
+      {ROWS.map(({ key, label, currentKeys }) => {
+        const cur = currentKeys.reduce((sum, assetClass) => sum + (current[assetClass] ?? 0), 0)
         const tgt = target[key] ?? 0
         const isOver = cur > tgt + 5
         const isUnder = cur < tgt - 5

--- a/src/components/ConfirmCard.tsx
+++ b/src/components/ConfirmCard.tsx
@@ -27,6 +27,7 @@ export function ConfirmCard({ position, pct, isDuplicate, asRow, onDelete, onAss
     avgCost: String(Math.round(position.avgCost)),
     currentPrice: String(Math.round(position.currentPrice)),
   })
+  const isManualCash = position.name === '현금' && position.sourceImage === 0 && position.assetClass === '기타'
   const selectedSector = SECTOR_LABELS.some(label => label === position.sector)
     ? position.sector
     : '기타'
@@ -57,6 +58,7 @@ export function ConfirmCard({ position, pct, isDuplicate, asRow, onDelete, onAss
         </td>
         <td className={styles.td}>
           <select className={styles.selectSm} value={position.assetClass}
+            disabled={isManualCash}
             onChange={e => onAssetClassChange(position.id, e.target.value as AssetClass)}>
             {ASSET_CLASSES.map(ac => <option key={ac} value={ac}>{ac}</option>)}
           </select>
@@ -65,6 +67,7 @@ export function ConfirmCard({ position, pct, isDuplicate, asRow, onDelete, onAss
           <select
             className={`${styles.selectSm} ${styles.sectorSelectSm}`}
             value={selectedSector}
+            disabled={isManualCash}
             onChange={e => onSectorChange(position.id, e.target.value)}
             aria-label="섹터 수정"
           >
@@ -82,12 +85,14 @@ export function ConfirmCard({ position, pct, isDuplicate, asRow, onDelete, onAss
         <td className={`${styles.tdNum} ${styles.tdPct}`}>{pct.toFixed(1)}%</td>
         <td className={styles.tdNum}>
           <input className={`${styles.tdInput} ${styles.secondary}`} inputMode="numeric" value={editValues.avgCost}
+            disabled={isManualCash}
             onChange={e => setEditValues(prev => ({ ...prev, avgCost: e.target.value }))}
             onBlur={() => handleBlur('avgCost')} onKeyDown={e => handleKeyDown(e, 'avgCost')}
             aria-label="매입가 수정" />
         </td>
         <td className={styles.tdNum}>
           <input className={`${styles.tdInput} ${styles.secondary}`} inputMode="numeric" value={editValues.currentPrice}
+            disabled={isManualCash}
             onChange={e => setEditValues(prev => ({ ...prev, currentPrice: e.target.value }))}
             onBlur={() => handleBlur('currentPrice')} onKeyDown={e => handleKeyDown(e, 'currentPrice')}
             aria-label="현재가 수정" />
@@ -170,6 +175,7 @@ export function ConfirmCard({ position, pct, isDuplicate, asRow, onDelete, onAss
           <select
             className={styles.select}
             value={position.assetClass}
+            disabled={isManualCash}
             onChange={e => onAssetClassChange(position.id, e.target.value as AssetClass)}
             aria-label="자산군 선택"
           >
@@ -180,6 +186,7 @@ export function ConfirmCard({ position, pct, isDuplicate, asRow, onDelete, onAss
           <select
             className={`${styles.select} ${styles.sectorSelect}`}
             value={selectedSector}
+            disabled={isManualCash}
             onChange={e => onSectorChange(position.id, e.target.value)}
             aria-label="섹터 수정"
           >
@@ -207,7 +214,7 @@ export function ConfirmCard({ position, pct, isDuplicate, asRow, onDelete, onAss
           </div>
           <div className={styles.expandRow}>
             <span className={styles.expandLabel}>출처</span>
-            <span className={styles.expandVal}>이미지 {position.sourceImage}</span>
+            <span className={styles.expandVal}>{isManualCash ? '직접 입력' : `이미지 ${position.sourceImage}`}</span>
           </div>
         </div>
       )}

--- a/src/lib/engine.test.ts
+++ b/src/lib/engine.test.ts
@@ -76,6 +76,18 @@ describe('runDiagnosis', () => {
     expect(result.actions).toHaveLength(0)
   })
 
+  it('기타 자산은 currentAllocation 기타 비중에 포함된다', () => {
+    const positions = [
+      makePos({ value: 8_000_000, assetClass: '국내주식', name: '삼성전자' }),
+      makePos({ value: 2_000_000, assetClass: '기타', name: '현금', code: null, qty: 0, avgCost: 0, currentPrice: 0 }),
+    ]
+
+    const result = runDiagnosis(positions, TARGET)
+
+    expect(result.currentAllocation['국내주식']).toBe(80)
+    expect(result.currentAllocation['기타']).toBe(20)
+  })
+
   it('국내주식만 100% → 액션에 매도 항목 포함', () => {
     const positions = [
       makePos({ value: 10_000_000, assetClass: '국내주식', name: '현대차', code: '005380', qty: 20, currentPrice: 500_000 }),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -64,6 +64,7 @@ export interface DiagnosisResult {
 export const SESSION_KEYS = {
   RAW_POSITIONS: 'pd_positions',       // OCR 직후 원본 (PortfolioPosition[])
   CONFIRMED: 'pd_confirmed_positions', // 확인 완료 (PortfolioPosition[])
+  CASH: 'pd_cash_amount',              // 확인 화면 수동 입력 현금
   TARGET: 'pd_target',                 // TargetAllocation
   DIAGNOSIS: 'pd_diagnosis',           // DiagnosisResult
   INVESTOR_PROFILE: 'pd_investor_profile', // InvestorProfile


### PR DESCRIPTION
## Summary
- confirm 페이지에 보유 현금 입력 필드 추가
- 입력 금액 > 0이면 `name='현금', assetClass='기타'`로 진단에 포함
- `displayedPositions` 파생 상태로 OCR 원본 positions 불변 보장
- `AllocationBar`: 기타 자산군을 채권·기타 행에 합산 표시
- `SESSION_KEYS.CASH`로 새로고침 후에도 입력값 유지

## Test plan
- [x] `pnpm verify` 66 tests passed
- [x] engine: 기타 자산 currentAllocation 포함 검증
- [x] AllocationBar: 채권+기타 합산 렌더링 검증

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)