### PR TITLE
feat: 포트폴리오 개선 보기 바텀시트

### DIFF
--- a/src/app/diagnosis/page.module.css
+++ b/src/app/diagnosis/page.module.css
@@ -75,6 +75,30 @@
   overflow: hidden;
 }
 
+.improvementBtn {
+  width: 100%;
+  background: linear-gradient(135deg, rgba(26, 35, 126, 0.08), rgba(57, 73, 171, 0.02));
+  border: 1px solid rgba(26, 35, 126, 0.14);
+  border-radius: var(--radius-card);
+  padding: 16px 18px;
+  font-size: 14px;
+  font-weight: 800;
+  color: var(--navy);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  letter-spacing: -0.2px;
+}
+
+.improvementBtn:active {
+  background: linear-gradient(135deg, rgba(26, 35, 126, 0.14), rgba(57, 73, 171, 0.05));
+}
+
+.improvementBtnArrow {
+  font-size: 16px;
+  line-height: 1;
+}
+
 .explainBtn {
   width: 100%;
   background: var(--surface);

--- a/src/app/diagnosis/page.tsx
+++ b/src/app/diagnosis/page.tsx
@@ -5,8 +5,9 @@ import { useRouter } from 'next/navigation'
 import { ProblemCard } from '@/components/ProblemCard'
 import { AllocationBar } from '@/components/AllocationBar'
 import { ActionItem } from '@/components/ActionItem'
+import { ImprovementSheet } from '@/components/ImprovementSheet'
 import { DIAGNOSIS_DISCLAIMER_LINES } from '@/lib/disclaimers'
-import { computeHealthScore } from '@/lib/healthScore'
+import { computeHealthScore, computeIdealScore } from '@/lib/healthScore'
 import { inferStyleKey } from '@/lib/investorProfile'
 import { getTargetAllocationErrorMessage } from '@/lib/targetAllocation'
 import { inferMbtiType, MBTI_PROFILES } from '@/lib/mbti'
@@ -64,6 +65,7 @@ export default function DiagnosisPage() {
   const [explanation, setExplanation] = useState<string | null>(null)
   const [explainLoading, setExplainLoading] = useState(false)
   const [explainError, setExplainError] = useState(false)
+  const [sheetOpen, setSheetOpen] = useState(false)
 
   useEffect(() => {
     const raw = sessionStorage.getItem(SESSION_KEYS.DIAGNOSIS)
@@ -118,7 +120,8 @@ export default function DiagnosisPage() {
   const isHealthy = diagnosis.problems.length === 0
   const target = diagnosis.targetAllocation
   const targetErrorMessage = getTargetAllocationErrorMessage(target)
-  const healthScore = computeHealthScore(diagnosis.currentAllocation, target, positions, desiredStyle)
+  const currentScore = computeHealthScore(diagnosis.currentAllocation, target, positions, desiredStyle)
+  const idealScore = computeIdealScore(diagnosis.currentAllocation, positions, desiredStyle)
 
   return (
     <div className={styles.wrap}>
@@ -139,7 +142,7 @@ export default function DiagnosisPage() {
         )}
         <div className={styles.healthScore}>
           <span className={styles.healthScoreLabel}>건강점수</span>
-          <strong className={styles.healthScoreValue}>{healthScore}점</strong>
+          <strong className={styles.healthScoreValue}>{currentScore}점</strong>
         </div>
         <AllocationBar current={diagnosis.currentAllocation} target={target} />
         {targetErrorMessage && (
@@ -164,6 +167,10 @@ export default function DiagnosisPage() {
             </div>
           </>
         )}
+        <button className={styles.improvementBtn} onClick={() => setSheetOpen(true)}>
+          포트폴리오 개선 보기
+          <span className={styles.improvementBtnArrow} aria-hidden="true">→</span>
+        </button>
 
         {/* 왜 이 조언인가요? */}
         <button className={`${styles.explainBtn} ${explainOpen ? styles.explainOpen : ''}`} onClick={toggleExplain}>
@@ -217,6 +224,14 @@ export default function DiagnosisPage() {
           ↩ 다시 진단하기
         </button>
       </div>
+      <ImprovementSheet
+        currentAllocation={diagnosis.currentAllocation}
+        targetAllocation={target}
+        currentScore={currentScore}
+        idealScore={idealScore}
+        open={sheetOpen}
+        onClose={() => setSheetOpen(false)}
+      />
     </div>
   )
 }

--- a/src/components/ImprovementSheet.module.css
+++ b/src/components/ImprovementSheet.module.css
@@ -1,0 +1,207 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.5);
+  z-index: 30;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding-top: 24px;
+}
+
+.sheet {
+  width: 100%;
+  max-height: 80vh;
+  overflow-y: auto;
+  background: var(--surface);
+  border-radius: 24px 24px 0 0;
+  padding: 18px 18px calc(22px + env(safe-area-inset-bottom));
+  box-shadow: 0 -12px 32px rgba(15, 23, 42, 0.16);
+  animation: slideUp 0.22s ease-out;
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.eyebrow {
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  margin-bottom: 4px;
+}
+
+.title {
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: -0.6px;
+  color: var(--text-1);
+}
+
+.closeButton {
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--surface);
+  color: var(--text-2);
+  font-size: 18px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.scoreCard {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 10px;
+  align-items: center;
+  padding: 18px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, var(--navy-tint), #f8faff);
+  margin-bottom: 20px;
+}
+
+.scoreBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.scoreLabel {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-3);
+}
+
+.scoreValue {
+  font-size: 30px;
+  font-weight: 800;
+  letter-spacing: -1px;
+  color: var(--navy);
+}
+
+.scoreValueIdeal { color: var(--green); }
+
+.scoreArrow {
+  font-size: 24px;
+  font-weight: 700;
+  color: rgba(26, 35, 126, 0.5);
+}
+
+.section + .section { margin-top: 22px; }
+
+.sectionTitle {
+  font-size: 14px;
+  font-weight: 800;
+  color: var(--text-1);
+  margin-bottom: 12px;
+}
+
+.rowList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.row {
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: #fbfcff;
+}
+
+.rowTop {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.bucketLabel {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-1);
+}
+
+.rowMeta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.percent {
+  font-size: 14px;
+  font-weight: 800;
+  color: var(--text-1);
+  font-variant-numeric: tabular-nums;
+}
+
+.deltaNeutral {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-3);
+}
+
+.deltaAlert {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--red);
+}
+
+.targetCheck {
+  font-size: 14px;
+  font-weight: 800;
+  color: var(--green);
+}
+
+.track {
+  width: 100%;
+  height: 10px;
+  background: #e8edf8;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.trackFill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--navy), var(--navy-mid));
+}
+
+.trackFillTarget {
+  background: linear-gradient(90deg, #10b981, #34d399);
+}
+
+@keyframes slideUp {
+  from {
+    transform: translateY(24px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (min-width: 768px) {
+  .overlay {
+    align-items: center;
+    padding: 24px;
+  }
+
+  .sheet {
+    max-width: 480px;
+    max-height: min(80vh, 720px);
+    border-radius: 24px;
+    box-shadow: 0 20px 48px rgba(15, 23, 42, 0.2);
+  }
+}

--- a/src/components/ImprovementSheet.test.ts
+++ b/src/components/ImprovementSheet.test.ts
@@ -1,0 +1,66 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { ImprovementSheet, getImprovementRows } from './ImprovementSheet'
+
+describe('getImprovementRows', () => {
+  it('tolerance 이내 차이는 중립 상태로 처리한다', () => {
+    const rows = getImprovementRows(
+      { '국내주식': 39, '해외주식': 25, '채권': 27, '현금': 12, '기타': 2 },
+      { '국내주식': 35, '해외주식': 25, '채권': 30, '현금': 10 },
+    )
+
+    expect(rows.find(row => row.key === '국내주식')).toMatchObject({
+      deltaLabel: '—',
+      withinTolerance: true,
+    })
+    expect(rows.find(row => row.key === '현금')).toMatchObject({
+      deltaLabel: '—',
+      withinTolerance: true,
+    })
+  })
+
+  it('tolerance 초과 차이는 방향과 pp를 표시한다', () => {
+    const rows = getImprovementRows(
+      { '국내주식': 50, '해외주식': 10, '채권': 25, '현금': 10, '기타': 5 },
+      { '국내주식': 35, '해외주식': 25, '채권': 30, '현금': 10 },
+    )
+
+    expect(rows.find(row => row.key === '국내주식')).toMatchObject({
+      deltaLabel: '▲15pp',
+      withinTolerance: false,
+    })
+    expect(rows.find(row => row.key === '해외주식')).toMatchObject({
+      deltaLabel: '▼15pp',
+      withinTolerance: false,
+    })
+    expect(rows.find(row => row.key === '기타')).toMatchObject({
+      target: 0,
+      deltaLabel: '▲5pp',
+      withinTolerance: false,
+    })
+  })
+})
+
+describe('ImprovementSheet', () => {
+  it('점수 비교와 목표 섹션을 함께 렌더링한다', () => {
+    const html = renderToStaticMarkup(
+      createElement(ImprovementSheet, {
+        currentAllocation: { '국내주식': 50, '해외주식': 10, '채권': 25, '현금': 10, '기타': 5 },
+        targetAllocation: { '국내주식': 35, '해외주식': 25, '채권': 30, '현금': 10 },
+        currentScore: 48,
+        idealScore: 72,
+        onClose: () => {},
+        open: true,
+      }),
+    )
+
+    expect(html).toContain('현재')
+    expect(html).toContain('48점')
+    expect(html).toContain('개선 시')
+    expect(html).toContain('72점')
+    expect(html).toContain('목표 포트폴리오')
+    expect(html).toContain('▲15pp')
+    expect(html).toContain('✓')
+  })
+})

--- a/src/components/ImprovementSheet.tsx
+++ b/src/components/ImprovementSheet.tsx
@@ -1,0 +1,191 @@
+import { useEffect } from 'react'
+import type { AllocationBucket, TargetAllocation } from '@/lib/types'
+import styles from './ImprovementSheet.module.css'
+
+const ROWS: AllocationBucket[] = ['국내주식', '해외주식', '채권', '현금', '기타']
+
+const LABELS: Record<AllocationBucket, string> = {
+  '국내주식': '국내주식',
+  '해외주식': '해외주식',
+  '채권': '채권',
+  '현금': '현금',
+  '기타': '기타',
+}
+
+const TOLERANCE: Record<AllocationBucket, number> = {
+  '국내주식': 5,
+  '해외주식': 5,
+  '채권': 5,
+  '현금': 3,
+  '기타': 3,
+}
+
+export interface ImprovementSheetProps {
+  currentAllocation: Record<AllocationBucket, number>
+  targetAllocation: TargetAllocation
+  currentScore: number
+  idealScore: number
+  onClose: () => void
+  open: boolean
+}
+
+export interface ImprovementRow {
+  key: AllocationBucket
+  label: string
+  current: number
+  target: number
+  delta: number
+  deltaLabel: string
+  withinTolerance: boolean
+}
+
+function getTargetValue(targetAllocation: TargetAllocation, bucket: AllocationBucket): number {
+  return bucket === '기타' ? 0 : targetAllocation[bucket]
+}
+
+function formatPercent(value: number): string {
+  return Number.isInteger(value) ? `${value}` : value.toFixed(1)
+}
+
+function getDeltaLabel(delta: number, tolerance: number): string {
+  if (Math.abs(delta) <= tolerance) {
+    return '—'
+  }
+
+  const direction = delta > 0 ? '▲' : '▼'
+  return `${direction}${formatPercent(Math.abs(delta))}pp`
+}
+
+export function getImprovementRows(
+  currentAllocation: Record<AllocationBucket, number>,
+  targetAllocation: TargetAllocation,
+): ImprovementRow[] {
+  return ROWS.map(bucket => {
+    const current = currentAllocation[bucket] ?? 0
+    const target = getTargetValue(targetAllocation, bucket)
+    const delta = current - target
+    const tolerance = TOLERANCE[bucket]
+
+    return {
+      key: bucket,
+      label: LABELS[bucket],
+      current,
+      target,
+      delta,
+      deltaLabel: getDeltaLabel(delta, tolerance),
+      withinTolerance: Math.abs(delta) <= tolerance,
+    }
+  })
+}
+
+export function ImprovementSheet({
+  currentAllocation,
+  targetAllocation,
+  currentScore,
+  idealScore,
+  onClose,
+  open,
+}: ImprovementSheetProps) {
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    const originalOverflow = document.body.style.overflow
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose()
+      }
+    }
+
+    document.body.style.overflow = 'hidden'
+    window.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.body.style.overflow = originalOverflow
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [onClose, open])
+
+  if (!open) {
+    return null
+  }
+
+  const rows = getImprovementRows(currentAllocation, targetAllocation)
+
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div
+        className={styles.sheet}
+        onClick={event => event.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="improvement-sheet-title"
+      >
+        <div className={styles.header}>
+          <div>
+            <div className={styles.eyebrow}>포트폴리오 개선 보기</div>
+            <h2 id="improvement-sheet-title" className={styles.title}>현재 vs 목표 비중</h2>
+          </div>
+          <button className={styles.closeButton} type="button" onClick={onClose} aria-label="닫기">
+            ✕
+          </button>
+        </div>
+
+        <section className={styles.scoreCard} aria-label="건강점수 비교">
+          <div className={styles.scoreBlock}>
+            <div className={styles.scoreLabel}>현재</div>
+            <div className={styles.scoreValue}>{formatPercent(currentScore)}점</div>
+          </div>
+          <div className={styles.scoreArrow} aria-hidden="true">→</div>
+          <div className={styles.scoreBlock}>
+            <div className={styles.scoreLabel}>개선 시</div>
+            <div className={`${styles.scoreValue} ${styles.scoreValueIdeal}`}>{formatPercent(idealScore)}점</div>
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.sectionTitle}>현재 포트폴리오</div>
+          <div className={styles.rowList}>
+            {rows.map(row => (
+              <div key={row.key} className={styles.row}>
+                <div className={styles.rowTop}>
+                  <span className={styles.bucketLabel}>{row.label}</span>
+                  <div className={styles.rowMeta}>
+                    <span className={styles.percent}>{formatPercent(row.current)}%</span>
+                    <span className={row.withinTolerance ? styles.deltaNeutral : styles.deltaAlert}>
+                      {row.deltaLabel}
+                    </span>
+                  </div>
+                </div>
+                <div className={styles.track} aria-hidden="true">
+                  <div className={styles.trackFill} style={{ width: `${Math.min(row.current, 100)}%` }} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.sectionTitle}>목표 포트폴리오</div>
+          <div className={styles.rowList}>
+            {rows.map(row => (
+              <div key={row.key} className={styles.row}>
+                <div className={styles.rowTop}>
+                  <span className={styles.bucketLabel}>{row.label}</span>
+                  <div className={styles.rowMeta}>
+                    <span className={styles.percent}>{formatPercent(row.target)}%</span>
+                    <span className={styles.targetCheck}>✓</span>
+                  </div>
+                </div>
+                <div className={styles.track} aria-hidden="true">
+                  <div className={`${styles.trackFill} ${styles.trackFillTarget}`} style={{ width: `${Math.min(row.target, 100)}%` }} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/healthScore.test.ts
+++ b/src/lib/healthScore.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { computeHealthScore } from './healthScore'
+import { computeHealthScore, computeIdealScore } from './healthScore'
 import type {
   AllocationBucket,
   AssetClass,
@@ -120,5 +120,31 @@ describe('computeHealthScore', () => {
 
   it('Simplicity: 보유 종목 수 20개 경계값을 반영한다', () => {
     expect(computeBoundaryScore(20)).toBe(97)
+  })
+})
+
+describe('computeIdealScore', () => {
+  it('현재 건강점수보다 낮지 않고 Style Fit 만점을 반영한다', () => {
+    const currentAllocation: Record<AllocationBucket, number> = {
+      '국내주식': 55,
+      '해외주식': 15,
+      '채권': 20,
+      '현금': 5,
+      '기타': 5,
+    }
+    const positions = [
+      createPosition(1, 55, '국내주식', '반도체'),
+      createPosition(2, 15, '해외주식', '미국주식'),
+      createPosition(3, 20, '채권', '채권 ETF'),
+      createPosition(4, 5, '기타', '기타'),
+      { ...createPosition(5, 5, '기타', '기타'), name: '현금', code: null, qty: 0, avgCost: 0, currentPrice: 0 },
+    ]
+
+    const currentScore = computeHealthScore(currentAllocation, TARGET, positions, 'balanced')
+    const idealScore = computeIdealScore(currentAllocation, positions, 'balanced')
+
+    expect(idealScore).toBeGreaterThanOrEqual(currentScore)
+    expect(idealScore).toBeLessThanOrEqual(100)
+    expect(idealScore - currentScore).toBeGreaterThan(0)
   })
 })

--- a/src/lib/healthScore.ts
+++ b/src/lib/healthScore.ts
@@ -45,6 +45,8 @@ const STYLE_FIT_RULES: Record<AllocationBucket, StyleFitRule> = {
   },
 }
 
+const MAX_STYLE_FIT_SCORE = 60
+
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max)
 }
@@ -171,4 +173,15 @@ export function computeHealthScore(
   const simplicityScore = getSimplicityScore(currentAllocation, positions)
 
   return clamp(Math.round(styleFitScore + diversificationScore + simplicityScore), 0, 100)
+}
+
+export function computeIdealScore(
+  currentAllocation: Record<AllocationBucket, number>,
+  positions: PortfolioPosition[],
+  desiredStyle: StyleKey,
+): number {
+  const diversificationScore = getDiversificationScore(positions, desiredStyle)
+  const simplicityScore = getSimplicityScore(currentAllocation, positions)
+
+  return clamp(Math.round(MAX_STYLE_FIT_SCORE + diversificationScore + simplicityScore), 0, 100)
 }


### PR DESCRIPTION
## Summary
- 진단 결과 페이지에 "포트폴리오 개선 보기 →" 버튼 추가
- 클릭 시 바텀시트: 현재→이상 건강점수 + 자산군별 현재/목표 비중 diff 표시
- tolerance 이내 이탈은 중립(`—`), 초과는 빨강(▲▼pp), 목표는 초록(✓)
- `computeIdealScore` 헬퍼로 이상 점수 정확하게 계산
- 모바일(80vh 슬라이드업) / 데스크톱(중앙 모달 480px) 반응형

## ⚠️ 머지 순서
**PR #63 (#61 healthScore)을 먼저 머지한 뒤 이 PR을 머지해야 합니다.**
(이 브랜치에 healthScore.ts가 포함돼 있어 #63 머지 후 rebase 필요)

## Test plan
- [x] tolerance 이내 차이 중립 처리 검증
- [x] tolerance 초과 시 방향+pp 표시 검증
- [x] 바텀시트 open=true 렌더 smoke test
- [x] healthScore/idealScore 회귀 테스트
- [x] `pnpm verify` 80/80 통과

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)