### PR TITLE
fix: 브랜드명 Dr.Folio로 통일 + 진단 숫자-텍스트 간격 개선

### DIFF
--- a/src/app/diagnosis/page.module.css
+++ b/src/app/diagnosis/page.module.css
@@ -19,7 +19,14 @@
   color: #fff;
   margin-bottom: 4px;
 }
-.bigNum em { font-style: normal; font-size: 18px; font-weight: 700; color: rgba(255,255,255,.7); vertical-align: middle; }
+.bigNum em {
+  margin-left: 6px;
+  font-style: normal;
+  font-size: 18px;
+  font-weight: 700;
+  color: rgba(255,255,255,.7);
+  vertical-align: middle;
+}
 .subline { font-size: 14px; font-weight: 600; color: rgba(255,255,255,.75); margin-bottom: 10px; }
 .targetError {
   margin-top: 10px;

--- a/src/app/diagnosis/page.tsx
+++ b/src/app/diagnosis/page.tsx
@@ -106,7 +106,7 @@ export default function DiagnosisPage() {
   const mbtiProfile = MBTI_PROFILES[mbtiType]
 
   async function handleShare() {
-    const text = `나의 투자 MBTI는 ${mbtiProfile.emoji} ${mbtiProfile.type} ${mbtiProfile.name}!\n포트폴리오 닥터에서 내 투자 성향을 분석해봤어요`
+    const text = `나의 투자 MBTI는 ${mbtiProfile.emoji} ${mbtiProfile.type} ${mbtiProfile.name}!\nDr.Folio에서 내 투자 성향을 분석해봤어요`
     if (typeof navigator !== 'undefined' && navigator.share) {
       try { await navigator.share({ title: '투자 MBTI', text }) } catch { /* 취소 */ }
     } else if (typeof navigator !== 'undefined' && navigator.clipboard) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next'
 import './globals.css'
 
 export const metadata: Metadata = {
-  title: '포트폴리오 닥터',
+  title: 'Dr.Folio',
   description: 'MTS 캡처 한 장으로 포트폴리오 진단',
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -82,7 +82,7 @@ export default function UploadPage() {
   if (loading) {
     return (
       <div className={styles.wrap}>
-        <nav className="nav"><span className="logo">포트폴리오<em>·</em>닥터</span><span className="nav-step">1 / 2</span></nav>
+        <nav className="nav"><span className="logo">Dr.Folio</span><span className="nav-step">1 / 2</span></nav>
         <div className={styles.loadingBody}>
           <div className={styles.eyebrow}>분석 중</div>
           <h1 className={styles.loadingTitle}>포트폴리오<br />읽는 중...</h1>
@@ -108,7 +108,7 @@ export default function UploadPage() {
 
   return (
     <div className={styles.wrap}>
-      <nav className="nav"><span className="logo">포트폴리오<em>·</em>닥터</span></nav>
+      <nav className="nav"><span className="logo">Dr.Folio</span></nav>
       <div className={styles.body}>
         <div className={styles.intro}>
           <h1 className={styles.headline}>건강검진은 챙기시면서,<br />포트폴리오 검진은<br />언제 받으셨나요?</h1>

--- a/src/app/style/page.tsx
+++ b/src/app/style/page.tsx
@@ -148,7 +148,7 @@ export default function StylePage() {
   return (
     <div className={styles.wrap}>
       <nav className="nav">
-        <span className="logo">포트폴리오<em>·</em>닥터</span>
+        <span className="logo">Dr.Folio</span>
         <span className="nav-step">2 / 2</span>
       </nav>
 


### PR DESCRIPTION
## Summary
- 모든 nav 로고 및 metadata title `포트폴리오 닥터` → `Dr.Folio` 로 통일 (layout, page, style/page, diagnosis/page)
- 진단 페이지 `N가지` 숫자와 `가지` 텍스트 사이 `margin-left: 6px` 추가

## Test plan
- [ ] `pnpm verify` 통과 (15 test files, 97 tests ✅)
- [ ] 업로드/확인/진단/성향 4개 화면 nav 로고 Dr.Folio 확인
- [ ] 진단 페이지 대형 숫자와 "가지" 사이 간격 시각 확인

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)