### PR TITLE
feat: SNS 공유 시 미리보기를 위한 OG 이미지 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,9 +2,30 @@
 import type { Metadata } from 'next'
 import './globals.css'
 
+const title = 'Dr.Folio'
+const description = 'MTS 캡처 한 장으로 포트폴리오 진단'
+const siteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL ??
+  process.env.VERCEL_PROJECT_PRODUCTION_URL ??
+  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000')
+const metadataBase = new URL(siteUrl.startsWith('http') ? siteUrl : `https://${siteUrl}`)
+const openGraphImagePath = '/opengraph-image'
+
 export const metadata: Metadata = {
-  title: 'Dr.Folio',
-  description: 'MTS 캡처 한 장으로 포트폴리오 진단',
+  metadataBase,
+  title,
+  description,
+  openGraph: {
+    title,
+    description,
+    images: [openGraphImagePath],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title,
+    description,
+    images: [openGraphImagePath],
+  },
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,61 @@
+import { ImageResponse } from 'next/og'
+
+export const alt = 'Dr.Folio - MTS 캡처 한 장으로 포트폴리오 진단'
+
+export const size = {
+  width: 1200,
+  height: 630,
+}
+
+export const contentType = 'image/png'
+
+export default function OpenGraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: '#1C2B5E',
+          color: '#FFFFFF',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          padding: '72px',
+          fontFamily: 'system-ui, sans-serif',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '18px',
+            maxWidth: '900px',
+          }}
+        >
+          <div
+            style={{
+              fontSize: 88,
+              fontWeight: 700,
+              letterSpacing: '-0.04em',
+              lineHeight: 1.05,
+            }}
+          >
+            Dr.Folio
+          </div>
+          <div
+            style={{
+              fontSize: 38,
+              fontWeight: 500,
+              lineHeight: 1.3,
+              opacity: 0.92,
+            }}
+          >
+            MTS 캡처 한 장으로 포트폴리오 진단
+          </div>
+        </div>
+      </div>
+    ),
+    size
+  )
+}


### PR DESCRIPTION
## Summary
- `src/app/opengraph-image.tsx` 추가 — Next.js 15 `ImageResponse`로 1200×630 OG 이미지 생성 (navy 배경, Dr.Folio 타이틀)
- `src/app/layout.tsx`에 `openGraph` / `twitter` 메타데이터 필드 추가

## Test plan
- [ ] `pnpm verify` 122/122 통과 확인
- [ ] Vercel 배포 후 `/opengraph-image` 경로에서 이미지 렌더링 확인
- [ ] [opengraph.xyz](https://www.opengraph.xyz) 또는 카카오톡 공유 링크로 미리보기 확인

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)