### PR TITLE
feat: 종목 직접 입력 페이지 (/manual)

### DIFF
--- a/src/app/manual/page.module.css
+++ b/src/app/manual/page.module.css
@@ -1,0 +1,241 @@
+.wrap {
+  width: 100%;
+  max-width: 440px;
+  margin: 0 auto;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  justify-content: flex-start;
+  padding: 18px 20px 12px;
+}
+
+.brand {
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: -0.6px;
+  color: var(--navy);
+}
+
+.backButton {
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+  color: var(--text-1);
+  font-size: 20px;
+  line-height: 1;
+}
+
+.content {
+  flex: 1;
+  padding: 8px 20px 132px;
+}
+
+.hero {
+  margin-bottom: 24px;
+}
+
+.eyebrow {
+  margin-bottom: 8px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--navy-mid);
+}
+
+.title {
+  font-size: 28px;
+  line-height: 1.28;
+  letter-spacing: -0.7px;
+}
+
+.description {
+  margin-top: 10px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-2);
+}
+
+.section + .section {
+  margin-top: 20px;
+}
+
+.formCard,
+.positionCard,
+.emptyState {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--surface);
+}
+
+.formCard {
+  padding: 18px 16px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+}
+
+.field + .field {
+  margin-top: 14px;
+}
+
+.label {
+  margin-bottom: 8px;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-1);
+}
+
+.input,
+.select {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px 16px;
+  background: var(--surface);
+  color: var(--text-1);
+  font-size: 15px;
+}
+
+.input:focus,
+.select:focus {
+  outline: none;
+  border-color: var(--navy);
+  box-shadow: 0 0 0 3px rgba(26, 35, 126, 0.08);
+}
+
+.moneyField {
+  position: relative;
+}
+
+.moneyField .input {
+  padding-right: 44px;
+}
+
+.moneyUnit {
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  transform: translateY(-50%);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-2);
+}
+
+.addButton {
+  margin-top: 18px;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.sectionTitle {
+  font-size: 16px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+}
+
+.sectionMeta {
+  font-size: 13px;
+  color: var(--text-3);
+}
+
+.positionList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.positionCard {
+  padding: 16px;
+}
+
+.positionMain {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.positionName {
+  font-size: 15px;
+  font-weight: 800;
+  color: var(--text-1);
+}
+
+.positionCode {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--text-3);
+}
+
+.positionValue {
+  flex-shrink: 0;
+  font-size: 15px;
+  font-weight: 800;
+  color: var(--text-1);
+}
+
+.positionFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.assetBadge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: var(--navy-tint);
+  color: var(--navy);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.deleteButton {
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0 14px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+  color: var(--text-2);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.emptyState {
+  padding: 24px 20px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-2);
+}
+
+.addButton:disabled,
+.ctaButton:disabled {
+  background: var(--border-2);
+  color: rgba(255, 255, 255, 0.92);
+  cursor: not-allowed;
+}
+
+.ctaButton {
+  padding-bottom: calc(15px + env(safe-area-inset-bottom));
+}

--- a/src/app/manual/page.test.ts
+++ b/src/app/manual/page.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { createManualPosition, isManualDraftComplete } from './page'
+
+describe('ManualInputPage helpers', () => {
+  it('activates add only when required fields are present', () => {
+    expect(isManualDraftComplete({
+      assetClass: '',
+      code: '',
+      name: '삼성전자',
+      value: '100000',
+    })).toBe(false)
+
+    expect(isManualDraftComplete({
+      assetClass: '국내주식',
+      code: '',
+      name: '삼성전자',
+      value: '100000',
+    })).toBe(true)
+  })
+
+  it('creates a confirm-page compatible position payload', () => {
+    const position = createManualPosition({
+      assetClass: '해외주식',
+      code: '  ',
+      name: ' Apple ',
+      value: '150000',
+    })
+
+    expect(position).toMatchObject({
+      name: 'Apple',
+      code: null,
+      qty: 1,
+      value: 150000,
+      avgCost: 150000,
+      currentPrice: 150000,
+      assetClass: '해외주식',
+      sector: '해외주식',
+      sourceImage: 1,
+    })
+    expect(position.id).toMatch(/^[0-9a-f-]{36}$/)
+  })
+
+  it('keeps the manual page constrained to the mobile container and safe-area CTA', () => {
+    const css = readFileSync(new URL('./page.module.css', import.meta.url), 'utf8')
+
+    expect(css).toContain('max-width: 440px;')
+    expect(css).toContain('env(safe-area-inset-bottom)')
+  })
+})

--- a/src/app/manual/page.tsx
+++ b/src/app/manual/page.tsx
@@ -1,0 +1,221 @@
+'use client'
+import { FormEvent, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { SESSION_KEYS } from '@/lib/types'
+import type { AssetClass, PortfolioPosition } from '@/lib/types'
+import styles from './page.module.css'
+
+const ASSET_CLASSES: AssetClass[] = ['국내주식', '해외주식', '채권', '기타']
+const currencyFormatter = new Intl.NumberFormat('ko-KR')
+
+export interface ManualPositionDraft {
+  assetClass: '' | AssetClass
+  code: string
+  name: string
+  value: string
+}
+
+const EMPTY_DRAFT: ManualPositionDraft = {
+  assetClass: '',
+  code: '',
+  name: '',
+  value: '',
+}
+
+function parseManualValue(value: string): number {
+  const digits = value.replace(/\D/g, '')
+  if (!digits) return 0
+
+  return Number(digits)
+}
+
+export function isManualDraftComplete(
+  draft: ManualPositionDraft
+): draft is ManualPositionDraft & { assetClass: AssetClass } {
+  return draft.name.trim().length > 0 && parseManualValue(draft.value) > 0 && draft.assetClass !== ''
+}
+
+export function createManualPosition(
+  draft: ManualPositionDraft & { assetClass: AssetClass }
+): PortfolioPosition {
+  const amount = parseManualValue(draft.value)
+  const code = draft.code.trim()
+
+  return {
+    id: crypto.randomUUID(),
+    name: draft.name.trim(),
+    code: code || null,
+    qty: 1,
+    value: amount,
+    avgCost: amount,
+    currentPrice: amount,
+    assetClass: draft.assetClass,
+    sector: draft.assetClass,
+    sourceImage: 1,
+  }
+}
+
+export default function ManualInputPage() {
+  const router = useRouter()
+  const [draft, setDraft] = useState<ManualPositionDraft>(EMPTY_DRAFT)
+  const [positions, setPositions] = useState<PortfolioPosition[]>([])
+
+  const canAdd = isManualDraftComplete(draft)
+  const hasPositions = positions.length > 0
+
+  function handleAddPosition(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!isManualDraftComplete(draft)) return
+
+    setPositions(currentPositions => [...currentPositions, createManualPosition(draft)])
+    setDraft(EMPTY_DRAFT)
+  }
+
+  function handleStartDiagnosis() {
+    if (!hasPositions) return
+
+    sessionStorage.setItem(SESSION_KEYS.RAW_POSITIONS, JSON.stringify(positions))
+    router.push('/confirm')
+  }
+
+  return (
+    <div className={styles.wrap}>
+      <nav className={styles.nav}>
+        <button
+          type="button"
+          className={styles.backButton}
+          onClick={() => router.back()}
+          aria-label="뒤로가기"
+        >
+          ←
+        </button>
+        <span className={styles.brand}>Dr.Folio</span>
+      </nav>
+
+      <main className={styles.content}>
+        <section className={styles.hero}>
+          <p className={styles.eyebrow}>직접 입력</p>
+          <h1 className={styles.title}>OCR 없이 종목을 직접 추가해 진단을 시작하세요.</h1>
+          <p className={styles.description}>종목명, 평가금액, 자산군만 입력하면 확인 화면으로 바로 이동합니다.</p>
+        </section>
+
+        <section className={styles.section}>
+          <form className={styles.formCard} onSubmit={handleAddPosition}>
+            <label className={styles.field}>
+              <span className={styles.label}>종목명</span>
+              <input
+                className={styles.input}
+                type="text"
+                value={draft.name}
+                onChange={event => setDraft(currentDraft => ({ ...currentDraft, name: event.target.value }))}
+                placeholder="예: 삼성전자"
+              />
+            </label>
+
+            <label className={styles.field}>
+              <span className={styles.label}>평가금액</span>
+              <div className={styles.moneyField}>
+                <input
+                  className={styles.input}
+                  type="number"
+                  min="0"
+                  step="1"
+                  inputMode="numeric"
+                  value={draft.value}
+                  onChange={event => setDraft(currentDraft => ({
+                    ...currentDraft,
+                    value: event.target.value.replace(/\D/g, ''),
+                  }))}
+                  placeholder="0"
+                />
+                <span className={styles.moneyUnit}>원</span>
+              </div>
+            </label>
+
+            <label className={styles.field}>
+              <span className={styles.label}>종목코드</span>
+              <input
+                className={styles.input}
+                type="text"
+                value={draft.code}
+                onChange={event => setDraft(currentDraft => ({ ...currentDraft, code: event.target.value }))}
+                placeholder="예: 005930 또는 AAPL"
+              />
+            </label>
+
+            <label className={styles.field}>
+              <span className={styles.label}>자산군</span>
+              <select
+                className={styles.select}
+                value={draft.assetClass}
+                onChange={event => setDraft(currentDraft => ({
+                  ...currentDraft,
+                  assetClass: event.target.value as ManualPositionDraft['assetClass'],
+                }))}
+              >
+                <option value="">선택해주세요</option>
+                {ASSET_CLASSES.map(assetClass => (
+                  <option key={assetClass} value={assetClass}>{assetClass}</option>
+                ))}
+              </select>
+            </label>
+
+            <button type="submit" className={`btn-primary ${styles.addButton}`} disabled={!canAdd}>
+              종목 추가
+            </button>
+          </form>
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <h2 className={styles.sectionTitle}>추가한 종목</h2>
+            <span className={styles.sectionMeta}>{positions.length}개</span>
+          </div>
+
+          {hasPositions ? (
+            <div className={styles.positionList}>
+              {positions.map(position => (
+                <article key={position.id} className={styles.positionCard}>
+                  <div className={styles.positionMain}>
+                    <div>
+                      <h3 className={styles.positionName}>{position.name}</h3>
+                      {position.code && <p className={styles.positionCode}>{position.code}</p>}
+                    </div>
+                    <p className={styles.positionValue}>{currencyFormatter.format(position.value)}원</p>
+                  </div>
+
+                  <div className={styles.positionFooter}>
+                    <span className={styles.assetBadge}>{position.assetClass}</span>
+                    <button
+                      type="button"
+                      className={styles.deleteButton}
+                      onClick={() => setPositions(currentPositions =>
+                        currentPositions.filter(currentPosition => currentPosition.id !== position.id)
+                      )}
+                      aria-label={`${position.name} 삭제`}
+                    >
+                      삭제
+                    </button>
+                  </div>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <div className={styles.emptyState}>아직 종목이 없습니다. 위 폼에서 추가해주세요.</div>
+          )}
+        </section>
+      </main>
+
+      <div className="fixed-cta">
+        <button
+          type="button"
+          className={`btn-primary ${styles.ctaButton}`}
+          onClick={handleStartDiagnosis}
+          disabled={!hasPositions}
+        >
+          진단 시작
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 // src/app/page.tsx
 'use client'
+import Link from 'next/link'
 import { useState, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { SESSION_KEYS } from '@/lib/types'
@@ -144,7 +145,7 @@ export default function UploadPage() {
 
         {error && <p className={styles.error}>⚠️ {error} — <a href="#" onClick={() => setError(null)}>다시 시도</a></p>}
 
-        <p className={styles.manual}>또는 <a href="#">종목을 직접 입력하기</a></p>
+        <p className={styles.manual}>또는 <Link href="/manual">종목을 직접 입력하기</Link></p>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- `/manual` 페이지 신규 생성 — OCR 없이 종목명/평가금액/자산군 직접 입력 후 `/confirm`으로 이동
- 랜딩 페이지 "종목을 직접 입력하기" 링크 `href="#"` → `Link href="/manual"` 연결
- 로직 함수 export 분리로 유닛 테스트 3개 추가 (총 100 tests)

## Test plan
- [ ] `pnpm verify` 통과 (16 test files, 100 tests ✅)
- [ ] 랜딩 → "종목을 직접 입력하기" 탭 → `/manual` 이동 확인
- [ ] 종목 추가 폼: 종목명+평가금액+자산군 입력 시 추가 버튼 활성화
- [ ] 종목 삭제 버튼 동작 확인
- [ ] "진단 시작" → `/confirm` 이동 및 sessionStorage 데이터 확인

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)