### PR TITLE
[codex] diagnosis 페이지 개선 포인트 구조 재정리

### DIFF
--- a/src/app/diagnosis/page.module.css
+++ b/src/app/diagnosis/page.module.css
@@ -59,6 +59,12 @@
 
 .body { padding: 14px 16px 100px; display: flex; flex-direction: column; gap: 8px; }
 
+.improvementSection {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .sectionLabel {
   font-size: 11px;
   font-weight: 800;
@@ -66,6 +72,12 @@
   text-transform: uppercase;
   color: var(--text-3);
   padding: 10px 4px 4px;
+}
+
+.problemList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .actionCard {
@@ -87,16 +99,39 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 14px;
   letter-spacing: -0.2px;
+  text-align: left;
 }
 
 .improvementBtn:active {
   background: linear-gradient(135deg, rgba(26, 35, 126, 0.14), rgba(57, 73, 171, 0.05));
 }
 
+.improvementBtnText {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.improvementBtnTitle {
+  font-size: 14px;
+  font-weight: 800;
+  color: var(--navy);
+}
+
+.improvementBtnMeta {
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(26, 35, 126, 0.72);
+  line-height: 1.45;
+}
+
 .improvementBtnArrow {
   font-size: 16px;
   line-height: 1;
+  flex-shrink: 0;
 }
 
 .explainBtn {

--- a/src/app/diagnosis/page.tsx
+++ b/src/app/diagnosis/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { ProblemCard } from '@/components/ProblemCard'
 import { AllocationBar } from '@/components/AllocationBar'
-import { ActionItem } from '@/components/ActionItem'
 import { ImprovementSheet } from '@/components/ImprovementSheet'
 import { DIAGNOSIS_DISCLAIMER_LINES } from '@/lib/disclaimers'
 import { computeHealthScore, computeIdealScore } from '@/lib/healthScore'
@@ -122,6 +121,9 @@ export default function DiagnosisPage() {
   const targetErrorMessage = getTargetAllocationErrorMessage(target)
   const currentScore = computeHealthScore(diagnosis.currentAllocation, target, positions, desiredStyle)
   const idealScore = computeIdealScore(diagnosis.currentAllocation, positions, desiredStyle)
+  const scorePreview = idealScore > currentScore
+    ? `건강점수 ${currentScore}점 → ${idealScore}점`
+    : `건강점수 ${currentScore}점 기준으로 전체 비중 확인`
 
   return (
     <div className={styles.wrap}>
@@ -153,24 +155,28 @@ export default function DiagnosisPage() {
       </div>
 
       <div className={styles.body}>
-        {/* 문제 카드 */}
-        {diagnosis.problems.map((p, i) => (
-          <ProblemCard key={i} problem={p} index={i} />
-        ))}
+        <section className={styles.improvementSection} aria-label="포트폴리오 개선 요약">
+          {diagnosis.problems.length > 0 && (
+            <>
+              <div className={styles.sectionLabel}>개선 포인트</div>
+              <div className={styles.problemList}>
+                {diagnosis.problems.map((p, i) => (
+                  <ProblemCard key={i} problem={p} index={i} />
+                ))}
+              </div>
+            </>
+          )}
 
-        {/* 권장 조치 */}
-        {diagnosis.actions.length > 0 && (
-          <>
-            <div className={styles.sectionLabel}>권장 조치</div>
-            <div className={styles.actionCard}>
-              {diagnosis.actions.map((a, i) => <ActionItem key={i} action={a} />)}
+          <button className={styles.improvementBtn} onClick={() => setSheetOpen(true)}>
+            <div className={styles.improvementBtnText}>
+              <span className={styles.improvementBtnTitle}>포트폴리오 개선 보기</span>
+              <span className={styles.improvementBtnMeta}>
+                {scorePreview} · 현재/목표 비중 상세
+              </span>
             </div>
-          </>
-        )}
-        <button className={styles.improvementBtn} onClick={() => setSheetOpen(true)}>
-          포트폴리오 개선 보기
-          <span className={styles.improvementBtnArrow} aria-hidden="true">→</span>
-        </button>
+            <span className={styles.improvementBtnArrow} aria-hidden="true">→</span>
+          </button>
+        </section>
 
         {/* 왜 이 조언인가요? */}
         <button className={`${styles.explainBtn} ${explainOpen ? styles.explainOpen : ''}`} onClick={toggleExplain}>

--- a/src/components/ProblemCard.module.css
+++ b/src/components/ProblemCard.module.css
@@ -3,7 +3,7 @@
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-card);
-  padding: 18px 20px 18px 22px;
+  padding: 16px 18px 16px 20px;
   position: relative;
   overflow: hidden;
 }
@@ -16,37 +16,157 @@
 .red::before { background: var(--red); }
 .amber::before { background: var(--amber); }
 
+.top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
 .num {
   font-size: 10px;
   font-weight: 800;
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--text-3);
-  margin-bottom: 5px;
+  margin-bottom: 6px;
 }
+
 .title {
-  font-size: 17px;
+  font-size: 16px;
   font-weight: 800;
-  letter-spacing: -0.4px;
-  margin-bottom: 10px;
+  letter-spacing: -0.3px;
   line-height: 1.3;
 }
-.numbers {
-  display: flex;
-  align-items: baseline;
-  gap: 6px;
-  margin-bottom: 8px;
+
+.severityBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 800;
+  white-space: nowrap;
 }
-.current {
-  font-size: 36px;
+
+.severityHigh {
+  background: var(--red-bg);
+  color: var(--red);
+}
+
+.severityMedium {
+  background: rgba(245, 158, 11, 0.14);
+  color: #b45309;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 10px;
+  align-items: center;
+  padding: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  border-radius: 14px;
+  background: #fbfcff;
+}
+
+.metric {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.metric:last-child {
+  align-items: flex-end;
+  text-align: right;
+}
+
+.metricLabel {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-3);
+}
+
+.metricValue {
+  font-size: 24px;
   font-weight: 800;
   font-variant-numeric: tabular-nums;
-  letter-spacing: -1.5px;
+  letter-spacing: -0.9px;
   line-height: 1;
 }
+
 .currentRed { color: var(--red); }
 .currentAmber { color: var(--amber); }
-.arrow { font-size: 13px; color: var(--text-3); }
-.target { font-size: 18px; font-weight: 700; font-variant-numeric: tabular-nums; color: var(--text-2); }
-.targetNote { font-size: 11px; color: var(--text-3); margin-left: 2px; }
-.desc { font-size: 13px; color: var(--text-2); line-height: 1.6; }
+
+.deltaBadge {
+  padding: 8px 12px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 800;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.deltaHigh {
+  background: var(--red-bg);
+  color: var(--red);
+}
+
+.deltaMedium {
+  background: rgba(245, 158, 11, 0.14);
+  color: #b45309;
+}
+
+.desc {
+  margin-top: 10px;
+  font-size: 12px;
+  color: var(--text-2);
+  line-height: 1.55;
+}
+
+.recommendations {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(15, 23, 42, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  list-style: none;
+}
+
+.recommendations li {
+  position: relative;
+  padding-left: 12px;
+  font-size: 12px;
+  color: var(--text-1);
+  line-height: 1.55;
+}
+
+.recommendations li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.55em;
+  width: 5px;
+  height: 5px;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.45;
+}
+
+@media (max-width: 380px) {
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .metric:last-child {
+    align-items: flex-start;
+    text-align: left;
+  }
+
+  .deltaBadge {
+    justify-self: flex-start;
+  }
+}

--- a/src/components/ProblemCard.test.ts
+++ b/src/components/ProblemCard.test.ts
@@ -1,0 +1,54 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { ProblemCard } from './ProblemCard'
+
+describe('ProblemCard', () => {
+  it('drift 문제를 현재/목표/차이 중심으로 압축해서 보여준다', () => {
+    const html = renderToStaticMarkup(
+      createElement(ProblemCard, {
+        index: 0,
+        problem: {
+          type: 'drift',
+          severity: 'high',
+          assetClass: '국내주식',
+          current: 50,
+          target: 35,
+          label: '국내주식에 너무 쏠려 있습니다',
+          description: '현재 50%로 목표(35%)보다 15%p 높습니다.',
+        },
+      }),
+    )
+
+    expect(html).toContain('01 · 자산 배분')
+    expect(html).toContain('고위험')
+    expect(html).toContain('현재')
+    expect(html).toContain('목표')
+    expect(html).toContain('목표보다 15%p 높음')
+    expect(html).toContain('국내주식 비중을 현재 50% → 약 35% 수준까지 낮추는 것이 적절합니다.')
+    expect(html).toContain('주식 비중이 높은 상태이므로 일부를 줄이거나 신규 자금을 활용하는 방법이 있습니다.')
+  })
+
+  it('집중 문제는 권장 상한 기준으로 차이를 보여준다', () => {
+    const html = renderToStaticMarkup(
+      createElement(ProblemCard, {
+        index: 1,
+        problem: {
+          type: 'concentration_sector',
+          severity: 'medium',
+          sector: '반도체',
+          current: 62,
+          target: 50,
+          label: '반도체 섹터가 62%입니다',
+          description: '단일 섹터 50% 초과는 섹터 집중 위험입니다.',
+        },
+      }),
+    )
+
+    expect(html).toContain('02 · 섹터 집중')
+    expect(html).toContain('주의')
+    expect(html).toContain('권장 상한')
+    expect(html).toContain('권장 상한보다 12%p 높음')
+    expect(html).toContain('단일 섹터 비중을 현재 62% → 50% 이하 수준으로 낮추는 것이 적절합니다.')
+  })
+})

--- a/src/components/ProblemCard.tsx
+++ b/src/components/ProblemCard.tsx
@@ -7,9 +7,89 @@ interface Props {
   index: number
 }
 
+function getCategoryLabel(problem: Problem): string {
+  if (problem.type === 'drift') return '자산 배분'
+  if (problem.type === 'concentration_stock') return '단일 종목'
+  return '섹터 집중'
+}
+
+function getTargetLabel(problem: Problem): string {
+  return problem.type === 'drift' ? '목표' : '권장 상한'
+}
+
+function formatPercent(value: number): string {
+  return Number.isInteger(value) ? `${value}` : value.toFixed(1)
+}
+
+function getDeltaCopy(problem: Problem): string {
+  const diff = Math.round(Math.abs(problem.current - problem.target))
+
+  if (problem.type === 'drift') {
+    return problem.current > problem.target
+      ? `목표보다 ${diff}%p 높음`
+      : `목표보다 ${diff}%p 낮음`
+  }
+
+  return `${getTargetLabel(problem)}보다 ${diff}%p 높음`
+}
+
+function getAssetLabel(problem: Problem): string {
+  if (problem.type === 'drift' && problem.assetClass) {
+    return problem.assetClass
+  }
+
+  if (problem.type === 'concentration_stock') {
+    return '단일 종목'
+  }
+
+  return '단일 섹터'
+}
+
+function getRecommendationLines(problem: Problem): string[] {
+  const current = formatPercent(problem.current)
+  const target = formatPercent(problem.target)
+
+  if (problem.type === 'drift') {
+    const assetLabel = getAssetLabel(problem)
+
+    if (problem.current < problem.target) {
+      const followUp = assetLabel === '채권'
+        ? '신규 자금을 우선 배분하거나 변동성이 큰 자산 일부를 줄여 천천히 맞추는 방법이 있습니다.'
+        : `${assetLabel} 노출을 신규 자금이나 분할 매수로 보완하는 방법이 있습니다.`
+
+      return [
+        `${assetLabel} 비중을 현재 ${current}% → 약 ${target}% 수준까지 늘리는 것이 적절합니다.`,
+        followUp,
+      ]
+    }
+
+    const followUp = assetLabel.includes('주식')
+      ? '주식 비중이 높은 상태이므로 일부를 줄이거나 신규 자금을 활용하는 방법이 있습니다.'
+      : `${assetLabel} 비중이 높은 상태이므로 다른 자산군으로 천천히 분산하는 것이 좋습니다.`
+
+    return [
+      `${assetLabel} 비중을 현재 ${current}% → 약 ${target}% 수준까지 낮추는 것이 적절합니다.`,
+      followUp,
+    ]
+  }
+
+  if (problem.type === 'concentration_stock') {
+    return [
+      `단일 종목 비중을 현재 ${current}% → ${target}% 이하 수준으로 낮추는 것이 적절합니다.`,
+      '비슷한 역할의 ETF나 다른 종목으로 나눠 담아 변동성을 줄이는 방법이 있습니다.',
+    ]
+  }
+
+  return [
+    `단일 섹터 비중을 현재 ${current}% → ${target}% 이하 수준으로 낮추는 것이 적절합니다.`,
+    '같은 주식 비중 안에서도 다른 섹터로 분산하면 편중을 줄일 수 있습니다.',
+  ]
+}
+
 export function ProblemCard({ problem, index }: Props) {
   const num = String(index + 1).padStart(2, '0')
   const isRed = problem.severity === 'high'
+  const recommendationLines = getRecommendationLines(problem)
 
   return (
     <article
@@ -17,17 +97,38 @@ export function ProblemCard({ problem, index }: Props) {
       role="article"
       aria-label={`진단 항목 ${index + 1}`}
     >
-      <div className={styles.num}>{num} · {problem.type === 'drift' ? '자산 배분' : problem.type === 'concentration_stock' ? '단일 종목' : '섹터 집중'}</div>
-      <div className={styles.title}>{problem.label}</div>
-      <div className={styles.numbers}>
-        <span className={`${styles.current} ${isRed ? styles.currentRed : styles.currentAmber}`}>
-          {problem.current}%
+      <div className={styles.top}>
+        <div>
+          <div className={styles.num}>{num} · {getCategoryLabel(problem)}</div>
+          <div className={styles.title}>{problem.label}</div>
+        </div>
+        <span className={`${styles.severityBadge} ${isRed ? styles.severityHigh : styles.severityMedium}`}>
+          {isRed ? '고위험' : '주의'}
         </span>
-        <span className={styles.arrow}>→</span>
-        <span className={styles.target}>{problem.target}%</span>
-        <span className={styles.targetNote}>{problem.type === 'concentration_stock' ? '이하 권장' : '목표'}</span>
       </div>
+
+      <div className={styles.metrics}>
+        <div className={styles.metric}>
+          <span className={styles.metricLabel}>현재</span>
+          <strong className={`${styles.metricValue} ${isRed ? styles.currentRed : styles.currentAmber}`}>
+            {problem.current}%
+          </strong>
+        </div>
+        <div className={`${styles.deltaBadge} ${isRed ? styles.deltaHigh : styles.deltaMedium}`}>
+          {getDeltaCopy(problem)}
+        </div>
+        <div className={styles.metric}>
+          <span className={styles.metricLabel}>{getTargetLabel(problem)}</span>
+          <strong className={styles.metricValue}>{problem.target}%</strong>
+        </div>
+      </div>
+
       <p className={styles.desc}>{problem.description}</p>
+      <ul className={styles.recommendations} aria-label={`${getAssetLabel(problem)} 개선 방향`}>
+        {recommendationLines.map(line => (
+          <li key={line}>{line}</li>
+        ))}
+      </ul>
     </article>
   )
 }


### PR DESCRIPTION
## What changed
- ProblemCard를 현재/목표/차이 중심의 압축형 개선 카드로 재구성했습니다.
- diagnosis 페이지에서 별도 권장 조치 섹션을 제거하고, 개선 포인트 안에서 적정 비중과 실행 방향을 읽을 수 있게 바꿨습니다.
- 개선 바텀시트 CTA에 건강점수 프리뷰를 넣어 메인 화면과 상세 보기의 역할을 분리했습니다.
- ProblemCard 회귀 테스트를 추가했습니다.

## Why
- 기존 diagnosis 화면은 ProblemCard와 개선 바텀시트가 현재/목표 정보를 반복해서 보여줘서 세로 공간을 많이 쓰고 흐름이 끊겼습니다.
- 구체 종목 매도/매수 권유는 제품 단계상 과하게 처방적으로 보일 수 있어, 자산 배분 중심 가이드로 조정했습니다.

## Impact
- 사용자는 메인 화면에서 개선 포인트와 조정 방향을 더 빠르게 이해할 수 있습니다.
- 바텀시트는 전체 비중 상세 확인 역할에 집중합니다.

## Validation
- `COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm@9.15.4 verify`
- Chrome MCP로 diagnosis 페이지와 improvement sheet 확인

## Related
- Closes #67
