### PR TITLE
fix: 모바일 /confirm CTA가 현금 입력 가리는 문제 수정

### DIFF
--- a/src/app/confirm/page.module.css
+++ b/src/app/confirm/page.module.css
@@ -1,5 +1,10 @@
 /* src/app/confirm/page.module.css */
-.wrap { display: flex; flex-direction: column; min-height: 100dvh; }
+.wrap {
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+  --mobile-fixed-cta-clearance: calc(96px + env(safe-area-inset-bottom));
+}
 
 .header {
   background: var(--navy);
@@ -77,7 +82,8 @@
 .scroll {
   flex: 1;
   overflow-y: auto;
-  padding: 12px 16px 0;
+  padding: 12px 16px var(--mobile-fixed-cta-clearance);
+  scroll-padding-bottom: var(--mobile-fixed-cta-clearance);
   display: flex;
   flex-direction: column;
   gap: 8px;

--- a/src/app/confirm/page.test.ts
+++ b/src/app/confirm/page.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -84,5 +85,13 @@ describe('ConfirmPage', () => {
     const html = renderToStaticMarkup(createElement(ConfirmPage))
 
     expect(html).toBe('')
+  })
+
+  it('reserves mobile scroll space for the fixed CTA', () => {
+    const css = readFileSync(new URL('./page.module.css', import.meta.url), 'utf8')
+
+    expect(css).toContain('--mobile-fixed-cta-clearance: calc(96px + env(safe-area-inset-bottom));')
+    expect(css).toContain('padding: 12px 16px var(--mobile-fixed-cta-clearance);')
+    expect(css).toContain('scroll-padding-bottom: var(--mobile-fixed-cta-clearance);')
   })
 })


### PR DESCRIPTION
## Summary
- 고정 CTA(`다음 →`) 높이(96px) + `safe-area-inset-bottom`만큼 `.scroll` 영역 하단에 여백 확보
- `scroll-padding-bottom`도 함께 보정해 앵커 스크롤 위치도 정확하게 유지
- CSS 커스텀 프로퍼티(`--mobile-fixed-cta-clearance`)로 단일 소스 관리

## Test plan
- [ ] 모바일 뷰포트(390x844)에서 `/confirm` 페이지 하단까지 스크롤 시 현금 입력 필드가 CTA 위에 완전히 노출됨
- [ ] 현금 입력 필드 탭/포커스 가능 (Playwright 클릭 성공)
- [ ] `pnpm verify` 69/69 통과 ✓
- [ ] 데스크톱 레이아웃 시각적 영향 없음 (P2: 데스크톱에도 96px padding 적용되나 실질 영향 미미)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)