### PR TITLE
[codex] Refine manual entry flow and verification guardrails

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "verify": "tsc --noEmit && eslint src && vitest run",
+    "verify": "next build && tsc --noEmit && eslint src && vitest run",
     "test-ocr": "bun run ocr-test.ts"
   },
   "dependencies": {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -101,9 +101,10 @@ a { text-decoration: none; color: inherit; }
   padding: 18px 20px;
 }
 .logo {
-  font-size: 14px;
-  font-weight: 800;
-  letter-spacing: -0.3px;
+  font-size: 18px;
+  font-weight: 900;
+  line-height: 1;
+  letter-spacing: -0.5px;
   color: var(--navy);
 }
 .logo em { font-style: normal; color: var(--amber); }

--- a/src/app/manual/manualPosition.ts
+++ b/src/app/manual/manualPosition.ts
@@ -4,14 +4,20 @@ export interface ManualPositionDraft {
   assetClass: '' | AssetClass
   code: string
   name: string
+  sector: string
   value: string
+  avgCost: string
+  currentPrice: string
 }
 
 export const EMPTY_DRAFT: ManualPositionDraft = {
   assetClass: '',
   code: '',
   name: '',
+  sector: '',
   value: '',
+  avgCost: '',
+  currentPrice: '',
 }
 
 function parseManualValue(value: string): number {
@@ -24,13 +30,22 @@ function parseManualValue(value: string): number {
 export function isManualDraftComplete(
   draft: ManualPositionDraft
 ): draft is ManualPositionDraft & { assetClass: AssetClass } {
-  return draft.name.trim().length > 0 && parseManualValue(draft.value) > 0 && draft.assetClass !== ''
+  return (
+    draft.name.trim().length > 0 &&
+    parseManualValue(draft.value) > 0 &&
+    parseManualValue(draft.avgCost) > 0 &&
+    parseManualValue(draft.currentPrice) > 0 &&
+    draft.assetClass !== '' &&
+    draft.sector.trim().length > 0
+  )
 }
 
 export function createManualPosition(
   draft: ManualPositionDraft & { assetClass: AssetClass }
 ): PortfolioPosition {
-  const amount = parseManualValue(draft.value)
+  const value = parseManualValue(draft.value)
+  const avgCost = parseManualValue(draft.avgCost)
+  const currentPrice = parseManualValue(draft.currentPrice)
   const code = draft.code.trim()
 
   return {
@@ -38,11 +53,11 @@ export function createManualPosition(
     name: draft.name.trim(),
     code: code || null,
     qty: 1,
-    value: amount,
-    avgCost: amount,
-    currentPrice: amount,
+    value,
+    avgCost,
+    currentPrice,
     assetClass: draft.assetClass,
-    sector: draft.assetClass,
+    sector: draft.sector.trim(),
     sourceImage: 1,
   }
 }

--- a/src/app/manual/manualPosition.ts
+++ b/src/app/manual/manualPosition.ts
@@ -1,0 +1,48 @@
+import type { AssetClass, PortfolioPosition } from '@/lib/types'
+
+export interface ManualPositionDraft {
+  assetClass: '' | AssetClass
+  code: string
+  name: string
+  value: string
+}
+
+export const EMPTY_DRAFT: ManualPositionDraft = {
+  assetClass: '',
+  code: '',
+  name: '',
+  value: '',
+}
+
+function parseManualValue(value: string): number {
+  const digits = value.replace(/\D/g, '')
+  if (!digits) return 0
+
+  return Number(digits)
+}
+
+export function isManualDraftComplete(
+  draft: ManualPositionDraft
+): draft is ManualPositionDraft & { assetClass: AssetClass } {
+  return draft.name.trim().length > 0 && parseManualValue(draft.value) > 0 && draft.assetClass !== ''
+}
+
+export function createManualPosition(
+  draft: ManualPositionDraft & { assetClass: AssetClass }
+): PortfolioPosition {
+  const amount = parseManualValue(draft.value)
+  const code = draft.code.trim()
+
+  return {
+    id: crypto.randomUUID(),
+    name: draft.name.trim(),
+    code: code || null,
+    qty: 1,
+    value: amount,
+    avgCost: amount,
+    currentPrice: amount,
+    assetClass: draft.assetClass,
+    sector: draft.assetClass,
+    sourceImage: 1,
+  }
+}

--- a/src/app/manual/page.module.css
+++ b/src/app/manual/page.module.css
@@ -17,9 +17,10 @@
 }
 
 .brand {
-  font-size: 20px;
-  font-weight: 800;
-  letter-spacing: -0.6px;
+  font-size: 24px;
+  font-weight: 900;
+  line-height: 1;
+  letter-spacing: -0.8px;
   color: var(--navy);
 }
 
@@ -98,6 +99,13 @@
 .formGrid + .formGridTriple,
 .formGridTriple + .helperText,
 .helperText + .addButton {
+  margin-top: 14px;
+}
+
+.formCard > .field + .formGrid,
+.formCard > .field + .formGridTriple,
+.formCard > .field + .helperText,
+.formCard > .field + .addButton {
   margin-top: 14px;
 }
 
@@ -191,12 +199,6 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-}
-
-.positionCodeMeta {
-  padding: 0 4px;
-  font-size: 12px;
-  color: var(--text-3);
 }
 
 .emptyState {

--- a/src/app/manual/page.module.css
+++ b/src/app/manual/page.module.css
@@ -1,0 +1,241 @@
+.wrap {
+  width: 100%;
+  max-width: 440px;
+  margin: 0 auto;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  justify-content: flex-start;
+  padding: 18px 20px 12px;
+}
+
+.brand {
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: -0.6px;
+  color: var(--navy);
+}
+
+.backButton {
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+  color: var(--text-1);
+  font-size: 20px;
+  line-height: 1;
+}
+
+.content {
+  flex: 1;
+  padding: 8px 20px 132px;
+}
+
+.hero {
+  margin-bottom: 24px;
+}
+
+.eyebrow {
+  margin-bottom: 8px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--navy-mid);
+}
+
+.title {
+  font-size: 28px;
+  line-height: 1.28;
+  letter-spacing: -0.7px;
+}
+
+.description {
+  margin-top: 10px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-2);
+}
+
+.section + .section {
+  margin-top: 20px;
+}
+
+.formCard,
+.positionCard,
+.emptyState {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--surface);
+}
+
+.formCard {
+  padding: 18px 16px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+}
+
+.field + .field {
+  margin-top: 14px;
+}
+
+.label {
+  margin-bottom: 8px;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-1);
+}
+
+.input,
+.select {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px 16px;
+  background: var(--surface);
+  color: var(--text-1);
+  font-size: 15px;
+}
+
+.input:focus,
+.select:focus {
+  outline: none;
+  border-color: var(--navy);
+  box-shadow: 0 0 0 3px rgba(26, 35, 126, 0.08);
+}
+
+.moneyField {
+  position: relative;
+}
+
+.moneyField .input {
+  padding-right: 44px;
+}
+
+.moneyUnit {
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  transform: translateY(-50%);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-2);
+}
+
+.addButton {
+  margin-top: 18px;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.sectionTitle {
+  font-size: 16px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+}
+
+.sectionMeta {
+  font-size: 13px;
+  color: var(--text-3);
+}
+
+.positionList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.positionCard {
+  padding: 16px;
+}
+
+.positionMain {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.positionName {
+  font-size: 15px;
+  font-weight: 800;
+  color: var(--text-1);
+}
+
+.positionCode {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--text-3);
+}
+
+.positionValue {
+  flex-shrink: 0;
+  font-size: 15px;
+  font-weight: 800;
+  color: var(--text-1);
+}
+
+.positionFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.assetBadge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: var(--navy-tint);
+  color: var(--navy);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.deleteButton {
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0 14px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+  color: var(--text-2);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.emptyState {
+  padding: 24px 20px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-2);
+}
+
+.addButton:disabled,
+.ctaButton:disabled {
+  background: var(--border-2);
+  color: rgba(255, 255, 255, 0.92);
+  cursor: not-allowed;
+}
+
+.ctaButton {
+  padding-bottom: calc(15px + env(safe-area-inset-bottom));
+}

--- a/src/app/manual/page.module.css
+++ b/src/app/manual/page.module.css
@@ -80,12 +80,33 @@
   padding: 18px 16px;
 }
 
+.formGrid,
+.formGridTriple {
+  display: grid;
+  gap: 14px;
+}
+
+.formGrid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.formGridTriple {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.formGrid + .formGrid,
+.formGrid + .formGridTriple,
+.formGridTriple + .helperText,
+.helperText + .addButton {
+  margin-top: 14px;
+}
+
 .field {
   display: flex;
   flex-direction: column;
 }
 
-.field + .field {
+.formCard > .field + .field {
   margin-top: 14px;
 }
 
@@ -132,6 +153,12 @@
   color: var(--text-2);
 }
 
+.helperText {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-2);
+}
+
 .addButton {
   margin-top: 18px;
 }
@@ -160,66 +187,16 @@
   gap: 12px;
 }
 
-.positionCard {
-  padding: 16px;
-}
-
-.positionMain {
+.positionCardWrap {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
+  flex-direction: column;
+  gap: 6px;
 }
 
-.positionName {
-  font-size: 15px;
-  font-weight: 800;
-  color: var(--text-1);
-}
-
-.positionCode {
-  margin-top: 6px;
+.positionCodeMeta {
+  padding: 0 4px;
   font-size: 12px;
   color: var(--text-3);
-}
-
-.positionValue {
-  flex-shrink: 0;
-  font-size: 15px;
-  font-weight: 800;
-  color: var(--text-1);
-}
-
-.positionFooter {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-top: 16px;
-}
-
-.assetBadge {
-  display: inline-flex;
-  align-items: center;
-  min-height: 32px;
-  padding: 0 12px;
-  border-radius: 999px;
-  background: var(--navy-tint);
-  color: var(--navy);
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.deleteButton {
-  min-width: 44px;
-  min-height: 44px;
-  padding: 0 14px;
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  background: var(--surface);
-  color: var(--text-2);
-  font-size: 14px;
-  font-weight: 700;
 }
 
 .emptyState {
@@ -238,4 +215,11 @@
 
 .ctaButton {
   padding-bottom: calc(15px + env(safe-area-inset-bottom));
+}
+
+@media (max-width: 640px) {
+  .formGrid,
+  .formGridTriple {
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/app/manual/page.test.ts
+++ b/src/app/manual/page.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
-import { createManualPosition, isManualDraftComplete } from './page'
+import { createManualPosition, isManualDraftComplete } from './manualPosition'
 
 describe('ManualInputPage helpers', () => {
   it('activates add only when required fields are present', () => {

--- a/src/app/manual/page.test.ts
+++ b/src/app/manual/page.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { createManualPosition, isManualDraftComplete } from './page'
+
+describe('ManualInputPage helpers', () => {
+  it('activates add only when required fields are present', () => {
+    expect(isManualDraftComplete({
+      assetClass: '',
+      code: '',
+      name: '삼성전자',
+      value: '100000',
+    })).toBe(false)
+
+    expect(isManualDraftComplete({
+      assetClass: '국내주식',
+      code: '',
+      name: '삼성전자',
+      value: '100000',
+    })).toBe(true)
+  })
+
+  it('creates a confirm-page compatible position payload', () => {
+    const position = createManualPosition({
+      assetClass: '해외주식',
+      code: '  ',
+      name: ' Apple ',
+      value: '150000',
+    })
+
+    expect(position).toMatchObject({
+      name: 'Apple',
+      code: null,
+      qty: 1,
+      value: 150000,
+      avgCost: 150000,
+      currentPrice: 150000,
+      assetClass: '해외주식',
+      sector: '해외주식',
+      sourceImage: 1,
+    })
+    expect(position.id).toMatch(/^[0-9a-f-]{36}$/)
+  })
+
+  it('keeps the manual page constrained to the mobile container and safe-area CTA', () => {
+    const css = readFileSync(new URL('./page.module.css', import.meta.url), 'utf8')
+
+    expect(css).toContain('max-width: 440px;')
+    expect(css).toContain('env(safe-area-inset-bottom)')
+  })
+})

--- a/src/app/manual/page.test.ts
+++ b/src/app/manual/page.test.ts
@@ -8,14 +8,20 @@ describe('ManualInputPage helpers', () => {
       assetClass: '',
       code: '',
       name: '삼성전자',
+      sector: '반도체',
       value: '100000',
+      avgCost: '90000',
+      currentPrice: '100000',
     })).toBe(false)
 
     expect(isManualDraftComplete({
       assetClass: '국내주식',
       code: '',
       name: '삼성전자',
+      sector: '반도체',
       value: '100000',
+      avgCost: '90000',
+      currentPrice: '100000',
     })).toBe(true)
   })
 
@@ -24,7 +30,10 @@ describe('ManualInputPage helpers', () => {
       assetClass: '해외주식',
       code: '  ',
       name: ' Apple ',
+      sector: '소프트웨어',
       value: '150000',
+      avgCost: '140000',
+      currentPrice: '155000',
     })
 
     expect(position).toMatchObject({
@@ -32,10 +41,10 @@ describe('ManualInputPage helpers', () => {
       code: null,
       qty: 1,
       value: 150000,
-      avgCost: 150000,
-      currentPrice: 150000,
+      avgCost: 140000,
+      currentPrice: 155000,
       assetClass: '해외주식',
-      sector: '해외주식',
+      sector: '소프트웨어',
       sourceImage: 1,
     })
     expect(position.id).toMatch(/^[0-9a-f-]{36}$/)
@@ -46,5 +55,6 @@ describe('ManualInputPage helpers', () => {
 
     expect(css).toContain('max-width: 440px;')
     expect(css).toContain('env(safe-area-inset-bottom)')
+    expect(css).toContain('grid-template-columns: repeat(3, minmax(0, 1fr));')
   })
 })

--- a/src/app/manual/page.tsx
+++ b/src/app/manual/page.tsx
@@ -88,29 +88,16 @@ export default function ManualInputPage() {
 
         <section className={styles.section}>
           <form className={styles.formCard} onSubmit={handleAddPosition}>
-            <div className={styles.formGrid}>
-              <label className={styles.field}>
-                <span className={styles.label}>종목명</span>
-                <input
-                  className={styles.input}
-                  type="text"
-                  value={draft.name}
-                  onChange={event => setDraft(currentDraft => ({ ...currentDraft, name: event.target.value }))}
-                  placeholder="예: 삼성전자"
-                />
-              </label>
-
-              <label className={styles.field}>
-                <span className={styles.label}>종목코드</span>
-                <input
-                  className={styles.input}
-                  type="text"
-                  value={draft.code}
-                  onChange={event => setDraft(currentDraft => ({ ...currentDraft, code: event.target.value }))}
-                  placeholder="예: 005930 또는 AAPL"
-                />
-              </label>
-            </div>
+            <label className={styles.field}>
+              <span className={styles.label}>종목명</span>
+              <input
+                className={styles.input}
+                type="text"
+                value={draft.name}
+                onChange={event => setDraft(currentDraft => ({ ...currentDraft, name: event.target.value }))}
+                placeholder="예: 삼성전자"
+              />
+            </label>
 
             <div className={styles.formGrid}>
               <label className={styles.field}>
@@ -227,7 +214,6 @@ export default function ManualInputPage() {
             <div className={styles.positionList}>
               {positions.map(position => (
                 <div key={position.id} className={styles.positionCardWrap}>
-                  {position.code && <p className={styles.positionCodeMeta}>종목코드 {position.code}</p>}
                   <ConfirmCard
                     position={position}
                     pct={totalValue > 0 ? Math.round((position.value / totalValue) * 1000) / 10 : 0}

--- a/src/app/manual/page.tsx
+++ b/src/app/manual/page.tsx
@@ -2,62 +2,16 @@
 import { FormEvent, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { SESSION_KEYS } from '@/lib/types'
-import type { AssetClass, PortfolioPosition } from '@/lib/types'
+import type { PortfolioPosition } from '@/lib/types'
+import { EMPTY_DRAFT, createManualPosition, isManualDraftComplete } from './manualPosition'
 import styles from './page.module.css'
 
-const ASSET_CLASSES: AssetClass[] = ['국내주식', '해외주식', '채권', '기타']
+const ASSET_CLASSES = ['국내주식', '해외주식', '채권', '기타'] as const
 const currencyFormatter = new Intl.NumberFormat('ko-KR')
-
-export interface ManualPositionDraft {
-  assetClass: '' | AssetClass
-  code: string
-  name: string
-  value: string
-}
-
-const EMPTY_DRAFT: ManualPositionDraft = {
-  assetClass: '',
-  code: '',
-  name: '',
-  value: '',
-}
-
-function parseManualValue(value: string): number {
-  const digits = value.replace(/\D/g, '')
-  if (!digits) return 0
-
-  return Number(digits)
-}
-
-export function isManualDraftComplete(
-  draft: ManualPositionDraft
-): draft is ManualPositionDraft & { assetClass: AssetClass } {
-  return draft.name.trim().length > 0 && parseManualValue(draft.value) > 0 && draft.assetClass !== ''
-}
-
-export function createManualPosition(
-  draft: ManualPositionDraft & { assetClass: AssetClass }
-): PortfolioPosition {
-  const amount = parseManualValue(draft.value)
-  const code = draft.code.trim()
-
-  return {
-    id: crypto.randomUUID(),
-    name: draft.name.trim(),
-    code: code || null,
-    qty: 1,
-    value: amount,
-    avgCost: amount,
-    currentPrice: amount,
-    assetClass: draft.assetClass,
-    sector: draft.assetClass,
-    sourceImage: 1,
-  }
-}
 
 export default function ManualInputPage() {
   const router = useRouter()
-  const [draft, setDraft] = useState<ManualPositionDraft>(EMPTY_DRAFT)
+  const [draft, setDraft] = useState(EMPTY_DRAFT)
   const [positions, setPositions] = useState<PortfolioPosition[]>([])
 
   const canAdd = isManualDraftComplete(draft)
@@ -150,7 +104,7 @@ export default function ManualInputPage() {
                 value={draft.assetClass}
                 onChange={event => setDraft(currentDraft => ({
                   ...currentDraft,
-                  assetClass: event.target.value as ManualPositionDraft['assetClass'],
+                  assetClass: event.target.value as typeof currentDraft.assetClass,
                 }))}
               >
                 <option value="">선택해주세요</option>

--- a/src/app/manual/page.tsx
+++ b/src/app/manual/page.tsx
@@ -2,12 +2,13 @@
 import { FormEvent, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { SESSION_KEYS } from '@/lib/types'
-import type { PortfolioPosition } from '@/lib/types'
+import { ConfirmCard } from '@/components/ConfirmCard'
+import { SECTOR_LABELS } from '@/lib/sectors'
+import type { AssetClass, PortfolioPosition } from '@/lib/types'
 import { EMPTY_DRAFT, createManualPosition, isManualDraftComplete } from './manualPosition'
 import styles from './page.module.css'
 
 const ASSET_CLASSES = ['국내주식', '해외주식', '채권', '기타'] as const
-const currencyFormatter = new Intl.NumberFormat('ko-KR')
 
 export default function ManualInputPage() {
   const router = useRouter()
@@ -16,6 +17,12 @@ export default function ManualInputPage() {
 
   const canAdd = isManualDraftComplete(draft)
   const hasPositions = positions.length > 0
+  const totalValue = positions.reduce((sum, position) => sum + position.value, 0)
+  const nameCounts: Record<string, number> = {}
+
+  for (const position of positions) {
+    nameCounts[position.name] = (nameCounts[position.name] ?? 0) + 1
+  }
 
   function handleAddPosition(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -23,6 +30,32 @@ export default function ManualInputPage() {
 
     setPositions(currentPositions => [...currentPositions, createManualPosition(draft)])
     setDraft(EMPTY_DRAFT)
+  }
+
+  function updatePositions(updater: (currentPositions: PortfolioPosition[]) => PortfolioPosition[]) {
+    setPositions(currentPositions => updater(currentPositions))
+  }
+
+  function handleDelete(id: string) {
+    updatePositions(currentPositions => currentPositions.filter(position => position.id !== id))
+  }
+
+  function handleAssetClassChange(id: string, assetClass: AssetClass) {
+    updatePositions(currentPositions =>
+      currentPositions.map(position => position.id === id ? { ...position, assetClass } : position)
+    )
+  }
+
+  function handleSectorChange(id: string, sector: string) {
+    updatePositions(currentPositions =>
+      currentPositions.map(position => position.id === id ? { ...position, sector } : position)
+    )
+  }
+
+  function handleFieldChange(id: string, field: 'value' | 'avgCost' | 'currentPrice', value: number) {
+    updatePositions(currentPositions =>
+      currentPositions.map(position => position.id === id ? { ...position, [field]: value } : position)
+    )
   }
 
   function handleStartDiagnosis() {
@@ -49,70 +82,134 @@ export default function ManualInputPage() {
       <main className={styles.content}>
         <section className={styles.hero}>
           <p className={styles.eyebrow}>직접 입력</p>
-          <h1 className={styles.title}>OCR 없이 종목을 직접 추가해 진단을 시작하세요.</h1>
-          <p className={styles.description}>종목명, 평가금액, 자산군만 입력하면 확인 화면으로 바로 이동합니다.</p>
+          <h1 className={styles.title}>OCR 없이 종목을 직접 추가해<br />진단을 시작하세요.</h1>
+          <p className={styles.description}>확인 화면과 같은 기준으로 금액, 자산군, 섹터를 맞춰 입력한 뒤 바로 진단을 시작할 수 있습니다.</p>
         </section>
 
         <section className={styles.section}>
           <form className={styles.formCard} onSubmit={handleAddPosition}>
-            <label className={styles.field}>
-              <span className={styles.label}>종목명</span>
-              <input
-                className={styles.input}
-                type="text"
-                value={draft.name}
-                onChange={event => setDraft(currentDraft => ({ ...currentDraft, name: event.target.value }))}
-                placeholder="예: 삼성전자"
-              />
-            </label>
-
-            <label className={styles.field}>
-              <span className={styles.label}>평가금액</span>
-              <div className={styles.moneyField}>
+            <div className={styles.formGrid}>
+              <label className={styles.field}>
+                <span className={styles.label}>종목명</span>
                 <input
                   className={styles.input}
-                  type="number"
-                  min="0"
-                  step="1"
-                  inputMode="numeric"
-                  value={draft.value}
+                  type="text"
+                  value={draft.name}
+                  onChange={event => setDraft(currentDraft => ({ ...currentDraft, name: event.target.value }))}
+                  placeholder="예: 삼성전자"
+                />
+              </label>
+
+              <label className={styles.field}>
+                <span className={styles.label}>종목코드</span>
+                <input
+                  className={styles.input}
+                  type="text"
+                  value={draft.code}
+                  onChange={event => setDraft(currentDraft => ({ ...currentDraft, code: event.target.value }))}
+                  placeholder="예: 005930 또는 AAPL"
+                />
+              </label>
+            </div>
+
+            <div className={styles.formGrid}>
+              <label className={styles.field}>
+                <span className={styles.label}>자산군</span>
+                <select
+                  className={styles.select}
+                  value={draft.assetClass}
                   onChange={event => setDraft(currentDraft => ({
                     ...currentDraft,
-                    value: event.target.value.replace(/\D/g, ''),
+                    assetClass: event.target.value as typeof currentDraft.assetClass,
                   }))}
-                  placeholder="0"
-                />
-                <span className={styles.moneyUnit}>원</span>
-              </div>
-            </label>
+                >
+                  <option value="">선택해주세요</option>
+                  {ASSET_CLASSES.map(assetClass => (
+                    <option key={assetClass} value={assetClass}>{assetClass}</option>
+                  ))}
+                </select>
+              </label>
 
-            <label className={styles.field}>
-              <span className={styles.label}>종목코드</span>
-              <input
-                className={styles.input}
-                type="text"
-                value={draft.code}
-                onChange={event => setDraft(currentDraft => ({ ...currentDraft, code: event.target.value }))}
-                placeholder="예: 005930 또는 AAPL"
-              />
-            </label>
+              <label className={styles.field}>
+                <span className={styles.label}>섹터</span>
+                <select
+                  className={styles.select}
+                  value={draft.sector}
+                  onChange={event => setDraft(currentDraft => ({ ...currentDraft, sector: event.target.value }))}
+                >
+                  <option value="">선택해주세요</option>
+                  {SECTOR_LABELS.map(sector => (
+                    <option key={sector} value={sector}>{sector}</option>
+                  ))}
+                </select>
+              </label>
+            </div>
 
-            <label className={styles.field}>
-              <span className={styles.label}>자산군</span>
-              <select
-                className={styles.select}
-                value={draft.assetClass}
-                onChange={event => setDraft(currentDraft => ({
-                  ...currentDraft,
-                  assetClass: event.target.value as typeof currentDraft.assetClass,
-                }))}
-              >
-                <option value="">선택해주세요</option>
-                {ASSET_CLASSES.map(assetClass => (
-                  <option key={assetClass} value={assetClass}>{assetClass}</option>
-                ))}
-              </select>
-            </label>
+            <div className={styles.formGridTriple}>
+              <label className={styles.field}>
+                <span className={styles.label}>보유금액</span>
+                <div className={styles.moneyField}>
+                  <input
+                    className={styles.input}
+                    type="number"
+                    min="0"
+                    step="1"
+                    inputMode="numeric"
+                    value={draft.value}
+                    onChange={event => setDraft(currentDraft => ({
+                      ...currentDraft,
+                      value: event.target.value.replace(/\D/g, ''),
+                    }))}
+                    placeholder="0"
+                  />
+                  <span className={styles.moneyUnit}>원</span>
+                </div>
+              </label>
+
+              <label className={styles.field}>
+                <span className={styles.label}>매입가</span>
+                <div className={styles.moneyField}>
+                  <input
+                    className={styles.input}
+                    type="number"
+                    min="0"
+                    step="1"
+                    inputMode="numeric"
+                    value={draft.avgCost}
+                    onChange={event => setDraft(currentDraft => ({
+                      ...currentDraft,
+                      avgCost: event.target.value.replace(/\D/g, ''),
+                    }))}
+                    placeholder="0"
+                  />
+                  <span className={styles.moneyUnit}>원</span>
+                </div>
+              </label>
+
+              <label className={styles.field}>
+                <span className={styles.label}>현재가</span>
+                <div className={styles.moneyField}>
+                  <input
+                    className={styles.input}
+                    type="number"
+                    min="0"
+                    step="1"
+                    inputMode="numeric"
+                    value={draft.currentPrice}
+                    onChange={event => setDraft(currentDraft => ({
+                      ...currentDraft,
+                      currentPrice: event.target.value.replace(/\D/g, ''),
+                    }))}
+                    placeholder="0"
+                  />
+                  <span className={styles.moneyUnit}>원</span>
+                </div>
+              </label>
+            </div>
+
+            <p className={styles.helperText}>
+              확인 화면과 같은 계산 기준을 쓰기 위해 보유금액, 매입가, 현재가, 자산군, 섹터를 모두 입력합니다.
+            </p>
 
             <button type="submit" className={`btn-primary ${styles.addButton}`} disabled={!canAdd}>
               종목 추가
@@ -129,29 +226,18 @@ export default function ManualInputPage() {
           {hasPositions ? (
             <div className={styles.positionList}>
               {positions.map(position => (
-                <article key={position.id} className={styles.positionCard}>
-                  <div className={styles.positionMain}>
-                    <div>
-                      <h3 className={styles.positionName}>{position.name}</h3>
-                      {position.code && <p className={styles.positionCode}>{position.code}</p>}
-                    </div>
-                    <p className={styles.positionValue}>{currencyFormatter.format(position.value)}원</p>
-                  </div>
-
-                  <div className={styles.positionFooter}>
-                    <span className={styles.assetBadge}>{position.assetClass}</span>
-                    <button
-                      type="button"
-                      className={styles.deleteButton}
-                      onClick={() => setPositions(currentPositions =>
-                        currentPositions.filter(currentPosition => currentPosition.id !== position.id)
-                      )}
-                      aria-label={`${position.name} 삭제`}
-                    >
-                      삭제
-                    </button>
-                  </div>
-                </article>
+                <div key={position.id} className={styles.positionCardWrap}>
+                  {position.code && <p className={styles.positionCodeMeta}>종목코드 {position.code}</p>}
+                  <ConfirmCard
+                    position={position}
+                    pct={totalValue > 0 ? Math.round((position.value / totalValue) * 1000) / 10 : 0}
+                    isDuplicate={(nameCounts[position.name] ?? 0) > 1}
+                    onDelete={handleDelete}
+                    onAssetClassChange={handleAssetClassChange}
+                    onSectorChange={handleSectorChange}
+                    onFieldChange={handleFieldChange}
+                  />
+                </div>
               ))}
             </div>
           ) : (

--- a/src/app/manual/page.tsx
+++ b/src/app/manual/page.tsx
@@ -1,0 +1,221 @@
+'use client'
+import { FormEvent, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { SESSION_KEYS } from '@/lib/types'
+import type { AssetClass, PortfolioPosition } from '@/lib/types'
+import styles from './page.module.css'
+
+const ASSET_CLASSES: AssetClass[] = ['국내주식', '해외주식', '채권', '기타']
+const currencyFormatter = new Intl.NumberFormat('ko-KR')
+
+export interface ManualPositionDraft {
+  assetClass: '' | AssetClass
+  code: string
+  name: string
+  value: string
+}
+
+const EMPTY_DRAFT: ManualPositionDraft = {
+  assetClass: '',
+  code: '',
+  name: '',
+  value: '',
+}
+
+function parseManualValue(value: string): number {
+  const digits = value.replace(/\D/g, '')
+  if (!digits) return 0
+
+  return Number(digits)
+}
+
+export function isManualDraftComplete(
+  draft: ManualPositionDraft
+): draft is ManualPositionDraft & { assetClass: AssetClass } {
+  return draft.name.trim().length > 0 && parseManualValue(draft.value) > 0 && draft.assetClass !== ''
+}
+
+export function createManualPosition(
+  draft: ManualPositionDraft & { assetClass: AssetClass }
+): PortfolioPosition {
+  const amount = parseManualValue(draft.value)
+  const code = draft.code.trim()
+
+  return {
+    id: crypto.randomUUID(),
+    name: draft.name.trim(),
+    code: code || null,
+    qty: 1,
+    value: amount,
+    avgCost: amount,
+    currentPrice: amount,
+    assetClass: draft.assetClass,
+    sector: draft.assetClass,
+    sourceImage: 1,
+  }
+}
+
+export default function ManualInputPage() {
+  const router = useRouter()
+  const [draft, setDraft] = useState<ManualPositionDraft>(EMPTY_DRAFT)
+  const [positions, setPositions] = useState<PortfolioPosition[]>([])
+
+  const canAdd = isManualDraftComplete(draft)
+  const hasPositions = positions.length > 0
+
+  function handleAddPosition(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!isManualDraftComplete(draft)) return
+
+    setPositions(currentPositions => [...currentPositions, createManualPosition(draft)])
+    setDraft(EMPTY_DRAFT)
+  }
+
+  function handleStartDiagnosis() {
+    if (!hasPositions) return
+
+    sessionStorage.setItem(SESSION_KEYS.RAW_POSITIONS, JSON.stringify(positions))
+    router.push('/confirm')
+  }
+
+  return (
+    <div className={styles.wrap}>
+      <nav className={styles.nav}>
+        <button
+          type="button"
+          className={styles.backButton}
+          onClick={() => router.back()}
+          aria-label="뒤로가기"
+        >
+          ←
+        </button>
+        <span className={styles.brand}>Dr.Folio</span>
+      </nav>
+
+      <main className={styles.content}>
+        <section className={styles.hero}>
+          <p className={styles.eyebrow}>직접 입력</p>
+          <h1 className={styles.title}>OCR 없이 종목을 직접 추가해 진단을 시작하세요.</h1>
+          <p className={styles.description}>종목명, 평가금액, 자산군만 입력하면 확인 화면으로 바로 이동합니다.</p>
+        </section>
+
+        <section className={styles.section}>
+          <form className={styles.formCard} onSubmit={handleAddPosition}>
+            <label className={styles.field}>
+              <span className={styles.label}>종목명</span>
+              <input
+                className={styles.input}
+                type="text"
+                value={draft.name}
+                onChange={event => setDraft(currentDraft => ({ ...currentDraft, name: event.target.value }))}
+                placeholder="예: 삼성전자"
+              />
+            </label>
+
+            <label className={styles.field}>
+              <span className={styles.label}>평가금액</span>
+              <div className={styles.moneyField}>
+                <input
+                  className={styles.input}
+                  type="number"
+                  min="0"
+                  step="1"
+                  inputMode="numeric"
+                  value={draft.value}
+                  onChange={event => setDraft(currentDraft => ({
+                    ...currentDraft,
+                    value: event.target.value.replace(/\D/g, ''),
+                  }))}
+                  placeholder="0"
+                />
+                <span className={styles.moneyUnit}>원</span>
+              </div>
+            </label>
+
+            <label className={styles.field}>
+              <span className={styles.label}>종목코드</span>
+              <input
+                className={styles.input}
+                type="text"
+                value={draft.code}
+                onChange={event => setDraft(currentDraft => ({ ...currentDraft, code: event.target.value }))}
+                placeholder="예: 005930 또는 AAPL"
+              />
+            </label>
+
+            <label className={styles.field}>
+              <span className={styles.label}>자산군</span>
+              <select
+                className={styles.select}
+                value={draft.assetClass}
+                onChange={event => setDraft(currentDraft => ({
+                  ...currentDraft,
+                  assetClass: event.target.value as ManualPositionDraft['assetClass'],
+                }))}
+              >
+                <option value="">선택해주세요</option>
+                {ASSET_CLASSES.map(assetClass => (
+                  <option key={assetClass} value={assetClass}>{assetClass}</option>
+                ))}
+              </select>
+            </label>
+
+            <button type="submit" className={`btn-primary ${styles.addButton}`} disabled={!canAdd}>
+              종목 추가
+            </button>
+          </form>
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <h2 className={styles.sectionTitle}>추가한 종목</h2>
+            <span className={styles.sectionMeta}>{positions.length}개</span>
+          </div>
+
+          {hasPositions ? (
+            <div className={styles.positionList}>
+              {positions.map(position => (
+                <article key={position.id} className={styles.positionCard}>
+                  <div className={styles.positionMain}>
+                    <div>
+                      <h3 className={styles.positionName}>{position.name}</h3>
+                      {position.code && <p className={styles.positionCode}>{position.code}</p>}
+                    </div>
+                    <p className={styles.positionValue}>{currencyFormatter.format(position.value)}원</p>
+                  </div>
+
+                  <div className={styles.positionFooter}>
+                    <span className={styles.assetBadge}>{position.assetClass}</span>
+                    <button
+                      type="button"
+                      className={styles.deleteButton}
+                      onClick={() => setPositions(currentPositions =>
+                        currentPositions.filter(currentPosition => currentPosition.id !== position.id)
+                      )}
+                      aria-label={`${position.name} 삭제`}
+                    >
+                      삭제
+                    </button>
+                  </div>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <div className={styles.emptyState}>아직 종목이 없습니다. 위 폼에서 추가해주세요.</div>
+          )}
+        </section>
+      </main>
+
+      <div className="fixed-cta">
+        <button
+          type="button"
+          className={`btn-primary ${styles.ctaButton}`}
+          onClick={handleStartDiagnosis}
+          disabled={!hasPositions}
+        >
+          진단 시작
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 // src/app/page.tsx
 'use client'
+import Link from 'next/link'
 import { useState, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { SESSION_KEYS } from '@/lib/types'
@@ -144,7 +145,7 @@ export default function UploadPage() {
 
         {error && <p className={styles.error}>⚠️ {error} — <a href="#" onClick={() => setError(null)}>다시 시도</a></p>}
 
-        <p className={styles.manual}>또는 <a href="#">종목을 직접 입력하기</a></p>
+        <p className={styles.manual}>또는 <Link href="/manual">종목을 직접 입력하기</Link></p>
       </div>
     </div>
   )


### PR DESCRIPTION
## What changed
- add the `/manual` portfolio entry flow and connect the landing-page manual-entry link
- fix the Next App Router page-export issue by moving manual helpers out of `app/manual/page.tsx`
- strengthen `verify` so it runs `next build` before typecheck/lint/tests
- align manual entry with confirm editing fields by collecting asset class, sector, value, avg cost, and current price up front
- remove the manual stock-code input, tighten spacing, and enlarge the header branding/logo

## Why
The previous work was pushed onto a branch that had already been merged, so a new reviewable PR was not visible. This branch carries the current manual-entry work on a fresh PR head.

## Impact
- users can start diagnosis without OCR through a manual-entry route
- build-only App Router regressions are caught during local verification instead of first surfacing on Vercel
- the manual-entry screen now better matches the confirm-page editing model and visual polish

## Root cause
Two separate issues were addressed in this series:
1. `src/app/manual/page.tsx` exposed named exports that Next App Router rejects during production build validation.
2. The subsequent follow-up work was pushed to a branch whose previous PR had already been merged, so GitHub did not surface a new PR automatically.

## Validation
- `bun run build`
- `COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm@9.15.4 verify`