### PR TITLE
feat: ProblemCard 리디자인 + SectorPieChart + OCR rate limiting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .next/
 node_modules/
 REVIEW*.md
+docs/superpowers/

--- a/src/app/diagnosis/page.module.css
+++ b/src/app/diagnosis/page.module.css
@@ -69,7 +69,7 @@
 .improvementSection {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
 
 .sectionLabel {
@@ -92,6 +92,14 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-card);
   overflow: hidden;
+}
+
+.fineLine {
+  margin-top: -2px;
+  padding: 0 4px;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-3);
 }
 
 .improvementBtn {

--- a/src/app/diagnosis/page.tsx
+++ b/src/app/diagnosis/page.tsx
@@ -163,6 +163,7 @@ export default function DiagnosisPage() {
   const sectorSlices = buildSectorAllocation(positions)
   const currentScore = computeHealthScore(diagnosis.currentAllocation, target, positions, desiredStyle)
   const idealScore = computeIdealScore(diagnosis.currentAllocation, positions, desiredStyle)
+  const hasActions = diagnosis.actions.length > 0
   const scorePreview = idealScore > currentScore
     ? `건강점수 ${currentScore}점 → ${idealScore}점`
     : `건강점수 ${currentScore}점 기준으로 전체 비중 확인`
@@ -209,7 +210,28 @@ export default function DiagnosisPage() {
             </>
           )}
 
-          <button className={styles.improvementBtn} onClick={() => setSheetOpen(true)}>
+          {hasActions && (
+            <>
+              <div className={styles.sectionLabel}>권장 조치</div>
+              <div className={styles.actionCard}>
+                {diagnosis.actions.map(action => (
+                  <ActionItem
+                    key={`${action.action}-${action.ticker}-${action.quantity}`}
+                    action={action}
+                  />
+                ))}
+              </div>
+              <p className={styles.fineLine}>
+                현재가는 캡처 시점 기준입니다. 실제 주문 전 가격과 세금은 다시 확인하세요.
+              </p>
+            </>
+          )}
+
+          <button
+            className={styles.improvementBtn}
+            type="button"
+            onClick={() => setSheetOpen(true)}
+          >
             <div className={styles.improvementBtnText}>
               <span className={styles.improvementBtnTitle}>포트폴리오 개선 보기</span>
               <span className={styles.improvementBtnMeta}>
@@ -233,7 +255,11 @@ export default function DiagnosisPage() {
         {sectorSlices.length > 0 && <SectorPieChart slices={sectorSlices} />}
 
         {/* 왜 이 조언인가요? */}
-        <button className={`${styles.explainBtn} ${explainOpen ? styles.explainOpen : ''}`} onClick={toggleExplain}>
+        <button
+          className={`${styles.explainBtn} ${explainOpen ? styles.explainOpen : ''}`}
+          type="button"
+          onClick={toggleExplain}
+        >
           왜 이 조언인가요?
           <span className={styles.explainIcon}>▾</span>
         </button>
@@ -242,7 +268,10 @@ export default function DiagnosisPage() {
             {explainLoading && <p>설명 불러오는 중...</p>}
             {explainError && (
               <p>설명을 불러오지 못했습니다.{' '}
-                <button onClick={() => { setExplanation(null); setExplainError(false); toggleExplain() }}>
+                <button
+                  type="button"
+                  onClick={() => { setExplanation(null); setExplainError(false); toggleExplain() }}
+                >
                   다시 시도
                 </button>
               </p>
@@ -267,6 +296,7 @@ export default function DiagnosisPage() {
           <div className={styles.mbtiDesc}>{mbtiProfile.desc}</div>
           <button
             className={styles.shareBtn}
+            type="button"
             onClick={handleShare}
             aria-label="투자 MBTI 공유하기"
           >
@@ -280,7 +310,7 @@ export default function DiagnosisPage() {
           ))}
         </div>
 
-        <button className={styles.resetBtn} onClick={() => router.push('/')}>
+        <button className={styles.resetBtn} type="button" onClick={() => router.push('/')}>
           ↩ 다시 진단하기
         </button>
       </div>

--- a/src/components/ActionItem.module.css
+++ b/src/components/ActionItem.module.css
@@ -6,6 +6,7 @@
 .buy  { background: var(--green-bg); color: var(--green); }
 .info { flex: 1; min-width: 0; }
 .name { font-size: 14px; font-weight: 700; letter-spacing: -0.2px; }
+.note { font-size: 12px; color: var(--text-2); margin-top: 3px; line-height: 1.45; }
 .tax  { font-size: 11px; color: var(--text-3); margin-top: 2px; }
 .qty  { text-align: right; flex-shrink: 0; }
 .qtyNum { font-size: 14px; font-weight: 700; font-variant-numeric: tabular-nums; }

--- a/src/components/ActionItem.tsx
+++ b/src/components/ActionItem.tsx
@@ -4,6 +4,14 @@ import styles from './ActionItem.module.css'
 
 interface Props { action: Action }
 
+function getActionNote(action: Action): string {
+  if (action.action === 'sell') {
+    return '비중이 높은 자산을 먼저 줄이는 조치'
+  }
+
+  return '부족한 자산군을 보완하는 조치'
+}
+
 export function ActionItem({ action }: Props) {
   const fmt = (n: number) => Math.round(n).toLocaleString('ko-KR')
   const isSell = action.action === 'sell'
@@ -15,6 +23,7 @@ export function ActionItem({ action }: Props) {
       </span>
       <div className={styles.info}>
         <div className={styles.name}>{action.name}</div>
+        <div className={styles.note}>{getActionNote(action)}</div>
         {action.taxEstimate !== undefined && (
           <div className={styles.tax}>해외주식 세금 약 ₩{fmt(action.taxEstimate)} 예상</div>
         )}

--- a/src/components/ProblemCard.tsx
+++ b/src/components/ProblemCard.tsx
@@ -125,8 +125,8 @@ export function ProblemCard({ problem, index }: Props) {
 
       <p className={styles.desc}>{problem.description}</p>
       <ul className={styles.recommendations} aria-label={`${getAssetLabel(problem)} 개선 방향`}>
-        {recommendationLines.map(line => (
-          <li key={line}>{line}</li>
+        {recommendationLines.map((line, recommendationIndex) => (
+          <li key={`${problem.type}-${index}-${recommendationIndex}`}>{line}</li>
         ))}
       </ul>
     </article>

--- a/src/components/SectorPieChart.test.ts
+++ b/src/components/SectorPieChart.test.ts
@@ -1,0 +1,32 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { SectorPieChart } from './SectorPieChart'
+
+describe('SectorPieChart', () => {
+  it('빈 섹터 데이터면 아무 것도 렌더링하지 않는다', () => {
+    const html = renderToStaticMarkup(
+      createElement(SectorPieChart, {
+        slices: [],
+      }),
+    )
+
+    expect(html).toBe('')
+  })
+
+  it('섹터 데이터가 있으면 대표 섹터와 비중을 렌더링한다', () => {
+    const html = renderToStaticMarkup(
+      createElement(SectorPieChart, {
+        slices: [
+          { sector: '반도체', value: 6000000, share: 60 },
+          { sector: '바이오', value: 4000000, share: 40 },
+        ],
+      }),
+    )
+
+    expect(html).toContain('섹터 비중')
+    expect(html).toContain('최대 반도체')
+    expect(html).toContain('60%')
+    expect(html).toContain('바이오')
+  })
+})

--- a/src/components/SectorPieChart.tsx
+++ b/src/components/SectorPieChart.tsx
@@ -18,6 +18,10 @@ interface SectorPieChartProps {
 }
 
 export function SectorPieChart({ slices }: SectorPieChartProps) {
+  if (slices.length === 0) {
+    return null
+  }
+
   const totalValue = slices.reduce((sum, slice) => sum + slice.value, 0)
   const chartFill = slices
     .map((slice, index) => {


### PR DESCRIPTION
## Summary

- **ProblemCard 리디자인**: severity badge(고위험/주의) + metrics grid(현재/목표/차이) + contextual recommendations list
- **SectorPieChart 신규**: CSS conic-gradient donut chart, 섹터별 legend, 진단 페이지 통합
- **sectorAllocation.ts 신규**: 섹터 집계 유틸리티, 5개 초과 시 `기타 외` 그루핑
- **OCR rate limiting**: IP당 24시간 5회 제한 (Upstash Redis, 미설정 시 graceful fallback)

## Test plan

- [x] `pnpm verify` — 99 tests passed
- [x] OCR rate limit: Redis 미설정 시 정상 동작 확인
- [x] SectorPieChart: conic-gradient 렌더링 확인
- [x] ProblemCard: drift / concentration 두 케이스 모두 렌더 검증

## Review

REVIEW-1.md — APPROVED (P1 없음, P2 3개 선택 반영)

🤖 Generated with [Claude Code](https://claude.com/claude-code)