### PR TITLE
feat: 종목 시그널 분석 화면 추가 (RSI·MACD·내부자매매·Fear&Greed)

### DIFF
--- a/src/app/api/signals/route.ts
+++ b/src/app/api/signals/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { fetchTradingSignal, type TradingMarket } from '@/lib/tradingSignals'
+
+const CACHE_HEADERS = {
+  'Cache-Control': 'public, max-age=0, s-maxage=86400, stale-while-revalidate=86400',
+  'CDN-Cache-Control': 'max-age=86400',
+  'Vercel-CDN-Cache-Control': 'max-age=86400',
+}
+
+export async function GET(request: NextRequest) {
+  const ticker = request.nextUrl.searchParams.get('ticker')?.trim().toUpperCase() ?? ''
+  const marketParam = request.nextUrl.searchParams.get('market')?.trim().toUpperCase() ?? ''
+
+  if (!ticker) {
+    return NextResponse.json(
+      { error: 'ticker 쿼리 파라미터가 필요합니다.' },
+      { status: 400, headers: CACHE_HEADERS },
+    )
+  }
+
+  if (!isTradingMarket(marketParam)) {
+    return NextResponse.json(
+      { error: 'market은 US 또는 KR 이어야 합니다.' },
+      { status: 400, headers: CACHE_HEADERS },
+    )
+  }
+
+  if ((marketParam === 'KR' && !/^\d{6}$/.test(ticker)) || (marketParam === 'US' && !/^[A-Z.-]{1,10}$/.test(ticker))) {
+    return NextResponse.json(
+      { error: 'ticker 형식이 market과 맞지 않습니다.' },
+      { status: 400, headers: CACHE_HEADERS },
+    )
+  }
+
+  try {
+    const signal = await fetchTradingSignal(ticker, marketParam)
+    return NextResponse.json(signal, { headers: CACHE_HEADERS })
+  } catch (error) {
+    console.error('signals route failed', error)
+    return NextResponse.json(
+      { error: '시그널 데이터를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.' },
+      { status: 502, headers: CACHE_HEADERS },
+    )
+  }
+}
+
+function isTradingMarket(value: string): value is TradingMarket {
+  return value === 'US' || value === 'KR'
+}

--- a/src/app/diagnosis/page.module.css
+++ b/src/app/diagnosis/page.module.css
@@ -141,6 +141,46 @@
   flex-shrink: 0;
 }
 
+.signalBtn {
+  width: 100%;
+  background: linear-gradient(135deg, rgba(5, 150, 105, 0.12), rgba(5, 150, 105, 0.03));
+  border: 1px solid rgba(5, 150, 105, 0.18);
+  border-radius: var(--radius-card);
+  padding: 16px 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  text-align: left;
+}
+
+.signalBtnText {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.signalBtnTitle {
+  font-size: 14px;
+  font-weight: 800;
+  color: #065f46;
+}
+
+.signalBtnMeta {
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(6, 95, 70, 0.8);
+  line-height: 1.45;
+}
+
+.signalBtnArrow {
+  font-size: 16px;
+  font-weight: 800;
+  color: #047857;
+  flex-shrink: 0;
+}
+
 .explainBtn {
   width: 100%;
   background: var(--surface);

--- a/src/app/diagnosis/page.tsx
+++ b/src/app/diagnosis/page.tsx
@@ -1,6 +1,6 @@
 // src/app/diagnosis/page.tsx
 'use client'
-import { useState, useEffect } from 'react'
+import { useEffect, useMemo, useState, useSyncExternalStore } from 'react'
 import { useRouter } from 'next/navigation'
 import { ProblemCard } from '@/components/ProblemCard'
 import { AllocationBar } from '@/components/AllocationBar'
@@ -13,6 +13,7 @@ import { inferStyleKey } from '@/lib/investorProfile'
 import { getTargetAllocationErrorMessage } from '@/lib/targetAllocation'
 import { inferMbtiType, MBTI_PROFILES } from '@/lib/mbti'
 import { buildSectorAllocation } from '@/lib/sectorAllocation'
+import { prefetchTradingSignals } from '@/lib/tradingSignalsClient'
 import { SESSION_KEYS } from '@/lib/types'
 import type {
   DiagnosisResult,
@@ -34,6 +35,31 @@ function readConfirmedPositions(): PortfolioPosition[] {
     return JSON.parse(raw) as PortfolioPosition[]
   } catch {
     return []
+  }
+}
+
+function subscribeToClientReady() {
+  return () => {}
+}
+
+function getClientReadySnapshot() {
+  return true
+}
+
+function getServerReadySnapshot() {
+  return false
+}
+
+function readStoredDiagnosis(): DiagnosisResult | null {
+  if (typeof window === 'undefined') return null
+
+  const raw = sessionStorage.getItem(SESSION_KEYS.DIAGNOSIS)
+  if (!raw) return null
+
+  try {
+    return JSON.parse(raw) as DiagnosisResult
+  } catch {
+    return null
   }
 }
 
@@ -59,9 +85,14 @@ function readDesiredStyle(positions: PortfolioPosition[]): StyleKey {
 
 export default function DiagnosisPage() {
   const router = useRouter()
-  const [diagnosis, setDiagnosis] = useState<DiagnosisResult | null>(null)
-  const [positions] = useState<PortfolioPosition[]>(() => readConfirmedPositions())
-  const [desiredStyle] = useState<StyleKey>(() => readDesiredStyle(positions))
+  const isClient = useSyncExternalStore(
+    subscribeToClientReady,
+    getClientReadySnapshot,
+    getServerReadySnapshot,
+  )
+  const diagnosis = useMemo(() => (isClient ? readStoredDiagnosis() : null), [isClient])
+  const positions = useMemo(() => (isClient ? readConfirmedPositions() : []), [isClient])
+  const desiredStyle = useMemo(() => readDesiredStyle(positions), [positions])
   const [copied, setCopied] = useState(false)
   const [explainOpen, setExplainOpen] = useState(false)
   const [explanation, setExplanation] = useState<string | null>(null)
@@ -70,14 +101,18 @@ export default function DiagnosisPage() {
   const [sheetOpen, setSheetOpen] = useState(false)
 
   useEffect(() => {
-    const raw = sessionStorage.getItem(SESSION_KEYS.DIAGNOSIS)
-    if (!raw) { router.replace('/'); return }
-    try {
-      setDiagnosis(JSON.parse(raw) as DiagnosisResult)
-    } catch {
-      router.replace('/')
-    }
-  }, [router])
+    if (isClient && !diagnosis) router.replace('/')
+  }, [diagnosis, isClient, router])
+
+  useEffect(() => {
+    if (!isClient) return
+    router.prefetch('/signals')
+    if (positions.length === 0) return
+
+    void prefetchTradingSignals(positions).catch(() => {
+      // signals page에서 다시 로드하므로 background warmup 실패는 무시한다.
+    })
+  }, [isClient, positions, router])
 
   async function toggleExplain() {
     if (explainOpen) { setExplainOpen(false); return }
@@ -116,7 +151,7 @@ export default function DiagnosisPage() {
     }
   }
 
-  if (!diagnosis) return null
+  if (!isClient || !diagnosis) return null
 
   const today = new Date().toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' })
   const isHealthy = diagnosis.problems.length === 0
@@ -179,6 +214,16 @@ export default function DiagnosisPage() {
               </span>
             </div>
             <span className={styles.improvementBtnArrow} aria-hidden="true">→</span>
+          </button>
+
+          <button className={styles.signalBtn} onClick={() => router.push('/signals')}>
+            <div className={styles.signalBtnText}>
+              <span className={styles.signalBtnTitle}>종목 시그널 분석 보기</span>
+              <span className={styles.signalBtnMeta}>
+                각 종목별 RSI, MACD, 거래량, 52주 위치를 카드로 정리했어요
+              </span>
+            </div>
+            <span className={styles.signalBtnArrow} aria-hidden="true">↗</span>
           </button>
         </section>
 

--- a/src/app/signals/page.module.css
+++ b/src/app/signals/page.module.css
@@ -1,0 +1,127 @@
+.wrap {
+  min-height: 100dvh;
+  background:
+    radial-gradient(circle at top right, rgba(255, 255, 255, 0.22), transparent 32%),
+    linear-gradient(180deg, var(--navy) 0 240px, var(--bg) 240px 100%);
+}
+
+.header {
+  padding: 24px 20px 28px;
+  color: #fff;
+}
+
+.eyebrow {
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.64);
+}
+
+.title {
+  margin-top: 10px;
+  font-size: 31px;
+  line-height: 1.12;
+  letter-spacing: -0.05em;
+}
+
+.sub {
+  margin-top: 12px;
+  max-width: 560px;
+  font-size: 14px;
+  line-height: 1.7;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.metaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.metaBadge,
+.metaHint {
+  border-radius: 999px;
+  padding: 9px 12px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.metaBadge {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.metaHint {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.body {
+  padding: 0 16px 40px;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: -8px;
+  margin-bottom: 16px;
+}
+
+.primaryButton,
+.secondaryButton,
+.inlineRetry {
+  border-radius: var(--radius-btn);
+  padding: 12px 16px;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.primaryButton {
+  background: var(--navy);
+  color: #fff;
+  border: none;
+}
+
+.secondaryButton {
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--navy);
+  border: 1px solid rgba(26, 35, 126, 0.12);
+}
+
+.cardList {
+  display: grid;
+  gap: 14px;
+}
+
+.stateCard {
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 18px;
+  margin-bottom: 16px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-2);
+}
+
+.inlineRetry {
+  margin-top: 12px;
+  background: var(--surface);
+  color: var(--navy);
+  border: 1px solid rgba(26, 35, 126, 0.14);
+}
+
+@media (min-width: 768px) {
+  .body {
+    max-width: 920px;
+    margin: 0 auto;
+    padding: 0 24px 56px;
+  }
+
+  .cardList {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+}

--- a/src/app/signals/page.tsx
+++ b/src/app/signals/page.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import { useEffect, useMemo, useState, useSyncExternalStore } from 'react'
+import { useRouter } from 'next/navigation'
+import { SignalCard } from '@/components/SignalCard'
+import { listSignalTargets, loadTradingSignals } from '@/lib/tradingSignalsClient'
+import { SESSION_KEYS, type PortfolioPosition } from '@/lib/types'
+import type { TradingSignal } from '@/lib/tradingSignals'
+import styles from './page.module.css'
+
+function readConfirmedPositions(): PortfolioPosition[] {
+  if (typeof window === 'undefined') return []
+
+  const raw = sessionStorage.getItem(SESSION_KEYS.CONFIRMED)
+  if (!raw) return []
+
+  try {
+    return JSON.parse(raw) as PortfolioPosition[]
+  } catch {
+    return []
+  }
+}
+
+function subscribeToClientReady() {
+  return () => {}
+}
+
+function getClientReadySnapshot() {
+  return true
+}
+
+function getServerReadySnapshot() {
+  return false
+}
+
+export default function SignalsPage() {
+  const router = useRouter()
+  const isClient = useSyncExternalStore(
+    subscribeToClientReady,
+    getClientReadySnapshot,
+    getServerReadySnapshot,
+  )
+  const positions = useMemo(() => (isClient ? readConfirmedPositions() : []), [isClient])
+  const [signals, setSignals] = useState<TradingSignal[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const supportedCount = useMemo(() => listSignalTargets(positions).length, [positions])
+  const unsupportedCount = Math.max(
+    positions.filter(position => position.assetClass === '국내주식' || position.assetClass === '해외주식').length - supportedCount,
+    0,
+  )
+
+  async function handleRefresh() {
+    setLoading(true)
+    setError(null)
+
+    try {
+      setSignals(await loadTradingSignals(positions))
+    } catch {
+      setError('종목 시그널을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (!isClient) return
+    if (positions.length === 0) {
+      router.replace('/')
+      return
+    }
+  }, [isClient, positions.length, router])
+
+  useEffect(() => {
+    if (!isClient || positions.length === 0) return
+
+    let active = true
+
+    async function hydrateSignals() {
+      try {
+        const nextSignals = await loadTradingSignals(positions)
+        if (active) setSignals(nextSignals)
+      } catch {
+        if (active) setError('종목 시그널을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.')
+      } finally {
+        if (active) setLoading(false)
+      }
+    }
+
+    void hydrateSignals()
+
+    return () => {
+      active = false
+    }
+  }, [isClient, positions])
+
+  if (!isClient) return null
+
+  return (
+    <div className={styles.wrap}>
+      <div className={styles.header}>
+        <div className={styles.eyebrow}>종목 시그널 분석</div>
+        <h1 className={styles.title}>각 종목이 지금 보내는 신호를 한 번에 확인해보세요.</h1>
+        <p className={styles.sub}>
+          RSI, MACD, 거래량, 52주 위치, 6개월 평균, 내부자 매매, Fear&Greed를 한 카드에 묶어 보여드려요.
+        </p>
+        <div className={styles.metaRow}>
+          <span className={styles.metaBadge}>분석 가능 {supportedCount}종목</span>
+          {unsupportedCount > 0 && <span className={styles.metaHint}>코드 없는 {unsupportedCount}종목은 제외됐어요.</span>}
+        </div>
+      </div>
+
+      <div className={styles.body}>
+        <div className={styles.actions}>
+          <button className={styles.secondaryButton} onClick={() => router.push('/diagnosis')}>
+            ← 진단 결과로 돌아가기
+          </button>
+          <button className={styles.primaryButton} onClick={() => void handleRefresh()}>
+            최신 신호 다시 보기
+          </button>
+        </div>
+
+        {loading && <div className={styles.stateCard}>종목별 시그널을 계산하고 있습니다…</div>}
+
+        {error && (
+          <div className={styles.stateCard}>
+            <p>{error}</p>
+            <button className={styles.inlineRetry} onClick={() => void handleRefresh()}>
+              페이지 다시 불러오기
+            </button>
+          </div>
+        )}
+
+        {!loading && !error && signals.length === 0 && (
+          <div className={styles.stateCard}>
+            현재 포트폴리오에서 시그널을 계산할 수 있는 주식 코드가 없습니다.
+          </div>
+        )}
+
+        <div className={styles.cardList}>
+          {signals.map(signal => (
+            <SignalCard key={`${signal.market}:${signal.ticker}`} signal={signal} />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/SignalCard.module.css
+++ b/src/components/SignalCard.module.css
@@ -1,0 +1,117 @@
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 18px;
+  box-shadow: 0 12px 24px rgba(18, 24, 88, 0.05);
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.marketRow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.market,
+.ticker {
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+
+.name {
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: var(--text-1);
+}
+
+.badge {
+  flex-shrink: 0;
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.badge_buy {
+  background: var(--green-bg);
+  color: var(--green);
+}
+
+.badge_neutral {
+  background: var(--amber-bg);
+  color: var(--amber);
+}
+
+.badge_sell {
+  background: var(--red-bg);
+  color: var(--red);
+}
+
+.headline {
+  margin-top: 14px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-2);
+}
+
+.metricList {
+  display: grid;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.metric {
+  background: linear-gradient(180deg, rgba(232, 234, 246, 0.65), rgba(244, 246, 255, 0.3));
+  border: 1px solid rgba(26, 35, 126, 0.08);
+  border-radius: 14px;
+  padding: 14px;
+}
+
+.metricTop {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.metricLabel {
+  font-size: 13px;
+  font-weight: 800;
+  color: var(--navy);
+}
+
+.metricSignal {
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.metricSignal_buy {
+  color: var(--green);
+}
+
+.metricSignal_neutral {
+  color: var(--amber);
+}
+
+.metricSignal_sell {
+  color: var(--red);
+}
+
+.metricSummary {
+  margin-top: 8px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text-2);
+}

--- a/src/components/SignalCard.tsx
+++ b/src/components/SignalCard.tsx
@@ -1,0 +1,47 @@
+import type { TradingRecommendation, TradingSignal } from '@/lib/tradingSignals'
+import styles from './SignalCard.module.css'
+
+interface SignalCardProps {
+  signal: TradingSignal
+}
+
+const RECOMMENDATION_LABEL: Record<TradingRecommendation, string> = {
+  buy: '매수 관점',
+  neutral: '중립',
+  sell: '매도 관점',
+}
+
+export function SignalCard({ signal }: SignalCardProps) {
+  return (
+    <article className={styles.card}>
+      <div className={styles.header}>
+        <div>
+          <div className={styles.marketRow}>
+            <span className={styles.market}>{signal.market}</span>
+            <span className={styles.ticker}>{signal.ticker}</span>
+          </div>
+          <h2 className={styles.name}>{signal.companyName}</h2>
+        </div>
+        <span className={`${styles.badge} ${styles[`badge_${signal.recommendation}`]}`}>
+          {RECOMMENDATION_LABEL[signal.recommendation]}
+        </span>
+      </div>
+
+      <p className={styles.headline}>{signal.headline}</p>
+
+      <div className={styles.metricList}>
+        {signal.metrics.map(metric => (
+          <section key={metric.key} className={styles.metric}>
+            <div className={styles.metricTop}>
+              <span className={styles.metricLabel}>{metric.label}</span>
+              <span className={`${styles.metricSignal} ${styles[`metricSignal_${metric.signal}`]}`}>
+                {metric.value}
+              </span>
+            </div>
+            <p className={styles.metricSummary}>{metric.summary}</p>
+          </section>
+        ))}
+      </div>
+    </article>
+  )
+}

--- a/src/lib/tradingSignals.test.ts
+++ b/src/lib/tradingSignals.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildTradingSignal,
+  calculateMacdState,
+  calculateRsi,
+  parseOpenInsiderActivity,
+  resolveTradingSignalTarget,
+} from './tradingSignals'
+import type { PortfolioPosition } from './types'
+
+function makePosition(overrides: Partial<PortfolioPosition>): PortfolioPosition {
+  return {
+    id: 'position-1',
+    name: '테스트 종목',
+    code: 'AAPL',
+    qty: 3,
+    value: 300_000,
+    avgCost: 100_000,
+    currentPrice: 100_000,
+    assetClass: '해외주식',
+    sector: '하드웨어',
+    sourceImage: 1,
+    ...overrides,
+  }
+}
+
+describe('resolveTradingSignalTarget', () => {
+  it('해외주식은 US 티커로 변환한다', () => {
+    expect(resolveTradingSignalTarget(makePosition({ code: 'msft' }))).toEqual({
+      market: 'US',
+      name: '테스트 종목',
+      ticker: 'MSFT',
+    })
+  })
+
+  it('국내주식은 KR 티커로 변환한다', () => {
+    expect(resolveTradingSignalTarget(makePosition({
+      assetClass: '국내주식',
+      code: '005930',
+      name: '삼성전자',
+    }))).toEqual({
+      market: 'KR',
+      name: '삼성전자',
+      ticker: '005930',
+    })
+  })
+
+  it('코드가 없거나 주식이 아니면 null을 반환한다', () => {
+    expect(resolveTradingSignalTarget(makePosition({ code: null }))).toBeNull()
+    expect(resolveTradingSignalTarget(makePosition({ assetClass: '채권', code: 'IEF' }))).toBeNull()
+  })
+})
+
+describe('calculateRsi', () => {
+  it('상승 추세는 높은 RSI를 반환한다', () => {
+    const closes = Array.from({ length: 20 }, (_, index) => 100 + index * 2)
+    expect(calculateRsi(closes)).toBeGreaterThan(70)
+  })
+
+  it('하락 추세는 낮은 RSI를 반환한다', () => {
+    const closes = Array.from({ length: 20 }, (_, index) => 100 - index * 2)
+    expect(calculateRsi(closes)).toBeLessThan(30)
+  })
+})
+
+describe('calculateMacdState', () => {
+  it('상승 추세면 MACD histogram이 양수다', () => {
+    const closes = Array.from({ length: 60 }, (_, index) => 100 + index * 1.5)
+    expect(calculateMacdState(closes).histogram).toBeGreaterThan(0)
+  })
+
+  it('하락 추세면 MACD histogram이 음수다', () => {
+    const closes = Array.from({ length: 60 }, (_, index) => 200 - index * 1.5)
+    expect(calculateMacdState(closes).histogram).toBeLessThan(0)
+  })
+})
+
+describe('parseOpenInsiderActivity', () => {
+  it('최근 매수/매도 건수와 순매매 금액을 요약한다', () => {
+    const html = `
+      <tr style="background:#efffef"><td>P</td><td align=right><div>2026-04-10</div></td><td><b>AAPL</b></td><td>CEO</td><td>P - Purchase</td><td align=right>$182.10</td><td align=right>1,000</td><td align=right>20,000</td><td align=right>5%</td><td align=right>$182,100</td></tr>
+      <tr style="background:#ffefef"><td>S</td><td align=right><div>2026-04-11</div></td><td><b>AAPL</b></td><td>CFO</td><td>S - Sale</td><td align=right>$183.00</td><td align=right>-500</td><td align=right>10,000</td><td align=right>-2%</td><td align=right>-$91,500</td></tr>
+    `
+
+    expect(parseOpenInsiderActivity(html)).toEqual({
+      buyCount: 1,
+      netValue: 90_600,
+      sellCount: 1,
+    })
+  })
+})
+
+describe('buildTradingSignal', () => {
+  it('과매도 + 바닥권 조합이면 매수 추천을 준다', () => {
+    const signal = buildTradingSignal({
+      companyName: 'Apple',
+      currentPrice: 92,
+      fearGreed: { label: 'Fear', score: 25 },
+      insiderActivity: { buyCount: 2, netValue: 3_000_000, sellCount: 0 },
+      market: 'US',
+      marketSymbol: 'AAPL',
+      priceHistory: Array.from({ length: 260 }, (_, index) => ({
+        close: 150 - index * 0.22,
+        volume: 100_000 + index * 100,
+      })).reverse(),
+      ticker: 'AAPL',
+      week52High: 180,
+      week52Low: 88,
+    })
+
+    expect(signal.metrics).toHaveLength(7)
+    expect(signal.recommendation).toBe('buy')
+    expect(signal.metrics[0].summary).toContain('RSI')
+    expect(signal.metrics[6].label).toBe('Fear&Greed')
+  })
+
+  it('과열 지표가 많으면 매도 추천을 준다', () => {
+    const signal = buildTradingSignal({
+      companyName: 'Samsung Electronics',
+      currentPrice: 220,
+      fearGreed: { label: 'Greed', score: 78 },
+      insiderActivity: { buyCount: 0, netValue: -5_000_000, sellCount: 3 },
+      market: 'KR',
+      marketSymbol: '005930.KS',
+      priceHistory: Array.from({ length: 260 }, (_, index) => ({
+        close: 100 + index * 0.5,
+        volume: 100_000 + index * 50,
+      })),
+      ticker: '005930',
+      week52High: 225,
+      week52Low: 95,
+    })
+
+    expect(signal.recommendation).toBe('sell')
+    expect(signal.metrics.some(metric => metric.signal === 'sell')).toBe(true)
+  })
+})

--- a/src/lib/tradingSignals.ts
+++ b/src/lib/tradingSignals.ts
@@ -1,0 +1,638 @@
+import type { PortfolioPosition } from './types'
+
+export type TradingMarket = 'US' | 'KR'
+export type TradingRecommendation = 'buy' | 'neutral' | 'sell'
+
+export interface TradingSignalTarget {
+  market: TradingMarket
+  name: string
+  ticker: string
+}
+
+export interface PriceHistoryPoint {
+  close: number
+  volume: number
+}
+
+export interface FearGreedSnapshot {
+  label: string
+  score: number
+}
+
+export interface InsiderActivitySummary {
+  buyCount: number
+  netValue: number
+  sellCount: number
+}
+
+export interface TradingSignalMetric {
+  key: 'rsi' | 'macd' | 'volume' | 'fiftyTwoWeek' | 'sixMonthAverage' | 'insider' | 'fearGreed'
+  label: string
+  signal: TradingRecommendation
+  summary: string
+  value: string
+}
+
+export interface TradingSignal {
+  companyName: string
+  fetchedAt: string
+  headline: string
+  market: TradingMarket
+  marketSymbol: string
+  metrics: TradingSignalMetric[]
+  recommendation: TradingRecommendation
+  score: number
+  ticker: string
+}
+
+export interface BuildTradingSignalInput {
+  companyName: string
+  currentPrice: number
+  fearGreed: FearGreedSnapshot
+  insiderActivity: InsiderActivitySummary
+  market: TradingMarket
+  marketSymbol: string
+  priceHistory: PriceHistoryPoint[]
+  ticker: string
+  week52High: number
+  week52Low: number
+}
+
+export interface YahooSnapshot {
+  companyName: string
+  currentPrice: number
+  marketSymbol: string
+  priceHistory: PriceHistoryPoint[]
+  week52High: number
+  week52Low: number
+}
+
+type YahooChartResponse = {
+  chart?: {
+    error?: { code?: string; description?: string } | null
+    result?: Array<{
+      indicators?: {
+        quote?: Array<{
+          close?: Array<number | null>
+          volume?: Array<number | null>
+        }>
+      }
+      meta?: {
+        fiftyTwoWeekHigh?: number
+        fiftyTwoWeekLow?: number
+        longName?: string
+        regularMarketPrice?: number
+        shortName?: string
+        symbol?: string
+      }
+    }>
+  }
+}
+
+const DAY_IN_SECONDS = 86_400
+const YAHOO_HEADERS = {
+  Accept: 'application/json',
+  'User-Agent': 'Mozilla/5.0 (compatible; DrFolio/1.0; +https://vercel.app)',
+}
+
+const SEC_HEADERS = {
+  Accept: 'application/atom+xml, text/html;q=0.9, application/xhtml+xml;q=0.8, */*;q=0.5',
+  'User-Agent': 'portfolio-doctor/1.0 help@example.com',
+}
+
+export const SIGNAL_CACHE_SECONDS = DAY_IN_SECONDS
+
+export function resolveTradingSignalTarget(position: PortfolioPosition): TradingSignalTarget | null {
+  if ((position.assetClass !== '국내주식' && position.assetClass !== '해외주식') || !position.code) {
+    return null
+  }
+
+  const code = position.code.trim()
+  if (!code) return null
+
+  if (position.assetClass === '국내주식') {
+    return /^\d{6}$/.test(code)
+      ? { ticker: code, market: 'KR', name: position.name }
+      : null
+  }
+
+  const normalized = code.toUpperCase()
+  return /^[A-Z.-]{1,10}$/.test(normalized)
+    ? { ticker: normalized, market: 'US', name: position.name }
+    : null
+}
+
+export function calculateRsi(closes: number[], period = 14): number {
+  if (closes.length <= period) return 50
+
+  let gainSum = 0
+  let lossSum = 0
+
+  for (let index = 1; index <= period; index += 1) {
+    const diff = closes[index] - closes[index - 1]
+    if (diff >= 0) gainSum += diff
+    else lossSum += Math.abs(diff)
+  }
+
+  let averageGain = gainSum / period
+  let averageLoss = lossSum / period
+
+  for (let index = period + 1; index < closes.length; index += 1) {
+    const diff = closes[index] - closes[index - 1]
+    const gain = diff > 0 ? diff : 0
+    const loss = diff < 0 ? Math.abs(diff) : 0
+
+    averageGain = ((averageGain * (period - 1)) + gain) / period
+    averageLoss = ((averageLoss * (period - 1)) + loss) / period
+  }
+
+  if (averageLoss === 0) return 100
+
+  const relativeStrength = averageGain / averageLoss
+  return 100 - (100 / (1 + relativeStrength))
+}
+
+export function calculateMacdState(closes: number[]): { histogram: number; macd: number; signal: number } {
+  if (closes.length < 35) {
+    return { histogram: 0, macd: 0, signal: 0 }
+  }
+
+  const ema12 = calculateExponentialMovingAverage(closes, 12)
+  const ema26 = calculateExponentialMovingAverage(closes, 26)
+  const macdSeries = ema12.map((value, index) => value - ema26[index])
+  const signalSeries = calculateExponentialMovingAverage(macdSeries, 9)
+  const macd = macdSeries[macdSeries.length - 1]
+  const signal = signalSeries[signalSeries.length - 1]
+
+  return {
+    histogram: macd - signal,
+    macd,
+    signal,
+  }
+}
+
+export function parseOpenInsiderActivity(html: string): InsiderActivitySummary {
+  const rows = html.match(/<tr[\s\S]*?<\/tr>/gi) ?? []
+  let buyCount = 0
+  let sellCount = 0
+  let netValue = 0
+
+  for (const row of rows) {
+    const cells = Array.from(row.matchAll(/<td[^>]*>([\s\S]*?)<\/td>/gi)).map(match => stripHtml(match[1]))
+    const transactionCell = cells.find(cell => /^[PS]\s+-/i.test(cell))
+    if (!transactionCell) continue
+
+    const valueCell = [...cells].reverse().find(cell => /\$-?[\d,]+/.test(cell))
+    const value = valueCell ? parseMoney(valueCell) : 0
+
+    if (/^P\s+-/i.test(transactionCell)) {
+      buyCount += 1
+      netValue += Math.abs(value)
+    } else if (/^S\s+-/i.test(transactionCell)) {
+      sellCount += 1
+      netValue -= Math.abs(value)
+    }
+  }
+
+  return { buyCount, sellCount, netValue }
+}
+
+export function buildTradingSignal(input: BuildTradingSignalInput): TradingSignal {
+  const closes = input.priceHistory.map(point => point.close)
+  const volumes = input.priceHistory.map(point => point.volume)
+  const currentPrice = input.currentPrice || closes[closes.length - 1] || 0
+  const rsi = calculateRsi(closes)
+  const macdState = calculateMacdState(closes)
+  const averageVolume20 = average(volumes.slice(-20))
+  const latestVolume = volumes[volumes.length - 1] ?? 0
+  const latestClose = closes[closes.length - 1] ?? currentPrice
+  const previousClose = closes[closes.length - 2] ?? latestClose
+  const volumeRatio = averageVolume20 > 0 ? latestVolume / averageVolume20 : 1
+  const week52Band = input.week52High > input.week52Low
+    ? ((currentPrice - input.week52Low) / (input.week52High - input.week52Low))
+    : 0.5
+  const average6Month = average(closes.slice(-126))
+  const diffFromAverage6Month = average6Month > 0 ? ((currentPrice - average6Month) / average6Month) * 100 : 0
+
+  const metrics: TradingSignalMetric[] = [
+    buildRsiMetric(rsi),
+    buildMacdMetric(macdState),
+    buildVolumeMetric(volumeRatio, latestClose - previousClose),
+    buildFiftyTwoWeekMetric(week52Band),
+    buildSixMonthMetric(diffFromAverage6Month),
+    buildInsiderMetric(input.insiderActivity, input.market),
+    buildFearGreedMetric(input.fearGreed),
+  ]
+
+  const score = metrics.reduce((sum, metric) => sum + scoreSignal(metric.signal), 0)
+  const recommendation = score >= 2 ? 'buy' : score <= -2 ? 'sell' : 'neutral'
+  const strongestMetric = [...metrics]
+    .sort((left, right) => Math.abs(scoreSignal(right.signal)) - Math.abs(scoreSignal(left.signal)))
+    .find(metric => metric.signal !== 'neutral')
+
+  return {
+    companyName: input.companyName,
+    fetchedAt: new Date().toISOString(),
+    headline: strongestMetric
+      ? `${input.companyName}은(는) 지금 ${strongestMetric.label} 흐름이 가장 두드러져 보여요.`
+      : `${input.companyName}은(는) 지금 뚜렷한 과열·과매도 신호가 크지 않아요.`,
+    market: input.market,
+    marketSymbol: input.marketSymbol,
+    metrics,
+    recommendation,
+    score,
+    ticker: input.ticker,
+  }
+}
+
+export async function fetchTradingSignal(ticker: string, market: TradingMarket): Promise<TradingSignal> {
+  const [yahooSnapshot, fearGreed, insiderActivity] = await Promise.all([
+    fetchYahooSnapshot(ticker, market),
+    fetchFearGreedSnapshot(),
+    fetchInsiderActivity(ticker, market),
+  ])
+
+  return buildTradingSignal({
+    companyName: yahooSnapshot.companyName,
+    currentPrice: yahooSnapshot.currentPrice,
+    fearGreed,
+    insiderActivity,
+    market,
+    marketSymbol: yahooSnapshot.marketSymbol,
+    priceHistory: yahooSnapshot.priceHistory,
+    ticker,
+    week52High: yahooSnapshot.week52High,
+    week52Low: yahooSnapshot.week52Low,
+  })
+}
+
+export async function fetchFearGreedSnapshot(): Promise<FearGreedSnapshot> {
+  const response = await fetch('https://onoff.markets/data/stocks-fear-greed.json', {
+    headers: YAHOO_HEADERS,
+  })
+
+  if (!response.ok) {
+    throw new Error(`Fear & Greed fetch failed: ${response.status}`)
+  }
+
+  const data = await response.json() as { label?: string; score?: number }
+  return {
+    label: typeof data.label === 'string' ? data.label : 'Neutral',
+    score: typeof data.score === 'number' ? data.score : 50,
+  }
+}
+
+export async function fetchInsiderActivity(ticker: string, market: TradingMarket): Promise<InsiderActivitySummary> {
+  if (market !== 'US') {
+    return { buyCount: 0, sellCount: 0, netValue: 0 }
+  }
+
+  const url = new URL('http://openinsider.com/screener')
+  url.searchParams.set('s', ticker)
+  url.searchParams.set('fd', '30')
+  url.searchParams.set('xp', '1')
+  url.searchParams.set('xs', '1')
+  url.searchParams.set('cnt', '10')
+  url.searchParams.set('page', '1')
+
+  const response = await fetch(url, { headers: YAHOO_HEADERS })
+  if (!response.ok) {
+    return { buyCount: 0, sellCount: 0, netValue: 0 }
+  }
+
+  return parseOpenInsiderActivity(await response.text())
+}
+
+export async function fetchYahooSnapshot(ticker: string, market: TradingMarket): Promise<YahooSnapshot> {
+  const symbols = market === 'KR'
+    ? [`${ticker}.KS`, `${ticker}.KQ`]
+    : [ticker.toUpperCase()]
+
+  for (const symbol of symbols) {
+    const url = new URL(`https://query1.finance.yahoo.com/v8/finance/chart/${symbol}`)
+    url.searchParams.set('range', '1y')
+    url.searchParams.set('interval', '1d')
+    url.searchParams.set('includePrePost', 'false')
+    url.searchParams.set('events', 'div,splits')
+
+    const response = await fetch(url, { headers: SEC_HEADERS })
+    if (!response.ok) continue
+
+    const payload = await response.json() as YahooChartResponse
+    const result = payload.chart?.result?.[0]
+    const meta = result?.meta
+    const quote = result?.indicators?.quote?.[0]
+    const closes = quote?.close ?? []
+    const volumes = quote?.volume ?? []
+    const priceHistory = closes.reduce<PriceHistoryPoint[]>((points, close, index) => {
+      if (typeof close !== 'number') return points
+
+      points.push({
+        close,
+        volume: typeof volumes[index] === 'number' ? volumes[index] ?? 0 : 0,
+      })
+      return points
+    }, [])
+
+    if (priceHistory.length < 35 || !meta) continue
+
+    const lastClose = priceHistory[priceHistory.length - 1]?.close ?? 0
+    return {
+      companyName: meta.longName || meta.shortName || ticker,
+      currentPrice: meta.regularMarketPrice || lastClose,
+      marketSymbol: meta.symbol || symbol,
+      priceHistory,
+      week52High: meta.fiftyTwoWeekHigh || Math.max(...priceHistory.map(point => point.close)),
+      week52Low: meta.fiftyTwoWeekLow || Math.min(...priceHistory.map(point => point.close)),
+    }
+  }
+
+  throw new Error(`Unable to fetch price history for ${market}:${ticker}`)
+}
+
+function buildRsiMetric(rsi: number): TradingSignalMetric {
+  if (rsi <= 35) {
+    return {
+      key: 'rsi',
+      label: 'RSI',
+      signal: 'buy',
+      summary: `RSI가 ${formatNumber(rsi)}라 많이 눌린 구간이라, 단기 반등을 노리는 매수 관점으로 볼 수 있어요.`,
+      value: `RSI ${formatNumber(rsi)}`,
+    }
+  }
+
+  if (rsi >= 70) {
+    return {
+      key: 'rsi',
+      label: 'RSI',
+      signal: 'sell',
+      summary: `RSI가 ${formatNumber(rsi)}라 단기 과열 신호가 강해서, 추격 매수보다 일부 차익 실현을 생각할 수 있어요.`,
+      value: `RSI ${formatNumber(rsi)}`,
+    }
+  }
+
+  return {
+    key: 'rsi',
+    label: 'RSI',
+    signal: 'neutral',
+    summary: `RSI가 ${formatNumber(rsi)}라 과열도 과매도도 아닌 중간 구간이라, 방향성이 더 모일 때까지 관망 구간이에요.`,
+    value: `RSI ${formatNumber(rsi)}`,
+  }
+}
+
+function buildMacdMetric(macdState: { histogram: number; macd: number; signal: number }): TradingSignalMetric {
+  if (macdState.histogram > 0) {
+    return {
+      key: 'macd',
+      label: 'MACD',
+      signal: 'buy',
+      summary: `MACD가 시그널선 위로 올라와서, 최근 상승 탄력이 붙기 시작한 흐름으로 해석할 수 있어요.`,
+      value: `히스토그램 ${formatSignedNumber(macdState.histogram)}`,
+    }
+  }
+
+  if (macdState.histogram < 0) {
+    return {
+      key: 'macd',
+      label: 'MACD',
+      signal: 'sell',
+      summary: `MACD가 시그널선 아래에 있어, 상승 힘보다 하락 압력이 더 강한 구간으로 볼 수 있어요.`,
+      value: `히스토그램 ${formatSignedNumber(macdState.histogram)}`,
+    }
+  }
+
+  return {
+    key: 'macd',
+    label: 'MACD',
+    signal: 'neutral',
+    summary: 'MACD가 기준선 근처라 매수세와 매도세가 팽팽해서, 추세 확인이 더 필요한 구간이에요.',
+    value: `히스토그램 ${formatSignedNumber(macdState.histogram)}`,
+  }
+}
+
+function buildVolumeMetric(volumeRatio: number, priceDelta: number): TradingSignalMetric {
+  const value = `20일 평균의 ${formatNumber(volumeRatio)}배`
+
+  if (volumeRatio >= 1.3 && priceDelta > 0) {
+    return {
+      key: 'volume',
+      label: '거래량',
+      signal: 'buy',
+      summary: '거래량이 평소보다 크게 늘면서 가격도 같이 올라, 매수세가 실제로 붙는지 확인되는 장면이에요.',
+      value,
+    }
+  }
+
+  if (volumeRatio >= 1.3 && priceDelta < 0) {
+    return {
+      key: 'volume',
+      label: '거래량',
+      signal: 'sell',
+      summary: '거래량이 크게 터졌는데 가격이 밀려서, 매도 압력이 강하게 나오는 구간으로 볼 수 있어요.',
+      value,
+    }
+  }
+
+  return {
+    key: 'volume',
+    label: '거래량',
+    signal: 'neutral',
+    summary: '거래량이 평소와 비슷해서, 아직은 시장 참여가 폭발적으로 몰린 구간은 아니에요.',
+    value,
+  }
+}
+
+function buildFiftyTwoWeekMetric(week52Band: number): TradingSignalMetric {
+  const percentile = week52Band * 100
+
+  if (week52Band <= 0.35) {
+    return {
+      key: 'fiftyTwoWeek',
+      label: '52주 위치',
+      signal: 'buy',
+      summary: `52주 범위의 하단 ${formatNumber(percentile)}% 근처라, 가격이 바닥권에 가까운지 체크해볼 만해요.`,
+      value: `하단에서 ${formatNumber(percentile)}%`,
+    }
+  }
+
+  if (week52Band >= 0.8) {
+    return {
+      key: 'fiftyTwoWeek',
+      label: '52주 위치',
+      signal: 'sell',
+      summary: `52주 범위의 상단 ${formatNumber(percentile)}% 근처라, 이미 많이 오른 자리인지 확인이 필요한 구간이에요.`,
+      value: `하단에서 ${formatNumber(percentile)}%`,
+    }
+  }
+
+  return {
+    key: 'fiftyTwoWeek',
+    label: '52주 위치',
+    signal: 'neutral',
+    summary: '52주 범위의 중간쯤에 있어서, 아직은 극단적으로 싸거나 비싼 자리라고 보긴 어려워요.',
+    value: `하단에서 ${formatNumber(percentile)}%`,
+  }
+}
+
+function buildSixMonthMetric(diffFromAverage6Month: number): TradingSignalMetric {
+  const value = `6개월 평균 대비 ${formatSignedPercent(diffFromAverage6Month)}`
+
+  if (diffFromAverage6Month <= -8) {
+    return {
+      key: 'sixMonthAverage',
+      label: '6개월 평균 대비',
+      signal: 'buy',
+      summary: '현재가가 6개월 평균보다 꽤 낮아서, 평균 회귀 관점의 저가 구간으로 볼 수 있어요.',
+      value,
+    }
+  }
+
+  if (diffFromAverage6Month >= 10) {
+    return {
+      key: 'sixMonthAverage',
+      label: '6개월 평균 대비',
+      signal: 'sell',
+      summary: '현재가가 6개월 평균보다 많이 위에 있어, 단기 과열로 되돌림이 나올 수 있는 자리예요.',
+      value,
+    }
+  }
+
+  return {
+    key: 'sixMonthAverage',
+    label: '6개월 평균 대비',
+    signal: 'neutral',
+    summary: '현재가가 6개월 평균과 크게 다르지 않아, 추세보다 박스권에 가까운 흐름으로 볼 수 있어요.',
+    value,
+  }
+}
+
+function buildInsiderMetric(activity: InsiderActivitySummary, market: TradingMarket): TradingSignalMetric {
+  if (market !== 'US') {
+    return {
+      key: 'insider',
+      label: '내부자 매매',
+      signal: 'neutral',
+      summary: '국내 종목은 무료 공개 소스가 제한적이라 내부자 매매는 참고용 중립 값으로 보여드려요.',
+      value: '무료 공개 데이터 제한',
+    }
+  }
+
+  if (activity.buyCount === 0 && activity.sellCount === 0) {
+    return {
+      key: 'insider',
+      label: '내부자 매매',
+      signal: 'neutral',
+      summary: '최근 30일 기준으로 눈에 띄는 내부자 매매가 없어, 경영진 신호는 중립으로 볼 수 있어요.',
+      value: '최근 30일 공시 없음',
+    }
+  }
+
+  if (activity.netValue > 0) {
+    return {
+      key: 'insider',
+      label: '내부자 매매',
+      signal: 'buy',
+      summary: `최근 30일 내부자 순매수가 보여서, 회사 안쪽 인물들이 주가를 긍정적으로 보는 신호로 읽을 수 있어요.`,
+      value: `매수 ${activity.buyCount}건 / 매도 ${activity.sellCount}건`,
+    }
+  }
+
+  if (activity.netValue < 0) {
+    return {
+      key: 'insider',
+      label: '내부자 매매',
+      signal: 'sell',
+      summary: `최근 30일 내부자 순매도가 우세해서, 경영진이 일부 차익 실현에 나선 흐름으로 볼 수 있어요.`,
+      value: `매수 ${activity.buyCount}건 / 매도 ${activity.sellCount}건`,
+    }
+  }
+
+  return {
+    key: 'insider',
+    label: '내부자 매매',
+    signal: 'neutral',
+    summary: '내부자 매수와 매도가 비슷하게 섞여 있어, 한쪽으로 강한 방향 신호를 주진 않아요.',
+    value: `매수 ${activity.buyCount}건 / 매도 ${activity.sellCount}건`,
+  }
+}
+
+function buildFearGreedMetric(fearGreed: FearGreedSnapshot): TradingSignalMetric {
+  if (fearGreed.score <= 35) {
+    return {
+      key: 'fearGreed',
+      label: 'Fear&Greed',
+      signal: 'buy',
+      summary: `시장 심리가 ${fearGreed.label.toLowerCase()} 쪽이라 겁먹은 매물이 많은 상태라, 역발상 매수 후보로 볼 수 있어요.`,
+      value: `${fearGreed.label} ${formatNumber(fearGreed.score)}`,
+    }
+  }
+
+  if (fearGreed.score >= 70) {
+    return {
+      key: 'fearGreed',
+      label: 'Fear&Greed',
+      signal: 'sell',
+      summary: `시장 심리가 ${fearGreed.label.toLowerCase()} 쪽이라 모두가 낙관적인 구간이라, 추격보다 리스크 관리를 먼저 볼 수 있어요.`,
+      value: `${fearGreed.label} ${formatNumber(fearGreed.score)}`,
+    }
+  }
+
+  return {
+    key: 'fearGreed',
+    label: 'Fear&Greed',
+    signal: 'neutral',
+    summary: '시장 심리가 공포와 탐욕 사이 중간 구간이라, 전체 분위기는 방향성보다 확인 국면에 가까워요.',
+    value: `${fearGreed.label} ${formatNumber(fearGreed.score)}`,
+  }
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) return 0
+  return values.reduce((sum, value) => sum + value, 0) / values.length
+}
+
+function calculateExponentialMovingAverage(values: number[], period: number): number[] {
+  if (values.length === 0) return []
+
+  const multiplier = 2 / (period + 1)
+  const [first, ...rest] = values
+  const ema = [first]
+
+  for (const value of rest) {
+    ema.push((value * multiplier) + (ema[ema.length - 1] * (1 - multiplier)))
+  }
+
+  return ema
+}
+
+function formatNumber(value: number): string {
+  return value.toFixed(1).replace(/\.0$/, '')
+}
+
+function formatSignedNumber(value: number): string {
+  return `${value >= 0 ? '+' : ''}${formatNumber(value)}`
+}
+
+function formatSignedPercent(value: number): string {
+  return `${value >= 0 ? '+' : ''}${formatNumber(value)}%`
+}
+
+function parseMoney(value: string): number {
+  const normalized = value.replace(/[,$]/g, '')
+  const parsed = Number(normalized)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function scoreSignal(signal: TradingRecommendation): number {
+  if (signal === 'buy') return 1
+  if (signal === 'sell') return -1
+  return 0
+}
+
+function stripHtml(value: string): string {
+  return value
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}

--- a/src/lib/tradingSignalsClient.ts
+++ b/src/lib/tradingSignalsClient.ts
@@ -1,0 +1,99 @@
+'use client'
+
+import { SESSION_KEYS, type PortfolioPosition } from './types'
+import {
+  SIGNAL_CACHE_SECONDS,
+  resolveTradingSignalTarget,
+  type TradingSignal,
+  type TradingSignalTarget,
+} from './tradingSignals'
+
+interface CachedTradingSignal {
+  data: TradingSignal
+  savedAt: number
+}
+
+type TradingSignalCache = Record<string, CachedTradingSignal>
+
+export function listSignalTargets(positions: PortfolioPosition[]): TradingSignalTarget[] {
+  return positions.flatMap(position => {
+    const target = resolveTradingSignalTarget(position)
+    return target ? [target] : []
+  })
+}
+
+export function readSignalCache(): TradingSignalCache {
+  if (typeof window === 'undefined') return {}
+
+  const raw = sessionStorage.getItem(SESSION_KEYS.SIGNALS)
+  if (!raw) return {}
+
+  try {
+    return JSON.parse(raw) as TradingSignalCache
+  } catch {
+    return {}
+  }
+}
+
+export async function loadTradingSignals(positions: PortfolioPosition[]): Promise<TradingSignal[]> {
+  const targets = listSignalTargets(positions)
+  const cache = readSignalCache()
+  const now = Date.now()
+  const freshSignals = new Map<string, TradingSignal>()
+  const missingTargets: TradingSignalTarget[] = []
+
+  for (const target of targets) {
+    const key = getTradingSignalCacheKey(target)
+    const cached = cache[key]
+
+    if (cached && (now - cached.savedAt) < SIGNAL_CACHE_SECONDS * 1000) {
+      freshSignals.set(key, cached.data)
+      continue
+    }
+
+    missingTargets.push(target)
+  }
+
+  if (missingTargets.length > 0) {
+    const fetchedSignals = await Promise.all(missingTargets.map(fetchTradingSignalFromApi))
+    const nextCache = { ...cache }
+
+    for (const signal of fetchedSignals) {
+      const key = getTradingSignalCacheKey(signal)
+      nextCache[key] = {
+        data: signal,
+        savedAt: now,
+      }
+      freshSignals.set(key, signal)
+    }
+
+    writeSignalCache(nextCache)
+  }
+
+  return targets
+    .map(target => freshSignals.get(getTradingSignalCacheKey(target)))
+    .filter((signal): signal is TradingSignal => signal !== undefined)
+}
+
+export async function prefetchTradingSignals(positions: PortfolioPosition[]): Promise<void> {
+  await loadTradingSignals(positions)
+}
+
+function getTradingSignalCacheKey(target: Pick<TradingSignalTarget, 'market' | 'ticker'>): string {
+  return `${target.market}:${target.ticker}`
+}
+
+async function fetchTradingSignalFromApi(target: TradingSignalTarget): Promise<TradingSignal> {
+  const params = new URLSearchParams({ market: target.market, ticker: target.ticker })
+  const response = await fetch(`/api/signals?${params.toString()}`)
+  if (!response.ok) {
+    throw new Error(`signal fetch failed for ${target.market}:${target.ticker}`)
+  }
+
+  return await response.json() as TradingSignal
+}
+
+function writeSignalCache(cache: TradingSignalCache) {
+  if (typeof window === 'undefined') return
+  sessionStorage.setItem(SESSION_KEYS.SIGNALS, JSON.stringify(cache))
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -72,6 +72,7 @@ export const SESSION_KEYS = {
   TARGET: 'pd_target',                 // TargetAllocation
   DIAGNOSIS: 'pd_diagnosis',           // DiagnosisResult
   INVESTOR_PROFILE: 'pd_investor_profile', // InvestorProfile
+  SIGNALS: 'pd_signals',               // TradingSignal cache
 } as const
 
 // 투자 성향 위저드


### PR DESCRIPTION
## Summary

- `/signals` 페이지 신설 — 포트폴리오 종목별 기술적/수급 지표 카드 표시
- `GET /api/signals?ticker=X&market=US|KR` 엔드포인트 구현, Vercel edge cache 24h 적용
- RSI, MACD, 거래량, 52주 위치, 6개월 평균 대비, 내부자 매매(OpenInsider), Fear&Greed 분석
- 각 지표에 주린이 대상 자연어 1줄 해설 표시
- 진단 결과 화면 mount 시 백그라운드 prefetch + "시그널 분석" 버튼 추가

## Test plan

- [ ] `pnpm verify` 통과 확인 (17 files, 112 tests)
- [ ] 진단 결과 화면 진입 시 `/api/signals` 백그라운드 호출 확인 (Network 탭)
- [ ] `/signals` 페이지에서 종목 카드 정상 표시 확인
- [ ] 코드 없는 종목(code: null) 제외 처리 확인
- [ ] API 오류 시 에러 메시지 + 재시도 버튼 동작 확인

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)