### PR TITLE
feat: /style 페이지 투자 성향 퀴즈 위저드 (#65)

### DIFF
--- a/src/app/style/page.module.css
+++ b/src/app/style/page.module.css
@@ -216,6 +216,13 @@
   color: var(--green);
 }
 
+.selectionRequired {
+  margin: 4px 20px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #b45309;
+}
+
 /* 카드 스크롤 래퍼 — 오른쪽 페이드 */
 .cardWrap {
   position: relative;
@@ -431,7 +438,8 @@
   .quizEntry,
   .quizWrap,
   .quizResult,
-  .sameBanner {
+  .sameBanner,
+  .selectionRequired {
     margin-left: 32px;
     margin-right: 32px;
   }

--- a/src/app/style/page.module.css
+++ b/src/app/style/page.module.css
@@ -54,6 +54,156 @@
   padding: 0 20px 12px;
 }
 
+.quizResult {
+  margin: 0 20px 12px;
+  padding: 14px 16px;
+  border-radius: var(--radius-card);
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  font-size: 14px;
+  font-weight: 700;
+  color: #1d4ed8;
+}
+
+.quizEntry {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 0 20px 16px;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
+  background: linear-gradient(135deg, #fff, #f8fafc);
+}
+
+.quizEntryTitle {
+  display: block;
+  font-size: 16px;
+  font-weight: 800;
+  color: var(--text-1);
+}
+
+.quizEntryDesc {
+  margin: 6px 0 0;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text-2);
+}
+
+.quizEntryButton {
+  flex-shrink: 0;
+  border: 0;
+  border-radius: 999px;
+  padding: 12px 16px;
+  background: var(--navy);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.quizWrap {
+  margin: 0 20px 16px;
+  padding: 20px;
+  border-radius: var(--radius-card);
+  background: var(--surface);
+  border: 1px solid var(--border);
+}
+
+.quizProgress {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.quizProgressLabel {
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+
+.quizProgressStep {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--navy);
+}
+
+.quizQuestion {
+  margin: 0 0 16px;
+  font-size: 22px;
+  line-height: 1.4;
+  letter-spacing: -0.03em;
+  color: var(--text-1);
+}
+
+.quizChoices {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.quizChoice {
+  width: 100%;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: #fff;
+  text-align: left;
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--text-1);
+  cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.15s, transform 0.15s;
+}
+
+.quizChoiceSelected {
+  border-color: var(--navy);
+  box-shadow: 0 0 0 3px rgba(26,35,126,.08);
+  transform: translateY(-1px);
+}
+
+.quizNav {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.quizNavButton,
+.quizNavButtonPrimary {
+  min-width: 92px;
+  border-radius: 999px;
+  padding: 12px 16px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.quizNavButton {
+  border: 1px solid var(--border);
+  background: #fff;
+  color: var(--text-1);
+}
+
+.quizNavButtonPrimary {
+  margin-left: auto;
+  border: 0;
+  background: var(--navy);
+  color: #fff;
+}
+
+.quizNavButton:disabled,
+.quizNavButtonPrimary:disabled,
+.quizEntryButton:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 /* 동일성향 배너 */
 .sameBanner {
   margin: 0 20px 12px;
@@ -276,5 +426,13 @@
 
   .targetSection {
     padding: 0 32px 108px;
+  }
+
+  .quizEntry,
+  .quizWrap,
+  .quizResult,
+  .sameBanner {
+    margin-left: 32px;
+    margin-right: 32px;
   }
 }

--- a/src/app/style/page.tsx
+++ b/src/app/style/page.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { runDiagnosis } from '@/lib/engine'
-import { PRESETS, inferStyleKey } from '@/lib/investorProfile'
+import { PRESETS, QUIZ_QUESTIONS, inferStyleKey, scoreToStyleKey } from '@/lib/investorProfile'
 import { DEFAULT_TARGET, SESSION_KEYS } from '@/lib/types'
 import type { StyleKey, PortfolioPosition, TargetAllocation } from '@/lib/types'
 import styles from './page.module.css'
@@ -71,6 +71,10 @@ export default function StylePage() {
   })
   const [selected, setSelected] = useState<StyleKey | null>(null)
   const [target, setTarget] = useState<TargetAllocation>(() => readStoredTarget())
+  const [quizMode, setQuizMode] = useState(false)
+  const [currentQuestion, setCurrentQuestion] = useState(0)
+  const [quizAnswers, setQuizAnswers] = useState<Array<number | null>>(() => QUIZ_QUESTIONS.map(() => null))
+  const [quizResult, setQuizResult] = useState<StyleKey | null>(null)
 
   useEffect(() => {
     if (!loaded) router.replace('/confirm')
@@ -84,6 +88,33 @@ export default function StylePage() {
   const targetSum = TARGET_FIELDS.reduce((sum, assetClass) => sum + target[assetClass], 0)
   const isTargetBalanced = targetSum === 100
   const isSameStyle = TARGET_FIELDS.every(assetClass => target[assetClass] === currentPreset.target[assetClass])
+  const activeQuestion = QUIZ_QUESTIONS[currentQuestion]
+  const selectedChoice = quizAnswers[currentQuestion]
+
+  function handleSelectStyle(styleKey: StyleKey) {
+    setSelected(styleKey)
+    setTarget({ ...PRESETS[styleKey].target })
+  }
+
+  function handleStartQuiz() {
+    setQuizMode(true)
+    setCurrentQuestion(0)
+    setQuizAnswers(QUIZ_QUESTIONS.map(() => null))
+    setQuizResult(null)
+  }
+
+  function handleQuizChoice(score: number) {
+    setQuizAnswers(prev => prev.map((value, index) => (index === currentQuestion ? score : value)))
+  }
+
+  function handleQuizComplete() {
+    const totalScore = quizAnswers.reduce<number>((sum, score) => sum + (score ?? 0), 0)
+    const styleKey = scoreToStyleKey(totalScore)
+    handleSelectStyle(styleKey)
+    setQuizResult(styleKey)
+    setQuizMode(false)
+    setCurrentQuestion(0)
+  }
 
   function moveToDiagnosis(target: typeof DEFAULT_TARGET) {
     sessionStorage.setItem(SESSION_KEYS.TARGET, JSON.stringify(target))
@@ -132,6 +163,82 @@ export default function StylePage() {
       <div className={styles.body}>
         <div className={styles.sectionLabel}>앞으로 어떻게 투자하고 싶으세요?</div>
 
+        {quizResult && !quizMode && (
+          <div className={styles.quizResult} role="status">
+            {PRESETS[quizResult].label}이에요 {PRESETS[quizResult].emoji} — 결과가 반영됐어요
+          </div>
+        )}
+
+        <div className={styles.quizEntry}>
+          <div>
+            <strong className={styles.quizEntryTitle}>어떤 성향인지 확인해볼까요?</strong>
+            <p className={styles.quizEntryDesc}>5개의 질문에 답하면 추천 성향을 바로 반영해드려요.</p>
+          </div>
+          <button className={styles.quizEntryButton} type="button" onClick={handleStartQuiz}>
+            투자 성향 퀴즈
+          </button>
+        </div>
+
+        {quizMode && (
+          <section className={styles.quizWrap} aria-labelledby="quiz-title">
+            <div className={styles.quizProgress}>
+              <span id="quiz-title" className={styles.quizProgressLabel}>투자 성향 퀴즈</span>
+              <span className={styles.quizProgressStep}>{currentQuestion + 1} / {QUIZ_QUESTIONS.length}</span>
+            </div>
+
+            <h2 className={styles.quizQuestion}>{activeQuestion.question}</h2>
+
+            <div className={styles.quizChoices} role="radiogroup" aria-label={activeQuestion.question}>
+              {activeQuestion.choices.map(choice => {
+                const isActive = selectedChoice === choice.score
+                return (
+                  <button
+                    key={`${activeQuestion.question}-${choice.label}`}
+                    type="button"
+                    role="radio"
+                    aria-checked={isActive}
+                    className={`${styles.quizChoice} ${isActive ? styles.quizChoiceSelected : ''}`}
+                    onClick={() => handleQuizChoice(choice.score)}
+                  >
+                    {choice.label}
+                  </button>
+                )
+              })}
+            </div>
+
+            <div className={styles.quizNav}>
+              <button
+                type="button"
+                className={styles.quizNavButton}
+                onClick={() => setCurrentQuestion(prev => Math.max(prev - 1, 0))}
+                disabled={currentQuestion === 0}
+              >
+                이전
+              </button>
+
+              {currentQuestion < QUIZ_QUESTIONS.length - 1 ? (
+                <button
+                  type="button"
+                  className={styles.quizNavButtonPrimary}
+                  onClick={() => setCurrentQuestion(prev => prev + 1)}
+                  disabled={selectedChoice === null}
+                >
+                  다음
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  className={styles.quizNavButtonPrimary}
+                  onClick={handleQuizComplete}
+                  disabled={selectedChoice === null}
+                >
+                  완료
+                </button>
+              )}
+            </div>
+          </section>
+        )}
+
         {isSameStyle && (
           <div className={styles.sameBanner} role="status">
             지금 투자 방향이 목표와 일치해요 👍
@@ -154,10 +261,7 @@ export default function StylePage() {
                   aria-checked={isSelected}
                   aria-label={`${p.label}: ${p.desc}. 국내 ${p.target['국내주식']}, 해외 ${p.target['해외주식']}, 채권 ${p.target['채권']}, 현금 ${p.target['현금']}`}
                   className={`${styles.card} ${isSelected ? styles.cardSelected : ''}`}
-                  onClick={() => {
-                    setSelected(key)
-                    setTarget(PRESETS[key].target)
-                  }}
+                  onClick={() => handleSelectStyle(key)}
                 >
                   {isSelected && <span className={styles.check} aria-hidden="true">✓</span>}
                   <span className={styles.cardEmoji}>{p.emoji}</span>

--- a/src/app/style/page.tsx
+++ b/src/app/style/page.tsx
@@ -10,6 +10,12 @@ import styles from './page.module.css'
 const STYLE_KEYS: StyleKey[] = ['stable', 'balanced', 'growth', 'aggressive']
 const TARGET_FIELDS: Array<keyof TargetAllocation> = ['국내주식', '해외주식', '채권', '현금']
 
+function findStyleKeyByTarget(target: TargetAllocation): StyleKey | null {
+  return STYLE_KEYS.find(styleKey =>
+    TARGET_FIELDS.every(assetClass => PRESETS[styleKey].target[assetClass] === target[assetClass]),
+  ) ?? null
+}
+
 function readConfirmedPositions(): PortfolioPosition[] {
   if (typeof window === 'undefined') return []
 
@@ -69,7 +75,7 @@ export default function StylePage() {
     if (typeof window === 'undefined') return false
     return sessionStorage.getItem(SESSION_KEYS.CONFIRMED) !== null
   })
-  const [selected, setSelected] = useState<StyleKey | null>(null)
+  const [selected, setSelected] = useState<StyleKey | null>(() => findStyleKeyByTarget(readStoredTarget()))
   const [target, setTarget] = useState<TargetAllocation>(() => readStoredTarget())
   const [quizMode, setQuizMode] = useState(false)
   const [currentQuestion, setCurrentQuestion] = useState(0)
@@ -87,6 +93,7 @@ export default function StylePage() {
   const allocationDesc = getAllocationDesc(positions)
   const targetSum = TARGET_FIELDS.reduce((sum, assetClass) => sum + target[assetClass], 0)
   const isTargetBalanced = targetSum === 100
+  const canProceed = selected !== null && isTargetBalanced
   const isSameStyle = TARGET_FIELDS.every(assetClass => target[assetClass] === currentPreset.target[assetClass])
   const activeQuestion = QUIZ_QUESTIONS[currentQuestion]
   const selectedChoice = quizAnswers[currentQuestion]
@@ -128,16 +135,12 @@ export default function StylePage() {
   }
 
   function handleNext() {
-    if (!isTargetBalanced) return
+    if (!selected || !isTargetBalanced) return
 
-    if (selected) {
-      sessionStorage.setItem(
-        SESSION_KEYS.INVESTOR_PROFILE,
-        JSON.stringify({ currentStyle, desiredStyle: selected }),
-      )
-    } else {
-      sessionStorage.removeItem(SESSION_KEYS.INVESTOR_PROFILE)
-    }
+    sessionStorage.setItem(
+      SESSION_KEYS.INVESTOR_PROFILE,
+      JSON.stringify({ currentStyle, desiredStyle: selected }),
+    )
 
     moveToDiagnosis(target)
   }
@@ -276,6 +279,12 @@ export default function StylePage() {
           </div>
         </div>
 
+        {!selected && (
+          <p className={styles.selectionRequired} role="status">
+            투자 성향을 먼저 선택하거나 퀴즈를 완료해주세요.
+          </p>
+        )}
+
         <section className={styles.targetSection}>
           <div className={styles.targetHeader}>
             <h2 className={styles.targetTitle}>목표 배분 설정</h2>
@@ -318,7 +327,7 @@ export default function StylePage() {
         <div className="fixed-cta">
           <button
             className="btn-primary"
-            disabled={!isTargetBalanced}
+            disabled={!canProceed}
             onClick={handleNext}
           >
             다음 →

--- a/src/lib/investorProfile.test.ts
+++ b/src/lib/investorProfile.test.ts
@@ -1,6 +1,6 @@
 // src/lib/investorProfile.test.ts
 import { describe, it, expect } from 'vitest'
-import { inferStyleKey, PRESETS } from './investorProfile'
+import { inferStyleKey, PRESETS, QUIZ_QUESTIONS, scoreToStyleKey } from './investorProfile'
 import type { PortfolioPosition } from './types'
 
 function pos(assetClass: PortfolioPosition['assetClass'], value: number): PortfolioPosition {
@@ -84,6 +84,35 @@ describe('PRESETS', () => {
       expect(preset.emoji).toBeTruthy()
       expect(preset.desc).toBeTruthy()
       expect(preset.target).toBeTruthy()
+    }
+  })
+})
+
+describe('scoreToStyleKey', () => {
+  it.each([
+    [-6, 'stable'],
+    [-1, 'stable'],
+    [0, 'balanced'],
+    [2, 'balanced'],
+    [3, 'growth'],
+    [6, 'growth'],
+    [7, 'aggressive'],
+    [10, 'aggressive'],
+  ] as const)('%i점을 %s로 매핑한다', (score, expected) => {
+    expect(scoreToStyleKey(score)).toBe(expected)
+  })
+})
+
+describe('QUIZ_QUESTIONS', () => {
+  it('5개의 질문으로 구성된다', () => {
+    expect(QUIZ_QUESTIONS).toHaveLength(5)
+  })
+
+  it('각 질문은 최소 3개의 선택지를 가진다', () => {
+    for (const question of QUIZ_QUESTIONS) {
+      expect(question.question).toBeTruthy()
+      expect(question.choices).toBeDefined()
+      expect(question.choices.length).toBeGreaterThanOrEqual(3)
     }
   })
 })

--- a/src/lib/investorProfile.ts
+++ b/src/lib/investorProfile.ts
@@ -8,6 +8,16 @@ export interface Preset {
   target: TargetAllocation
 }
 
+export interface QuizChoice {
+  label: string
+  score: number
+}
+
+export interface QuizQuestion {
+  question: string
+  choices: QuizChoice[]
+}
+
 export const PRESETS: Record<StyleKey, Preset> = {
   stable: {
     label: '안정형',
@@ -33,6 +43,60 @@ export const PRESETS: Record<StyleKey, Preset> = {
     desc: '리스크 감수하고 최대로',
     target: { '국내주식': 55, '해외주식': 35, '채권': 10, '현금': 0 },
   },
+}
+
+export const QUIZ_QUESTIONS: QuizQuestion[] = [
+  {
+    question: '투자한 금액이 -20% 하락했을 때 어떻게 하시겠어요?',
+    choices: [
+      { label: '추가 매수 기회라고 생각하고 더 투자해요', score: 2 },
+      { label: '상황을 지켜보며 일부만 더 담아요', score: 1 },
+      { label: '일단 유지하면서 시장을 관찰해요', score: 0 },
+      { label: '손실이 더 커지기 전에 빠르게 줄여요', score: -2 },
+    ],
+  },
+  {
+    question: '투자의 가장 큰 목적은 무엇인가요?',
+    choices: [
+      { label: '장기적으로 자산을 크게 불리는 것', score: 2 },
+      { label: '물가보다 높은 수익을 꾸준히 얻는 것', score: 1 },
+      { label: '원금 보전과 수익의 균형을 맞추는 것', score: 0 },
+      { label: '당장 필요한 자금을 안전하게 지키는 것', score: -1 },
+    ],
+  },
+  {
+    question: '투자 자금을 언제 사용할 계획인가요?',
+    choices: [
+      { label: '10년 이상 장기로 둘 수 있어요', score: 2 },
+      { label: '3년 이상은 유지할 수 있어요', score: 1 },
+      { label: '1~3년 안에는 쓸 수도 있어요', score: 0 },
+      { label: '1년 이내에 사용할 가능성이 커요', score: -1 },
+    ],
+  },
+  {
+    question: '어떤 포트폴리오가 더 편안하게 느껴지나요?',
+    choices: [
+      { label: '주식 비중이 높아도 성장 기대가 크면 괜찮아요', score: 2 },
+      { label: '주식과 채권이 고르게 섞인 구성이 좋아요', score: 1 },
+      { label: '채권과 현금이 많은 안정적인 구성이 좋아요', score: 0 },
+    ],
+  },
+  {
+    question: '자산 가치가 자주 크게 변동하는 상황이 어떤가요?',
+    choices: [
+      { label: '오히려 자연스러운 과정이라 크게 신경 쓰지 않아요', score: 2 },
+      { label: '부담은 있지만 감당할 수 있어요', score: 1 },
+      { label: '가능하면 변동이 적었으면 좋겠어요', score: 0 },
+      { label: '스트레스가 커서 피하고 싶어요', score: -2 },
+    ],
+  },
+]
+
+export function scoreToStyleKey(score: number): StyleKey {
+  if (score >= 7) return 'aggressive'
+  if (score >= 3) return 'growth'
+  if (score >= 0) return 'balanced'
+  return 'stable'
 }
 
 export function inferStyleKey(positions: PortfolioPosition[]): StyleKey {


### PR DESCRIPTION
## Summary
- `investorProfile.ts`에 5문항 퀴즈 데이터(`QUIZ_QUESTIONS`)와 점수→성향 매핑 함수(`scoreToStyleKey`) 추가
- `/style` 페이지에 '어떤 성향인지 확인해볼까요?' 인라인 퀴즈 위저드 추가
- 퀴즈 완료 시 점수 합산 → StyleKey 결정 → 카드 자동 선택 + 슬라이더 반영

## Test plan
- [ ] 퀴즈 버튼 클릭 → 5문항 순서대로 표시되는지 확인
- [ ] 이전/다음 네비게이션, 미선택 시 다음 버튼 비활성화 확인
- [ ] 완료 후 해당 성향 카드가 선택되고 슬라이더가 프리셋 값으로 세팅되는지 확인
- [ ] 카드 직접 선택도 여전히 동작하는지 확인
- [ ] `pnpm verify` 통과

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)