### PR TITLE
feat: 현금을 독립 자산군으로 분리 — 목표 배분·진단 엔진 반영

### DIFF
--- a/src/app/style/page.tsx
+++ b/src/app/style/page.tsx
@@ -8,7 +8,7 @@ import type { StyleKey, PortfolioPosition, TargetAllocation } from '@/lib/types'
 import styles from './page.module.css'
 
 const STYLE_KEYS: StyleKey[] = ['stable', 'balanced', 'growth', 'aggressive']
-const TARGET_FIELDS: Array<keyof TargetAllocation> = ['국내주식', '해외주식', '채권']
+const TARGET_FIELDS: Array<keyof TargetAllocation> = ['국내주식', '해외주식', '채권', '현금']
 
 function readConfirmedPositions(): PortfolioPosition[] {
   if (typeof window === 'undefined') return []
@@ -35,6 +35,7 @@ function readStoredTarget(): TargetAllocation {
       '국내주식': typeof parsed['국내주식'] === 'number' ? parsed['국내주식'] : DEFAULT_TARGET['국내주식'],
       '해외주식': typeof parsed['해외주식'] === 'number' ? parsed['해외주식'] : DEFAULT_TARGET['해외주식'],
       '채권': typeof parsed['채권'] === 'number' ? parsed['채권'] : DEFAULT_TARGET['채권'],
+      '현금': typeof parsed['현금'] === 'number' ? parsed['현금'] : DEFAULT_TARGET['현금'],
     }
   } catch {
     return { ...DEFAULT_TARGET }
@@ -151,7 +152,7 @@ export default function StylePage() {
                   key={key}
                   role="radio"
                   aria-checked={isSelected}
-                  aria-label={`${p.label}: ${p.desc}. 국내 ${p.target['국내주식']}, 해외 ${p.target['해외주식']}, 채권 ${p.target['채권']}`}
+                  aria-label={`${p.label}: ${p.desc}. 국내 ${p.target['국내주식']}, 해외 ${p.target['해외주식']}, 채권 ${p.target['채권']}, 현금 ${p.target['현금']}`}
                   className={`${styles.card} ${isSelected ? styles.cardSelected : ''}`}
                   onClick={() => {
                     setSelected(key)
@@ -163,7 +164,7 @@ export default function StylePage() {
                   <span className={styles.cardLabel}>{p.label}</span>
                   <span className={styles.cardDesc}>{p.desc}</span>
                   <span className={styles.cardAlloc}>
-                    국내 {p.target['국내주식']} · 해외 {p.target['해외주식']} · 채권 {p.target['채권']}
+                    국내 {p.target['국내주식']} · 해외 {p.target['해외주식']} · 채권 {p.target['채권']} · 현금 {p.target['현금']}
                   </span>
                 </button>
               )

--- a/src/components/AllocationBar.test.ts
+++ b/src/components/AllocationBar.test.ts
@@ -4,14 +4,15 @@ import { describe, expect, it } from 'vitest'
 import { AllocationBar } from './AllocationBar'
 
 describe('AllocationBar', () => {
-  it('채권·기타 행에 기타 비중을 합산해 표시한다', () => {
+  it('채권과 현금 행을 분리해 표시한다', () => {
     const html = renderToStaticMarkup(
       createElement(AllocationBar, {
-        current: { '국내주식': 40, '해외주식': 30, '채권': 10, '기타': 20 },
-        target: { '국내주식': 40, '해외주식': 30, '채권': 30 },
+        current: { '국내주식': 40, '해외주식': 30, '채권': 10, '현금': 20, '기타': 0 },
+        target: { '국내주식': 40, '해외주식': 30, '채권': 10, '현금': 20 },
       })
     )
 
-    expect(html).toMatch(/채권·기타.*?>30%<\/div>/)
+    expect(html).toMatch(/채권.*?>10%<\/div>/)
+    expect(html).toMatch(/현금.*?>20%<\/div>/)
   })
 })

--- a/src/components/AllocationBar.tsx
+++ b/src/components/AllocationBar.tsx
@@ -1,16 +1,17 @@
 // src/components/AllocationBar.tsx
-import type { AssetClass, TargetAllocation } from '@/lib/types'
+import type { AllocationBucket, TargetAllocation } from '@/lib/types'
 import styles from './AllocationBar.module.css'
 
 interface Props {
-  current: Record<AssetClass, number>
+  current: Record<AllocationBucket, number>
   target: TargetAllocation
 }
 
-const ROWS: { key: keyof TargetAllocation; label: string; currentKeys: AssetClass[] }[] = [
+const ROWS: { key: keyof TargetAllocation; label: string; currentKeys: AllocationBucket[] }[] = [
   { key: '국내주식', label: '국내주식', currentKeys: ['국내주식'] },
   { key: '해외주식', label: '해외주식', currentKeys: ['해외주식'] },
-  { key: '채권', label: '채권·기타', currentKeys: ['채권', '기타'] },
+  { key: '채권', label: '채권', currentKeys: ['채권'] },
+  { key: '현금', label: '현금', currentKeys: ['현금'] },
 ]
 
 export function AllocationBar({ current, target }: Props) {

--- a/src/lib/engine.test.ts
+++ b/src/lib/engine.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from 'vitest'
 import { runDiagnosis } from './engine'
 import type { PortfolioPosition, TargetAllocation } from './types'
 
-const TARGET: TargetAllocation = { '국내주식': 40, '해외주식': 30, '채권': 30 }
+const TARGET: TargetAllocation = { '국내주식': 35, '해외주식': 25, '채권': 30, '현금': 10 }
 
 function makePos(overrides: Partial<PortfolioPosition> & Pick<PortfolioPosition, 'value' | 'assetClass'>): PortfolioPosition {
   return {
@@ -30,7 +30,7 @@ describe('runDiagnosis', () => {
     const driftProblem = result.problems.find(p => p.type === 'drift' && p.assetClass === '국내주식')
     expect(driftProblem).toBeDefined()
     expect(driftProblem!.current).toBe(80)
-    expect(driftProblem!.target).toBe(40)
+    expect(driftProblem!.target).toBe(35)
     expect(driftProblem!.severity).toBe('high')
   })
 
@@ -59,12 +59,13 @@ describe('runDiagnosis', () => {
   })
 
   it('포트폴리오 양호 (drift < 10pp, 단일 종목 30% 이하) → problems 빈 배열', () => {
-    // 국내주식 40%를 2종목으로 분산 (각 20%), 해외 30%, 채권 30%
+    // 국내주식 40%(각 20%), 해외 25%, 채권 25%, 현금 10%
     const positions = [
       makePos({ value: 2_000_000, assetClass: '국내주식', name: '삼성전자' }),
       makePos({ value: 2_000_000, assetClass: '국내주식', name: 'SK하이닉스' }),
-      makePos({ value: 3_000_000, assetClass: '해외주식', name: 'TIGER 미국S&P500' }),
-      makePos({ value: 3_000_000, assetClass: '채권',     name: 'TIGER 채권' }),
+      makePos({ value: 2_500_000, assetClass: '해외주식', name: 'TIGER 미국S&P500' }),
+      makePos({ value: 2_500_000, assetClass: '채권',     name: 'TIGER 채권' }),
+      makePos({ value: 1_000_000, assetClass: '기타', name: '현금', code: null, qty: 0, avgCost: 0, currentPrice: 0 }),
     ]
     const result = runDiagnosis(positions, TARGET)
     expect(result.problems).toHaveLength(0)
@@ -76,16 +77,34 @@ describe('runDiagnosis', () => {
     expect(result.actions).toHaveLength(0)
   })
 
-  it('기타 자산은 currentAllocation 기타 비중에 포함된다', () => {
+  it('현금은 currentAllocation 현금 비중으로 분리되고 기타 자산은 기타에 남는다', () => {
     const positions = [
-      makePos({ value: 8_000_000, assetClass: '국내주식', name: '삼성전자' }),
+      makePos({ value: 6_000_000, assetClass: '국내주식', name: '삼성전자' }),
       makePos({ value: 2_000_000, assetClass: '기타', name: '현금', code: null, qty: 0, avgCost: 0, currentPrice: 0 }),
+      makePos({ value: 2_000_000, assetClass: '기타', name: '금 ETF', code: '132030' }),
     ]
 
     const result = runDiagnosis(positions, TARGET)
 
-    expect(result.currentAllocation['국내주식']).toBe(80)
+    expect(result.currentAllocation['국내주식']).toBe(60)
+    expect(result.currentAllocation['현금']).toBe(20)
     expect(result.currentAllocation['기타']).toBe(20)
+  })
+
+  it('현금 비중 이탈은 drift 문제로 감지한다', () => {
+    const positions = [
+      makePos({ value: 4_000_000, assetClass: '국내주식', name: '삼성전자' }),
+      makePos({ value: 2_000_000, assetClass: '해외주식', name: 'TIGER 미국S&P500' }),
+      makePos({ value: 1_000_000, assetClass: '채권', name: 'TIGER 채권' }),
+      makePos({ value: 3_000_000, assetClass: '기타', name: '현금', code: null, qty: 0, avgCost: 0, currentPrice: 0 }),
+    ]
+
+    const result = runDiagnosis(positions, TARGET)
+    const cashProblem = result.problems.find(p => p.type === 'drift' && p.assetClass === '현금')
+
+    expect(cashProblem).toBeDefined()
+    expect(cashProblem!.current).toBe(30)
+    expect(cashProblem!.target).toBe(10)
   })
 
   it('국내주식만 100% → 액션에 매도 항목 포함', () => {

--- a/src/lib/engine.ts
+++ b/src/lib/engine.ts
@@ -1,7 +1,7 @@
 // src/lib/engine.ts
 import type {
   PortfolioPosition, TargetAllocation, DiagnosisResult,
-  Problem, Action, AssetClass, Severity,
+  Problem, Action, AssetClass, Severity, AllocationBucket,
 } from './types'
 
 const DRIFT_THRESHOLD = 10        // pp 이상 이탈 시 문제
@@ -18,13 +18,17 @@ function groupByAssetClass(positions: PortfolioPosition[]): Record<AssetClass, n
   return result
 }
 
+function isCashPosition(position: PortfolioPosition): boolean {
+  return position.assetClass === '기타' && position.name === '현금'
+}
+
 function buildDriftProblems(
-  current: Record<AssetClass, number>,
+  current: Record<AllocationBucket, number>,
   target: TargetAllocation,
   total: number,
 ): Problem[] {
   const problems: Problem[] = []
-  const assetClasses: Array<keyof TargetAllocation> = ['국내주식', '해외주식', '채권']
+  const assetClasses: Array<keyof TargetAllocation> = ['국내주식', '해외주식', '채권', '현금']
 
   for (const ac of assetClasses) {
     const currentPct = pct(current[ac], total)
@@ -35,11 +39,11 @@ function buildDriftProblems(
 
     const over = diff > 0
     const severity: Severity = Math.abs(diff) >= 20 ? 'high' : 'medium'
-    const labelMap: Record<AssetClass, string> = {
+    const labelMap: Record<keyof TargetAllocation, string> = {
       '국내주식': '국내주식',
       '해외주식': '해외주식',
-      '채권': '채권·기타',
-      '기타': '기타',
+      '채권': '채권',
+      '현금': '현금',
     }
 
     problems.push({
@@ -66,6 +70,8 @@ function buildConcentrationProblems(positions: PortfolioPosition[], total: numbe
 
   // 단일 종목 — 30% 초과 시 집중 위험
   for (const p of positions) {
+    if (isCashPosition(p)) continue
+
     const currentPct = pct(p.value, total)
     if (currentPct > CONCENTRATION_STOCK) {
       problems.push({
@@ -106,18 +112,19 @@ function buildConcentrationProblems(positions: PortfolioPosition[], total: numbe
 
 function buildActions(
   positions: PortfolioPosition[],
-  current: Record<AssetClass, number>,
+  current: Record<AllocationBucket, number>,
   target: TargetAllocation,
   total: number,
 ): Action[] {
   const actions: Action[] = []
 
-  for (const ac of ['국내주식', '해외주식', '채권'] as Array<keyof TargetAllocation>) {
+  for (const ac of ['국내주식', '해외주식', '채권', '현금'] as Array<keyof TargetAllocation>) {
     const currentPct = pct(current[ac], total)
     const targetPct = target[ac]
     const diff = currentPct - targetPct
 
     if (Math.abs(diff) < DRIFT_THRESHOLD) continue
+    if (ac === '현금') continue
 
     const adjustAmount = Math.abs(diff / 100) * total
     const classPositions = positions.filter(p => p.assetClass === ac)
@@ -173,7 +180,7 @@ export function runDiagnosis(
     return {
       problems: [],
       actions: [],
-      currentAllocation: { '국내주식': 0, '해외주식': 0, '채권': 0, '기타': 0 },
+      currentAllocation: { '국내주식': 0, '해외주식': 0, '채권': 0, '현금': 0, '기타': 0 },
       targetAllocation: target,
       totalValue: 0,
     }
@@ -181,21 +188,29 @@ export function runDiagnosis(
 
   const total = positions.reduce((s, p) => s + p.value, 0)
   const byAssetClass = groupByAssetClass(positions)
+  const cashValue = positions.filter(isCashPosition).reduce((sum, position) => sum + position.value, 0)
+  const allocationAmounts: Record<AllocationBucket, number> = {
+    '국내주식': byAssetClass['국내주식'],
+    '해외주식': byAssetClass['해외주식'],
+    '채권': byAssetClass['채권'],
+    '현금': cashValue,
+    '기타': Math.max(byAssetClass['기타'] - cashValue, 0),
+  }
+  const currentAllocation = {
+    '국내주식': pct(allocationAmounts['국내주식'], total),
+    '해외주식': pct(allocationAmounts['해외주식'], total),
+    '채권': pct(allocationAmounts['채권'], total),
+    '현금': pct(allocationAmounts['현금'], total),
+    '기타': pct(allocationAmounts['기타'], total),
+  }
 
-  const driftProblems = buildDriftProblems(byAssetClass, target, total)
+  const driftProblems = buildDriftProblems(allocationAmounts, target, total)
   const concProblems = buildConcentrationProblems(positions, total)
   const problems = [...concProblems.filter(p => p.type === 'concentration_stock'), ...driftProblems, ...concProblems.filter(p => p.type === 'concentration_sector')]
 
-  const currentAllocation = {
-    '국내주식': pct(byAssetClass['국내주식'], total),
-    '해외주식': pct(byAssetClass['해외주식'], total),
-    '채권': pct(byAssetClass['채권'], total),
-    '기타': pct(byAssetClass['기타'], total),
-  }
-
   return {
     problems,
-    actions: buildActions(positions, byAssetClass, target, total),
+    actions: buildActions(positions, allocationAmounts, target, total),
     currentAllocation,
     targetAllocation: target,
     totalValue: total,

--- a/src/lib/explain.test.ts
+++ b/src/lib/explain.test.ts
@@ -23,8 +23,8 @@ const diagnosis: DiagnosisResult = {
       estimatedAmount: 210000,
     },
   ],
-  currentAllocation: { '국내주식': 80, '해외주식': 10, '채권': 10, '기타': 0 },
-  targetAllocation: { '국내주식': 40, '해외주식': 30, '채권': 30 },
+  currentAllocation: { '국내주식': 80, '해외주식': 10, '채권': 10, '현금': 0, '기타': 0 },
+  targetAllocation: { '국내주식': 40, '해외주식': 30, '채권': 30, '현금': 0 },
   totalValue: 1000000,
 }
 

--- a/src/lib/investorProfile.test.ts
+++ b/src/lib/investorProfile.test.ts
@@ -62,6 +62,7 @@ describe('PRESETS round-trip', () => {
         pos('국내주식', t['국내주식']),
         pos('해외주식', t['해외주식']),
         pos('채권', t['채권']),
+        pos('기타', t['현금']),
       ]
       expect(inferStyleKey(positions), `${key} round-trip`).toBe(key)
     }
@@ -73,7 +74,7 @@ describe('PRESETS', () => {
     const keys = ['stable', 'balanced', 'growth', 'aggressive'] as const
     for (const key of keys) {
       const t = PRESETS[key].target
-      expect(t['국내주식'] + t['해외주식'] + t['채권']).toBe(100)
+      expect(t['국내주식'] + t['해외주식'] + t['채권'] + t['현금']).toBe(100)
     }
   })
 

--- a/src/lib/investorProfile.ts
+++ b/src/lib/investorProfile.ts
@@ -13,25 +13,25 @@ export const PRESETS: Record<StyleKey, Preset> = {
     label: '안정형',
     emoji: '🛡️',
     desc: '원금 지키는 게 제일 중요해요',
-    target: { '국내주식': 20, '해외주식': 10, '채권': 70 },
+    target: { '국내주식': 20, '해외주식': 10, '채권': 55, '현금': 15 },
   },
   balanced: {
     label: '균형형',
     emoji: '⚖️',
     desc: '어느 정도 손실은 괜찮아요',
-    target: { '국내주식': 30, '해외주식': 20, '채권': 50 },
+    target: { '국내주식': 30, '해외주식': 20, '채권': 40, '현금': 10 },
   },
   growth: {
     label: '성장형',
     emoji: '🚀',
     desc: '장기적으로 크게 키울래요',
-    target: { '국내주식': 40, '해외주식': 30, '채권': 30 },
+    target: { '국내주식': 40, '해외주식': 30, '채권': 25, '현금': 5 },
   },
   aggressive: {
     label: '공격형',
     emoji: '⚡',
     desc: '리스크 감수하고 최대로',
-    target: { '국내주식': 55, '해외주식': 35, '채권': 10 },
+    target: { '국내주식': 55, '해외주식': 35, '채권': 10, '현금': 0 },
   },
 }
 
@@ -56,11 +56,11 @@ export function inferStyleKey(positions: PortfolioPosition[]): StyleKey {
   const stockPct = stockValue / total
 
   // 임계값은 각 프리셋 target이 자기 자신으로 round-trip되도록 설정
-  // stable(20/10/70): bond>60% → stable
-  // balanced(30/20/50): bond=50% → balanced
-  // growth(40/30/30): stock=70% → growth
-  // aggressive(55/35/10): stock=90% → aggressive
-  if (bondPct > 0.6) return 'stable'
+  // stable(20/10/55/15): bond=55% → stable
+  // balanced(30/20/40/10): bond=40% → balanced
+  // growth(40/30/25/5): stock=70% → growth
+  // aggressive(55/35/10/0): stock=90% → aggressive
+  if (bondPct >= 0.55) return 'stable'
   if (stockPct >= 0.85) return 'aggressive'
   if (stockPct >= 0.65) return 'growth'
   return 'balanced'

--- a/src/lib/targetAllocation.test.ts
+++ b/src/lib/targetAllocation.test.ts
@@ -3,16 +3,16 @@ import { getTargetAllocationErrorMessage, getTargetAllocationSum } from './targe
 
 describe('getTargetAllocationSum', () => {
   it('adds all target allocation buckets', () => {
-    expect(getTargetAllocationSum({ '국내주식': 50, '해외주식': 25, '채권': 15 })).toBe(90)
+    expect(getTargetAllocationSum({ '국내주식': 50, '해외주식': 25, '채권': 15, '현금': 10 })).toBe(100)
   })
 })
 
 describe('getTargetAllocationErrorMessage', () => {
   it('returns null when the target sums to 100', () => {
-    expect(getTargetAllocationErrorMessage({ '국내주식': 40, '해외주식': 30, '채권': 30 })).toBeNull()
+    expect(getTargetAllocationErrorMessage({ '국내주식': 35, '해외주식': 25, '채권': 30, '현금': 10 })).toBeNull()
   })
 
   it('returns the inline validation copy when the target sum is invalid', () => {
-    expect(getTargetAllocationErrorMessage({ '국내주식': 45, '해외주식': 30, '채권': 20 })).toBe('합계: 95% (100%여야 합니다)')
+    expect(getTargetAllocationErrorMessage({ '국내주식': 45, '해외주식': 30, '채권': 20, '현금': 15 })).toBe('합계: 110% (100%여야 합니다)')
   })
 })

--- a/src/lib/targetAllocation.ts
+++ b/src/lib/targetAllocation.ts
@@ -1,7 +1,7 @@
 import type { TargetAllocation } from './types'
 
 export function getTargetAllocationSum(target: TargetAllocation): number {
-  return target['국내주식'] + target['해외주식'] + target['채권']
+  return target['국내주식'] + target['해외주식'] + target['채권'] + target['현금']
 }
 
 export function getTargetAllocationErrorMessage(target: TargetAllocation): string | null {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,14 +19,18 @@ export interface TargetAllocation {
   '국내주식': number  // 0-100 (%)
   '해외주식': number
   '채권': number
+  '현금': number
   // 합계 = 100
 }
 
 export const DEFAULT_TARGET: TargetAllocation = {
-  '국내주식': 40,
-  '해외주식': 30,
+  '국내주식': 35,
+  '해외주식': 25,
   '채권': 30,
+  '현금': 10,
 }
+
+export type AllocationBucket = AssetClass | '현금'
 
 export type ProblemType = 'drift' | 'concentration_stock' | 'concentration_sector'
 export type Severity = 'high' | 'medium'
@@ -34,7 +38,7 @@ export type Severity = 'high' | 'medium'
 export interface Problem {
   type: ProblemType
   severity: Severity
-  assetClass?: AssetClass   // drift 타입일 때
+  assetClass?: AllocationBucket   // drift 타입일 때
   ticker?: string            // concentration_stock 타입일 때
   sector?: string            // concentration_sector 타입일 때
   current: number            // 현재 % (소수점 1자리)
@@ -55,7 +59,7 @@ export interface Action {
 export interface DiagnosisResult {
   problems: Problem[]        // 빈 배열 → "포트폴리오 양호"
   actions: Action[]
-  currentAllocation: Record<AssetClass, number>  // 실제 %
+  currentAllocation: Record<AllocationBucket, number>  // 실제 %
   targetAllocation: TargetAllocation
   totalValue: number
 }


### PR DESCRIPTION
## Summary

- `AllocationBucket = AssetClass | '현금'` 신규 타입으로 현금을 `기타`에서 분리
- `TargetAllocation`에 `'현금'` 버킷 추가, 모든 preset 목표 합계 100% 유지
- `engine.ts`: 현금 drift 감지 + 매수/매도 액션 생성 제외 (현금은 리밸런싱 액션 불가)
- `AllocationBar`: 현금 행 독립 표시
- `/style` 페이지: 현금 슬라이더 추가, `/confirm → /style → /diagnosis` 플로우 완성

## Test plan

- [x] `pnpm verify` — 10 test files, 67 tests passed
- [x] 현금 drift 신규 테스트 (`engine.test.ts`) 통과
- [x] `AllocationBar` 현금/채권 분리 테스트 통과

⚠️ **머지 주의:** fix/50-confirm-hydration(PR #55) 와 `confirm/page.tsx`, `style/page.tsx` 충돌 예정. fix/50 먼저 머지 후 이 브랜치 리베이스 권장.

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)