### PR TITLE
[codex] 종목 시그널 점수 체계를 시장과 분리한 점수형 진단으로 개편

### DIFF
--- a/docs/stock-signal-scoring.md
+++ b/docs/stock-signal-scoring.md
@@ -1,0 +1,225 @@
+# 종목 시그널 점수 계산 문서
+
+이 문서는 `src/lib/tradingSignals.ts`의 종목 진입 점수 계산 로직을 비즈니스 기준으로 설명한다.
+
+## 목적
+- 종목 페이지는 시장 판단과 분리된 `종목 자체 진입 타이밍`만 보여준다.
+- 사용자는 한 화면에서 `점수`, `상태 라벨`, `쉬운 설명`, `전문 지표 상세`를 함께 읽을 수 있어야 한다.
+- 점수 계산의 단일 진실 공급원은 `RSI`, `MACD`, `거래량`, `52주 위치` 4개 핵심 지표다.
+
+## 입력 지표
+
+### 점수 반영 지표
+- `RSI`
+- `MACD histogram`과 `previousHistogram`
+- `volumeRatio`
+- `week52Band`
+
+### 참고 지표
+- `6개월 평균 대비 괴리율`
+- `내부자 매매`
+
+참고 지표는 UI 상세에는 노출하지만 점수, 라벨, confidence 계산에는 포함하지 않는다.
+
+## 점수 공식
+
+각 핵심 지표는 아래 공식으로 기여도를 만든다.
+
+```ts
+contribution = directionScore * strength * weight
+```
+
+### directionScore
+- `buy` => `+1`
+- `neutral` => `0`
+- `sell` => `-1`
+
+### weight
+- `RSI` => `1.2`
+- `MACD` => `1.5`
+- `거래량` => `1.3`
+- `52주 위치` => `0.9`
+
+```ts
+TOTAL_WEIGHT = 4.9
+```
+
+### 최종 점수 변환
+
+```ts
+rawScore = sum(metric.contribution)
+normalizedScore = clamp(rawScore / TOTAL_WEIGHT, -1, 1)
+score = Math.round((normalizedScore + 1) * 50)
+```
+
+- `normalizedScore = -1` 이면 `0점`
+- `normalizedScore = 0` 이면 `50점`
+- `normalizedScore = +1` 이면 `100점`
+
+## 상태 라벨
+- `75~100` => `분할매수 고려`
+- `60~74` => `관심 종목`
+- `45~59` => `관망 우세`
+- `30~44` => `주의 필요`
+- `0~29` => `리스크 높음`
+
+추가로 UI 정렬을 위해 `recommendation`도 함께 계산한다.
+
+- `score >= 60` => `buy`
+- `45 <= score < 60` => `neutral`
+- `score < 45` => `sell`
+
+## 지표별 판정 규칙
+
+### RSI
+- `< 30` => `buy`, `strength 0.85`
+- `< 45` => `buy`, `strength 0.35`
+- `< 60` => `neutral`
+- `< 70` => `neutral`
+- `< 80` => `sell`, `strength 0.45`
+- `>= 80` => `sell`, `strength 0.85`
+
+역할:
+- 과열/과매도 판단
+- 초보자 문구에서는 "많이 눌린 구간", "과열 구간" 같은 쉬운 표현으로 번역
+
+### MACD
+판정 기준:
+- `histogram > 0 && histogram > previousHistogram` => `buy`, `strength 0.8`, `상승 흐름`
+- `histogram > 0 && histogram < previousHistogram` => `buy`, `strength 0.35`, `상승 둔화`
+- `histogram < 0 && histogram > previousHistogram` => `buy`, `strength 0.45`, `반등 조짐`
+- `histogram < 0 && histogram < previousHistogram` => `sell`, `strength 0.75`, `하락 압력`
+- 그 외 => `neutral`
+
+역할:
+- 추세 전환과 탄력 방향 판단
+
+### 거래량
+- `volumeRatio < 1.2` => `neutral`
+- 그 이상이면 `strength = min(1, (volumeRatio - 1.2) / 1.3)`
+- `recentReturn3d > 0` => `buy`
+- `recentReturn3d < 0` => `sell`
+- `recentReturn3d === 0` => `neutral`
+
+역할:
+- 수급이 가격 방향을 실제로 뒷받침하는지 판단
+
+### 52주 위치
+계산식:
+
+```ts
+week52Band = (currentPrice - week52Low) / (week52High - week52Low)
+```
+
+판정 기준:
+- `<= 0.25` => `buy`, `strength 0.75`
+- `<= 0.40` => `buy`, `strength 0.35`
+- `< 0.75` => `neutral`
+- `< 0.90` => `sell`, `strength 0.35`
+- `>= 0.90` => `sell`, `strength 0.75`
+
+역할:
+- 최근 1년 가격 범위에서 현재 가격대 부담 판단
+
+## Confidence
+confidence는 점수 절대값이 아니라 `핵심 지표 정렬도`를 기준으로 판단한다.
+
+대상 지표:
+- `rsi`
+- `macd`
+- `volume`
+
+규칙:
+
+```ts
+positive = number of buy signals in core metrics
+negative = number of sell signals in core metrics
+aligned = positive >= 2 || negative >= 2
+```
+
+- `aligned && abs(normalizedScore) >= 0.45` => `high`
+- `aligned && abs(normalizedScore) >= 0.25` => `medium`
+- 그 외 => `low`
+
+UI 문구:
+- `high` => `여러 핵심 지표가 같은 방향을 가리키고 있어요.`
+- `medium` => `일부 핵심 지표가 같은 방향을 보이고 있어요.`
+- `low` => `지표들이 엇갈려 조금 더 확인이 필요해요.`
+
+## 상단 요약 문구
+상단 문구는 아래 3단 조합으로 만든다.
+
+```text
+[가격 위치] + [추세/거래량] + [행동 가이드]
+```
+
+예:
+- `가격 부담은 낮고 상승 신호가 나오고 있어요. 한 번에 사기보다 조금씩 나눠서 보는 게 좋아요.`
+- `가격 흐름과 수급이 모두 약해 보여요. 새로 들어가기보다 반등 신호가 나올 때까지 기다리는 편이 좋아요.`
+
+## 반환 구조
+`TradingSignal`은 아래 정보를 포함한다.
+
+- `score`
+- `label`
+- `confidence`
+- `confidenceSummary`
+- `summary`
+- `metrics`
+- `expertDetails`
+- `referenceMetrics`
+
+### metrics
+점수 반영 핵심 지표 배열
+
+주요 필드:
+- `signal`
+- `strength`
+- `weight`
+- `contribution`
+- `status`
+- `summary`
+- `description`
+- `value`
+
+### expertDetails
+아코디언에서 노출할 전문가 상세 정보
+
+### referenceMetrics
+점수 제외 참고 지표
+
+## 예시
+
+입력:
+
+```ts
+rsi = 42.3
+macd histogram = 0.82
+previousHistogram = 0.38
+volumeRatio = 1.8
+recentReturn3d = 2.1
+week52Band = 0.35
+```
+
+기여도:
+
+```text
+RSI = +0.42
+MACD = +1.20
+거래량 = +0.60
+52주 위치 = +0.32
+```
+
+결과:
+
+```text
+rawScore = 2.54
+normalizedScore = 0.52
+score = 76
+label = 분할매수 고려
+confidence = high
+```
+
+## 변경 원칙
+- 핵심 4개 지표의 threshold나 weight를 바꾸면 이 문서와 `src/lib/tradingSignals.test.ts`를 함께 수정한다.
+- 시장 결합 판단은 이 모델에 다시 넣지 않는다. 시장 정보는 별도 시장 페이지에서 다룬다.

--- a/src/app/signals/page.test.ts
+++ b/src/app/signals/page.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('SignalsPage source', () => {
+  it('시장 배너와 시장 데이터 의존성 없이 종목 점수 화면으로 유지된다', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).not.toContain('MarketBanner')
+    expect(source).not.toContain('loadMarketSignals')
+    expect(source).not.toContain('resolveFinalJudgment')
+    expect(source).toContain('RSI, MACD, 거래량, 52주 위치로 종목 점수를 만들고')
+  })
+})

--- a/src/app/signals/page.tsx
+++ b/src/app/signals/page.tsx
@@ -2,13 +2,9 @@
 
 import { useEffect, useMemo, useState, useSyncExternalStore } from 'react'
 import { useRouter } from 'next/navigation'
-import { resolveFinalJudgment } from '@/lib/finalJudgment'
-import { loadMarketSignals } from '@/lib/marketSignalsClient'
 import { SignalCard } from '@/components/SignalCard'
-import { MarketBanner } from '@/components/MarketBanner'
 import { listSignalTargets, loadTradingSignals } from '@/lib/tradingSignalsClient'
 import { SESSION_KEYS, type PortfolioPosition } from '@/lib/types'
-import type { MarketResponse } from '@/lib/marketSignals'
 import type { TradingSignal } from '@/lib/tradingSignals'
 import styles from './page.module.css'
 
@@ -46,11 +42,8 @@ export default function SignalsPage() {
   )
   const positions = useMemo(() => (isClient ? readConfirmedPositions() : []), [isClient])
   const [signals, setSignals] = useState<TradingSignal[]>([])
-  const [market, setMarket] = useState<MarketResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [marketLoading, setMarketLoading] = useState(true)
-  const [marketError, setMarketError] = useState<string | null>(null)
   const supportedCount = useMemo(() => listSignalTargets(positions).length, [positions])
   const unsupportedCount = Math.max(
     positions.filter(position => position.assetClass === '국내주식' || position.assetClass === '해외주식').length - supportedCount,
@@ -60,8 +53,6 @@ export default function SignalsPage() {
   async function handleRefresh() {
     setLoading(true)
     setError(null)
-    setMarketLoading(true)
-    setMarketError(null)
 
     try {
       setSignals(await loadTradingSignals(positions))
@@ -69,14 +60,6 @@ export default function SignalsPage() {
       setError('종목 시그널을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.')
     } finally {
       setLoading(false)
-    }
-
-    try {
-      setMarket(await loadMarketSignals(true))
-    } catch {
-      setMarketError('거시 지표를 바로 불러오지 못했어요.')
-    } finally {
-      setMarketLoading(false)
     }
   }
 
@@ -102,15 +85,6 @@ export default function SignalsPage() {
       } finally {
         if (active) setLoading(false)
       }
-
-      try {
-        const nextMarket = await loadMarketSignals()
-        if (active) setMarket(nextMarket)
-      } catch {
-        if (active) setMarketError('거시 지표를 바로 불러오지 못했어요.')
-      } finally {
-        if (active) setMarketLoading(false)
-      }
     }
 
     void hydrateSignals()
@@ -126,9 +100,9 @@ export default function SignalsPage() {
     <div className={styles.wrap}>
       <div className={styles.header}>
         <div className={styles.eyebrow}>종목 시그널 분석</div>
-        <h1 className={styles.title}>각 종목이 지금 보내는 신호를 한 번에 확인해보세요.</h1>
+        <h1 className={styles.title}>각 종목의 진입 타이밍을 점수와 설명으로 확인해보세요.</h1>
         <p className={styles.sub}>
-          RSI, MACD, 거래량, 52주 위치, 6개월 평균, 내부자 매매를 종목 카드에 담고, 위에는 오늘 시장 온도를 따로 얹어 보여드려요.
+          RSI, MACD, 거래량, 52주 위치로 종목 점수를 만들고, 6개월 평균과 내부자 매매는 참고 지표로 따로 보여드려요.
         </p>
         <div className={styles.metaRow}>
           <span className={styles.metaBadge}>분석 가능 {supportedCount}종목</span>
@@ -137,8 +111,6 @@ export default function SignalsPage() {
       </div>
 
       <div className={styles.body}>
-        <MarketBanner error={marketError} loading={marketLoading} market={market} />
-
         <div className={styles.actions}>
           <button className={styles.secondaryButton} onClick={() => router.push('/diagnosis')}>
             ← 진단 결과로 돌아가기
@@ -169,7 +141,6 @@ export default function SignalsPage() {
           {signals.map(signal => (
             <SignalCard
               key={`${signal.market}:${signal.ticker}`}
-              judgment={resolveFinalJudgment(market?.macroState ?? 'neutral', signal)}
               signal={signal}
             />
           ))}

--- a/src/components/SignalCard.module.css
+++ b/src/components/SignalCard.module.css
@@ -1,9 +1,11 @@
 .card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 18px;
+  background:
+    radial-gradient(circle at top right, rgba(255, 255, 255, 0.72), transparent 36%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(247, 249, 255, 0.96));
+  border: 1px solid rgba(26, 35, 126, 0.1);
+  border-radius: 22px;
   padding: 18px;
-  box-shadow: 0 12px 24px rgba(18, 24, 88, 0.05);
+  box-shadow: 0 18px 36px rgba(18, 24, 88, 0.08);
 }
 
 .header {
@@ -30,52 +32,78 @@
 }
 
 .name {
-  font-size: 20px;
+  font-size: 22px;
   font-weight: 800;
   letter-spacing: -0.03em;
   color: var(--text-1);
 }
 
-.badge {
-  flex-shrink: 0;
+.scoreBlock {
+  display: grid;
+  justify-items: end;
+  min-width: 62px;
+}
+
+.scoreValue {
+  font-size: 34px;
+  line-height: 1;
+  font-weight: 900;
+  letter-spacing: -0.06em;
+  color: var(--navy);
+}
+
+.scoreUnit {
+  margin-top: 3px;
+  font-size: 12px;
+  font-weight: 800;
+  color: var(--text-3);
+}
+
+.topline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.badge,
+.badgeGhost {
   border-radius: 999px;
   padding: 8px 12px;
   font-size: 12px;
   font-weight: 800;
 }
 
-.badge_accumulate {
+.badge_buy {
   background: var(--green-bg);
   color: var(--green);
 }
 
-.badge_wait {
+.badge_neutral {
   background: var(--amber-bg);
   color: var(--amber);
 }
 
-.badge_caution {
+.badge_sell {
   background: var(--red-bg);
   color: var(--red);
 }
 
+.badgeGhost {
+  background: rgba(26, 35, 126, 0.06);
+  color: var(--navy);
+}
+
 .headline {
   margin-top: 14px;
-  font-size: 14px;
-  line-height: 1.6;
-  font-weight: 700;
+  font-size: 15px;
+  line-height: 1.7;
+  font-weight: 800;
   color: var(--text-1);
 }
 
-.decisionMeta {
+.confidenceText {
   margin-top: 8px;
-  font-size: 12px;
-  font-weight: 700;
-  color: var(--text-3);
-}
-
-.headlineSub {
-  margin-top: 10px;
   font-size: 13px;
   line-height: 1.6;
   color: var(--text-2);
@@ -84,24 +112,26 @@
 .metricList {
   display: grid;
   gap: 10px;
-  margin-top: 16px;
+  margin-top: 18px;
 }
 
 .metric {
-  background: linear-gradient(180deg, rgba(232, 234, 246, 0.65), rgba(244, 246, 255, 0.3));
+  background: linear-gradient(180deg, rgba(233, 236, 249, 0.72), rgba(246, 248, 255, 0.4));
   border: 1px solid rgba(26, 35, 126, 0.08);
-  border-radius: 14px;
+  border-radius: 16px;
   padding: 14px;
 }
 
-.metricTop {
+.metricTop,
+.expertTop {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
 }
 
-.metricLabel {
+.metricLabel,
+.expertLabel {
   font-size: 13px;
   font-weight: 800;
   color: var(--navy);
@@ -124,9 +154,83 @@
   color: var(--red);
 }
 
-.metricSummary {
+.metricSummary,
+.expertDescription {
   margin-top: 8px;
   font-size: 13px;
   line-height: 1.6;
   color: var(--text-2);
+}
+
+.metricMeta,
+.expertStatus {
+  margin-top: 8px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-3);
+}
+
+.expertPanel {
+  margin-top: 16px;
+  border: 1px solid rgba(26, 35, 126, 0.1);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.8);
+  overflow: hidden;
+}
+
+.expertToggle {
+  list-style: none;
+  cursor: pointer;
+  padding: 14px 16px;
+  font-size: 13px;
+  font-weight: 800;
+  color: var(--navy);
+}
+
+.expertToggle::-webkit-details-marker {
+  display: none;
+}
+
+.expertToggle::after {
+  content: '▾';
+  float: right;
+  color: var(--text-3);
+}
+
+.expertPanel[open] .expertToggle::after {
+  content: '▴';
+}
+
+.expertList {
+  display: grid;
+  gap: 10px;
+  padding: 0 14px 14px;
+}
+
+.expertMetric,
+.referenceMetric {
+  border-radius: 14px;
+  padding: 14px;
+  background: rgba(244, 246, 255, 0.72);
+  border: 1px solid rgba(26, 35, 126, 0.07);
+}
+
+.expertValue {
+  font-size: 12px;
+  font-weight: 800;
+  color: var(--text-1);
+}
+
+.referenceBlock {
+  display: grid;
+  gap: 10px;
+}
+
+.referenceTitle {
+  margin-top: 4px;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-3);
 }

--- a/src/components/SignalCard.test.ts
+++ b/src/components/SignalCard.test.ts
@@ -1,0 +1,167 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { SignalCard } from './SignalCard'
+
+describe('SignalCard', () => {
+  it('종목 점수 중심 카드와 접힘 상세를 렌더링한다', () => {
+    const html = renderToStaticMarkup(
+      createElement(SignalCard, {
+        signal: {
+          companyName: '현대차',
+          confidence: 'high',
+          confidenceSummary: '여러 핵심 지표가 같은 방향을 가리키고 있어요.',
+          expertDetails: [
+            {
+              contribution: '+0.42',
+              description: 'RSI 42.3: 최근 상승폭과 하락폭을 비교한 지표예요. 현재는 비교적 부담이 낮은 구간으로 해석됩니다.',
+              key: 'rsi',
+              status: '완만한 저점권',
+              title: 'RSI',
+              value: 'RSI 42.3',
+            },
+            {
+              contribution: '+1.20',
+              description: 'MACD Histogram +0.82: MACD가 Signal 선보다 위에 있으며, 전일 대비 개선되고 있습니다.',
+              key: 'macd',
+              status: '상승 흐름',
+              title: 'MACD',
+              value: 'MACD Histogram +0.82',
+            },
+            {
+              contribution: '+0.60',
+              description: '거래량 1.8배: 최근 20일 평균 거래량 대비 현재 거래량이에요. 최근 3일 수익률은 +2.1%입니다.',
+              key: 'volume',
+              status: '관심 증가',
+              title: '거래량',
+              value: '거래량 1.8배',
+            },
+            {
+              contribution: '+0.32',
+              description: '52주 위치 하위 35%: 52주 저가와 고가 사이에서 현재가가 위치한 비율입니다. 1년 가격 범위에서 비교적 낮은 편이에요.',
+              key: 'fiftyTwoWeek',
+              status: '낮은 가격대',
+              title: '52주 위치',
+              value: '52주 위치 하위 35%',
+            },
+            {
+              contribution: null,
+              description: '6개월 평균 대비 -4.2%: 현재가가 6개월 평균과 크게 다르지 않아 중기 기준으로는 중립 구간이에요.',
+              key: 'sixMonthAverage',
+              status: '중립',
+              title: '6개월 평균 대비',
+              value: '6개월 평균 대비 -4.2%',
+            },
+            {
+              contribution: null,
+              description: '최근 30일 내부자 순매수가 보여 회사 안쪽 인물들이 주가를 긍정적으로 보는 신호로 읽을 수 있어요.',
+              key: 'insider',
+              status: '순매수 우위',
+              title: '내부자 매매',
+              value: '매수 2건 / 매도 0건',
+            },
+          ],
+          fetchedAt: '2026-04-24T00:00:00.000Z',
+          label: '분할매수 고려',
+          market: 'KR',
+          marketSymbol: '005380.KS',
+          metrics: [
+            {
+              contribution: 0.42,
+              description: 'RSI 42.3: 최근 상승폭과 하락폭을 비교한 지표예요. 현재는 비교적 부담이 낮은 구간으로 해석됩니다.',
+              includedInScore: true,
+              key: 'rsi',
+              label: 'RSI',
+              signal: 'buy',
+              status: '완만한 저점권',
+              strength: 0.35,
+              summary: '과열은 아니고, 비교적 부담이 낮은 구간이에요.',
+              value: 'RSI 42.3',
+              weight: 1.2,
+            },
+            {
+              contribution: 1.2,
+              description: 'MACD Histogram +0.82: MACD가 Signal 선보다 위에 있으며, 전일 대비 개선되고 있습니다.',
+              includedInScore: true,
+              key: 'macd',
+              label: 'MACD',
+              signal: 'buy',
+              status: '상승 흐름',
+              strength: 0.8,
+              summary: '상승 흐름이 이어지고 있어요.',
+              value: 'MACD Histogram +0.82',
+              weight: 1.5,
+            },
+            {
+              contribution: 0.6,
+              description: '거래량 1.8배: 최근 20일 평균 거래량 대비 현재 거래량이에요. 최근 3일 수익률은 +2.1%입니다.',
+              includedInScore: true,
+              key: 'volume',
+              label: '거래량',
+              signal: 'buy',
+              status: '관심 증가',
+              strength: 0.46,
+              summary: '평소보다 거래가 늘면서 관심이 붙고 있어요.',
+              value: '거래량 1.8배',
+              weight: 1.3,
+            },
+            {
+              contribution: 0.32,
+              description: '52주 위치 하위 35%: 52주 저가와 고가 사이에서 현재가가 위치한 비율입니다. 1년 가격 범위에서 비교적 낮은 편이에요.',
+              includedInScore: true,
+              key: 'fiftyTwoWeek',
+              label: '52주 위치',
+              signal: 'buy',
+              status: '낮은 가격대',
+              strength: 0.35,
+              summary: '1년 가격 범위에서 비교적 낮은 편이에요.',
+              value: '52주 위치 하위 35%',
+              weight: 0.9,
+            },
+          ],
+          normalizedScore: 0.52,
+          recommendation: 'buy',
+          referenceMetrics: [
+            {
+              contribution: 0,
+              description: '6개월 평균 대비 -4.2%: 현재가가 6개월 평균과 크게 다르지 않아 중기 기준으로는 중립 구간이에요.',
+              includedInScore: false,
+              key: 'sixMonthAverage',
+              label: '6개월 평균 대비',
+              signal: 'neutral',
+              status: '중립',
+              strength: 0,
+              summary: '현재가가 6개월 평균과 크게 다르지 않아요.',
+              value: '6개월 평균 대비 -4.2%',
+              weight: 0,
+            },
+            {
+              contribution: 0,
+              description: '최근 30일 내부자 순매수가 보여 회사 안쪽 인물들이 주가를 긍정적으로 보는 신호로 읽을 수 있어요.',
+              includedInScore: false,
+              key: 'insider',
+              label: '내부자 매매',
+              signal: 'buy',
+              status: '순매수 우위',
+              strength: 0,
+              summary: '최근 30일 내부자 순매수가 보여요.',
+              value: '매수 2건 / 매도 0건',
+              weight: 0,
+            },
+          ],
+          score: 76,
+          summary: '가격도 합리적인 편이고 상승 신호가 나오고 있어요. 한 번에 사기보다 조금씩 나눠서 보는 게 좋아요.',
+          ticker: '005380',
+        },
+      }),
+    )
+
+    expect(html).toContain('현대차')
+    expect(html).toContain('76')
+    expect(html).toContain('분할매수 고려')
+    expect(html).toContain('여러 핵심 지표가 같은 방향을 가리키고 있어요.')
+    expect(html).toContain('전문 지표 이름·수치 보기')
+    expect(html).toContain('참고 지표')
+    expect(html).toContain('내부자 매매')
+  })
+})

--- a/src/components/SignalCard.tsx
+++ b/src/components/SignalCard.tsx
@@ -1,19 +1,23 @@
-import type { FinalJudgment } from '@/lib/finalJudgment'
-import type { TradingRecommendation, TradingSignal } from '@/lib/tradingSignals'
+import type { TradingConfidence, TradingRecommendation, TradingSignal } from '@/lib/tradingSignals'
 import styles from './SignalCard.module.css'
 
 interface SignalCardProps {
-  judgment: FinalJudgment
   signal: TradingSignal
 }
 
-const TECHNICAL_LABEL: Record<TradingRecommendation, string> = {
-  buy: '매수 관점',
+const RECOMMENDATION_LABEL: Record<TradingRecommendation, string> = {
+  buy: '긍정',
   neutral: '중립',
-  sell: '매도 관점',
+  sell: '주의',
 }
 
-export function SignalCard({ judgment, signal }: SignalCardProps) {
+const CONFIDENCE_LABEL: Record<TradingConfidence, string> = {
+  high: '확신도 높음',
+  low: '확인 더 필요',
+  medium: '확신도 보통',
+}
+
+export function SignalCard({ signal }: SignalCardProps) {
   return (
     <article className={styles.card}>
       <div className={styles.header}>
@@ -24,16 +28,23 @@ export function SignalCard({ judgment, signal }: SignalCardProps) {
           </div>
           <h2 className={styles.name}>{signal.companyName}</h2>
         </div>
-        <span className={`${styles.badge} ${styles[`badge_${judgment.key}`]}`}>
-          {judgment.label}
+        <div className={styles.scoreBlock}>
+          <strong className={styles.scoreValue}>{signal.score}</strong>
+          <span className={styles.scoreUnit}>점</span>
+        </div>
+      </div>
+
+      <div className={styles.topline}>
+        <span className={`${styles.badge} ${styles[`badge_${signal.recommendation}`]}`}>
+          {signal.label}
+        </span>
+        <span className={styles.badgeGhost}>
+          {RECOMMENDATION_LABEL[signal.recommendation]} · {CONFIDENCE_LABEL[signal.confidence]}
         </span>
       </div>
 
-      <p className={styles.headline}>{judgment.summary}</p>
-      <p className={styles.decisionMeta}>
-        기술 시그널 {TECHNICAL_LABEL[signal.recommendation]} · 점수 {signal.score >= 0 ? '+' : ''}{signal.score}
-      </p>
-      <p className={styles.headlineSub}>{signal.headline}</p>
+      <p className={styles.headline}>{signal.summary}</p>
+      <p className={styles.confidenceText}>{signal.confidenceSummary}</p>
 
       <div className={styles.metricList}>
         {signal.metrics.map(metric => (
@@ -41,13 +52,51 @@ export function SignalCard({ judgment, signal }: SignalCardProps) {
             <div className={styles.metricTop}>
               <span className={styles.metricLabel}>{metric.label}</span>
               <span className={`${styles.metricSignal} ${styles[`metricSignal_${metric.signal}`]}`}>
-                {metric.value}
+                {metric.status}
               </span>
             </div>
             <p className={styles.metricSummary}>{metric.summary}</p>
+            <p className={styles.metricMeta}>
+              {metric.value} · 점수 기여 {metric.contribution >= 0 ? '+' : ''}{metric.contribution.toFixed(2)}
+            </p>
           </section>
         ))}
       </div>
+
+      <details className={styles.expertPanel}>
+        <summary className={styles.expertToggle}>전문 지표 이름·수치 보기</summary>
+        <div className={styles.expertList}>
+          {signal.expertDetails.filter(detail => detail.contribution !== null).map(detail => (
+            <section key={detail.key} className={styles.expertMetric}>
+              <div className={styles.expertTop}>
+                <span className={styles.expertLabel}>{detail.title}</span>
+                <span className={styles.expertValue}>{detail.value}</span>
+              </div>
+              <p className={styles.expertStatus}>
+                {detail.status}
+                {detail.contribution ? ` · 점수 기여 ${detail.contribution}` : ''}
+              </p>
+              <p className={styles.expertDescription}>{detail.description}</p>
+            </section>
+          ))}
+
+          {signal.referenceMetrics.length > 0 && (
+            <div className={styles.referenceBlock}>
+              <p className={styles.referenceTitle}>참고 지표</p>
+              {signal.referenceMetrics.map(metric => (
+                <section key={metric.key} className={styles.referenceMetric}>
+                  <div className={styles.expertTop}>
+                    <span className={styles.expertLabel}>{metric.label}</span>
+                    <span className={styles.expertValue}>{metric.value}</span>
+                  </div>
+                  <p className={styles.expertStatus}>{metric.status}</p>
+                  <p className={styles.expertDescription}>{metric.description}</p>
+                </section>
+              ))}
+            </div>
+          )}
+        </div>
+      </details>
     </article>
   )
 }

--- a/src/lib/tradingSignals.test.ts
+++ b/src/lib/tradingSignals.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import {
+  analyzeTradingSignalIndicators,
   buildTradingSignal,
+  calculateConfidence,
   calculateMacdState,
   calculateRsi,
+  evaluateMacd,
+  evaluateRsi,
+  evaluateVolume,
+  evaluateWeek52Position,
   parseOpenInsiderActivity,
   resolveTradingSignalTarget,
 } from './tradingSignals'
@@ -90,8 +96,124 @@ describe('parseOpenInsiderActivity', () => {
   })
 })
 
+describe('metric evaluation', () => {
+  it('RSI 경계값을 새 설계대로 해석한다', () => {
+    expect(evaluateRsi(29).signal).toBe('buy')
+    expect(evaluateRsi(29).strength).toBe(0.85)
+    expect(evaluateRsi(42.3).strength).toBe(0.35)
+    expect(evaluateRsi(58).signal).toBe('neutral')
+    expect(evaluateRsi(74).signal).toBe('sell')
+    expect(evaluateRsi(84).strength).toBe(0.85)
+  })
+
+  it('MACD phase를 상승/반등/약세로 나눈다', () => {
+    expect(evaluateMacd({
+      histogram: 0.82,
+      macd: 1.2,
+      previousHistogram: 0.4,
+      signal: 0.38,
+    }).status).toBe('상승 흐름')
+
+    expect(evaluateMacd({
+      histogram: 0.32,
+      macd: 0.9,
+      previousHistogram: 0.5,
+      signal: 0.58,
+    }).status).toBe('상승 둔화')
+
+    expect(evaluateMacd({
+      histogram: -0.18,
+      macd: -0.8,
+      previousHistogram: -0.45,
+      signal: -0.62,
+    }).status).toBe('반등 조짐')
+
+    expect(evaluateMacd({
+      histogram: -0.72,
+      macd: -1.4,
+      previousHistogram: -0.5,
+      signal: -0.68,
+    }).signal).toBe('sell')
+  })
+
+  it('거래량은 최근 3일 수익률과 결합해 신호를 낸다', () => {
+    expect(evaluateVolume(1.1, 2.1).signal).toBe('neutral')
+    expect(evaluateVolume(1.8, 2.1).signal).toBe('buy')
+    expect(evaluateVolume(1.8, -2.1).signal).toBe('sell')
+  })
+
+  it('52주 위치는 설계안의 구간대로 점수를 준다', () => {
+    expect(evaluateWeek52Position(0.2).status).toBe('저점권 근접')
+    expect(evaluateWeek52Position(0.35).signal).toBe('buy')
+    expect(evaluateWeek52Position(0.6).signal).toBe('neutral')
+    expect(evaluateWeek52Position(0.82).status).toBe('고점권 경계')
+    expect(evaluateWeek52Position(0.93).signal).toBe('sell')
+  })
+})
+
+describe('calculateConfidence', () => {
+  it('핵심 지표 정렬도가 높고 점수 폭이 크면 high를 준다', () => {
+    expect(calculateConfidence([
+      { key: 'rsi', signal: 'buy' },
+      { key: 'macd', signal: 'buy' },
+      { key: 'volume', signal: 'buy' },
+      { key: 'fiftyTwoWeek', signal: 'buy' },
+    ], 0.52)).toBe('high')
+  })
+
+  it('방향은 맞지만 점수 폭이 약하면 medium을 준다', () => {
+    expect(calculateConfidence([
+      { key: 'rsi', signal: 'buy' },
+      { key: 'macd', signal: 'buy' },
+      { key: 'volume', signal: 'neutral' },
+      { key: 'fiftyTwoWeek', signal: 'neutral' },
+    ], 0.3)).toBe('medium')
+  })
+
+  it('지표가 엇갈리면 low를 준다', () => {
+    expect(calculateConfidence([
+      { key: 'rsi', signal: 'buy' },
+      { key: 'macd', signal: 'sell' },
+      { key: 'volume', signal: 'neutral' },
+      { key: 'fiftyTwoWeek', signal: 'buy' },
+    ], 0.18)).toBe('low')
+  })
+})
+
+describe('analyzeTradingSignalIndicators', () => {
+  it('설계안 예시 입력을 76점 / 분할매수 고려 / high로 변환한다', () => {
+    const analysis = analyzeTradingSignalIndicators({
+      diffFromAverage6Month: -4.2,
+      insiderActivity: { buyCount: 0, netValue: 0, sellCount: 0 },
+      macdState: {
+        histogram: 0.82,
+        macd: 1.1,
+        previousHistogram: 0.38,
+        signal: 0.28,
+      },
+      market: 'US',
+      recentReturn3d: 2.1,
+      rsi: 42.3,
+      volumeRatio: 1.8,
+      week52Band: 0.35,
+    })
+
+    expect(analysis.score).toBe(76)
+    expect(analysis.label).toBe('분할매수 고려')
+    expect(analysis.confidence).toBe('high')
+    expect(analysis.metrics.map(metric => metric.contribution.toFixed(2))).toEqual([
+      '0.42',
+      '1.20',
+      '0.60',
+      '0.32',
+    ])
+    expect(analysis.summary).toContain('가격도 합리적인 편이고')
+    expect(analysis.summary).toContain('상승 신호가 나오고 있어요.')
+  })
+})
+
 describe('buildTradingSignal', () => {
-  it('과매도 + 바닥권 조합이면 매수 추천을 준다', () => {
+  it('핵심 지표와 참고 지표를 분리해 반환한다', () => {
     const signal = buildTradingSignal({
       companyName: 'Apple',
       currentPrice: 92,
@@ -100,36 +222,17 @@ describe('buildTradingSignal', () => {
       marketSymbol: 'AAPL',
       priceHistory: Array.from({ length: 260 }, (_, index) => ({
         close: 150 - index * 0.22,
-        volume: 100_000 + index * 100,
+        volume: 100_000 + index * 150,
       })).reverse(),
       ticker: 'AAPL',
       week52High: 180,
       week52Low: 88,
     })
 
-    expect(signal.metrics).toHaveLength(6)
-    expect(signal.recommendation).toBe('buy')
-    expect(signal.metrics[0].summary).toContain('RSI')
-    expect(signal.metrics[5].label).toBe('내부자 매매')
-  })
-
-  it('과열 지표가 많으면 매도 추천을 준다', () => {
-    const signal = buildTradingSignal({
-      companyName: 'Samsung Electronics',
-      currentPrice: 220,
-      insiderActivity: { buyCount: 0, netValue: -5_000_000, sellCount: 3 },
-      market: 'KR',
-      marketSymbol: '005930.KS',
-      priceHistory: Array.from({ length: 260 }, (_, index) => ({
-        close: 100 + index * 0.5,
-        volume: 100_000 + index * 50,
-      })),
-      ticker: '005930',
-      week52High: 225,
-      week52Low: 95,
-    })
-
-    expect(signal.recommendation).toBe('sell')
-    expect(signal.metrics.some(metric => metric.signal === 'sell')).toBe(true)
+    expect(signal.metrics).toHaveLength(4)
+    expect(signal.referenceMetrics).toHaveLength(2)
+    expect(signal.expertDetails).toHaveLength(6)
+    expect(signal.label).toMatch(/분할매수 고려|관심 종목|관망 우세|주의 필요|리스크 높음/)
+    expect(signal.summary.length).toBeGreaterThan(0)
   })
 })

--- a/src/lib/tradingSignals.ts
+++ b/src/lib/tradingSignals.ts
@@ -2,6 +2,14 @@ import type { PortfolioPosition } from './types'
 
 export type TradingMarket = 'US' | 'KR'
 export type TradingRecommendation = 'buy' | 'neutral' | 'sell'
+export type TradingConfidence = 'low' | 'medium' | 'high'
+export type TradingSignalMetricKey =
+  | 'rsi'
+  | 'macd'
+  | 'volume'
+  | 'fiftyTwoWeek'
+  | 'sixMonthAverage'
+  | 'insider'
 
 export interface TradingSignalTarget {
   market: TradingMarket
@@ -21,22 +29,43 @@ export interface InsiderActivitySummary {
 }
 
 export interface TradingSignalMetric {
-  key: 'rsi' | 'macd' | 'volume' | 'fiftyTwoWeek' | 'sixMonthAverage' | 'insider'
+  contribution: number
+  description: string
+  includedInScore: boolean
+  key: TradingSignalMetricKey
   label: string
   signal: TradingRecommendation
+  strength: number
   summary: string
+  value: string
+  weight: number
+  status: string
+}
+
+export interface TradingSignalExpertDetail {
+  contribution: string | null
+  description: string
+  key: TradingSignalMetricKey
+  status: string
+  title: string
   value: string
 }
 
 export interface TradingSignal {
   companyName: string
+  confidence: TradingConfidence
+  confidenceSummary: string
+  expertDetails: TradingSignalExpertDetail[]
   fetchedAt: string
-  headline: string
+  label: string
   market: TradingMarket
   marketSymbol: string
   metrics: TradingSignalMetric[]
+  normalizedScore: number
   recommendation: TradingRecommendation
+  referenceMetrics: TradingSignalMetric[]
   score: number
+  summary: string
   ticker: string
 }
 
@@ -52,6 +81,30 @@ export interface BuildTradingSignalInput {
   week52Low: number
 }
 
+export interface BuildTradingSignalAnalysisInput {
+  diffFromAverage6Month: number
+  insiderActivity: InsiderActivitySummary
+  market: TradingMarket
+  macdState: MacdState
+  recentReturn3d: number
+  rsi: number
+  volumeRatio: number
+  week52Band: number
+}
+
+export interface TradingSignalAnalysis {
+  confidence: TradingConfidence
+  confidenceSummary: string
+  expertDetails: TradingSignalExpertDetail[]
+  label: string
+  metrics: TradingSignalMetric[]
+  normalizedScore: number
+  recommendation: TradingRecommendation
+  referenceMetrics: TradingSignalMetric[]
+  score: number
+  summary: string
+}
+
 export interface YahooSnapshot {
   companyName: string
   currentPrice: number
@@ -59,6 +112,13 @@ export interface YahooSnapshot {
   priceHistory: PriceHistoryPoint[]
   week52High: number
   week52Low: number
+}
+
+export interface MacdState {
+  histogram: number
+  macd: number
+  previousHistogram: number
+  signal: number
 }
 
 type YahooChartResponse = {
@@ -93,6 +153,15 @@ const SEC_HEADERS = {
   Accept: 'application/atom+xml, text/html;q=0.9, application/xhtml+xml;q=0.8, */*;q=0.5',
   'User-Agent': 'portfolio-doctor/1.0 help@example.com',
 }
+
+const WEIGHTS = {
+  fiftyTwoWeek: 0.9,
+  macd: 1.5,
+  rsi: 1.2,
+  volume: 1.3,
+} as const
+
+const TOTAL_WEIGHT = WEIGHTS.rsi + WEIGHTS.macd + WEIGHTS.volume + WEIGHTS.fiftyTwoWeek
 
 export const SIGNAL_CACHE_SECONDS = DAY_IN_SECONDS
 
@@ -146,21 +215,25 @@ export function calculateRsi(closes: number[], period = 14): number {
   return 100 - (100 / (1 + relativeStrength))
 }
 
-export function calculateMacdState(closes: number[]): { histogram: number; macd: number; signal: number } {
+export function calculateMacdState(closes: number[]): MacdState {
   if (closes.length < 35) {
-    return { histogram: 0, macd: 0, signal: 0 }
+    return { histogram: 0, macd: 0, previousHistogram: 0, signal: 0 }
   }
 
   const ema12 = calculateExponentialMovingAverage(closes, 12)
   const ema26 = calculateExponentialMovingAverage(closes, 26)
   const macdSeries = ema12.map((value, index) => value - ema26[index])
   const signalSeries = calculateExponentialMovingAverage(macdSeries, 9)
+  const histogramSeries = macdSeries.map((value, index) => value - signalSeries[index])
   const macd = macdSeries[macdSeries.length - 1]
   const signal = signalSeries[signalSeries.length - 1]
+  const histogram = histogramSeries[histogramSeries.length - 1]
+  const previousHistogram = histogramSeries[histogramSeries.length - 2] ?? histogram
 
   return {
-    histogram: macd - signal,
+    histogram,
     macd,
+    previousHistogram,
     signal,
   }
 }
@@ -191,6 +264,334 @@ export function parseOpenInsiderActivity(html: string): InsiderActivitySummary {
   return { buyCount, sellCount, netValue }
 }
 
+export function evaluateRsi(rsi: number): TradingSignalMetric {
+  if (rsi < 30) {
+    return createCoreMetric({
+      description: `RSI ${formatNumber(rsi)}: 최근 상승폭과 하락폭을 비교한 지표예요. 현재는 많이 눌린 저점권으로 해석됩니다.`,
+      key: 'rsi',
+      label: 'RSI',
+      signal: 'buy',
+      status: '저점권',
+      strength: 0.85,
+      summary: '많이 눌린 구간이라 반등 가능성을 볼 수 있어요.',
+      value: `RSI ${formatNumber(rsi)}`,
+    })
+  }
+
+  if (rsi < 45) {
+    return createCoreMetric({
+      description: `RSI ${formatNumber(rsi)}: 최근 상승폭과 하락폭을 비교한 지표예요. 현재는 비교적 부담이 낮은 구간으로 해석됩니다.`,
+      key: 'rsi',
+      label: 'RSI',
+      signal: 'buy',
+      status: '완만한 저점권',
+      strength: 0.35,
+      summary: '과열은 아니고, 비교적 부담이 낮은 구간이에요.',
+      value: `RSI ${formatNumber(rsi)}`,
+    })
+  }
+
+  if (rsi < 60) {
+    return createCoreMetric({
+      description: `RSI ${formatNumber(rsi)}: 최근 상승폭과 하락폭을 비교한 지표예요. 현재는 과열도 과매도도 아닌 중립 구간입니다.`,
+      key: 'rsi',
+      label: 'RSI',
+      signal: 'neutral',
+      status: '중립',
+      strength: 0,
+      summary: '가격이 과하게 싸거나 비싼 구간은 아니에요.',
+      value: `RSI ${formatNumber(rsi)}`,
+    })
+  }
+
+  if (rsi < 70) {
+    return createCoreMetric({
+      description: `RSI ${formatNumber(rsi)}: 최근 상승폭과 하락폭을 비교한 지표예요. 현재는 다소 올라왔지만 아직 극단적 과열은 아닌 중립 구간입니다.`,
+      key: 'rsi',
+      label: 'RSI',
+      signal: 'neutral',
+      status: '중립',
+      strength: 0,
+      summary: '가격이 과하게 싸거나 비싼 구간은 아니에요.',
+      value: `RSI ${formatNumber(rsi)}`,
+    })
+  }
+
+  if (rsi < 80) {
+    return createCoreMetric({
+      description: `RSI ${formatNumber(rsi)}: 최근 상승폭과 하락폭을 비교한 지표예요. 현재는 단기 과열 경계 구간으로 해석됩니다.`,
+      key: 'rsi',
+      label: 'RSI',
+      signal: 'sell',
+      status: '과열 경계',
+      strength: 0.45,
+      summary: '조금 많이 오른 상태라 쉬어갈 수 있어요.',
+      value: `RSI ${formatNumber(rsi)}`,
+    })
+  }
+
+  return createCoreMetric({
+    description: `RSI ${formatNumber(rsi)}: 최근 상승폭과 하락폭을 비교한 지표예요. 현재는 단기 과열 구간으로 해석됩니다.`,
+    key: 'rsi',
+    label: 'RSI',
+    signal: 'sell',
+    status: '강한 과열',
+    strength: 0.85,
+    summary: '단기 과열 구간이라 추격 매수는 주의가 필요해요.',
+    value: `RSI ${formatNumber(rsi)}`,
+  })
+}
+
+export function evaluateMacd(macdState: MacdState): TradingSignalMetric {
+  const improving = macdState.histogram > macdState.previousHistogram
+  const weakening = macdState.histogram < macdState.previousHistogram
+  const aboveBelow = macdState.macd >= macdState.signal ? '위' : '아래'
+  const changeDirection = improving ? '개선' : weakening ? '둔화' : '유지'
+  const value = `MACD Histogram ${formatSignedNumber(macdState.histogram)}`
+
+  if (macdState.histogram > 0 && improving) {
+    return createCoreMetric({
+      description: `${value}: MACD가 Signal 선보다 ${aboveBelow}에 있으며, 전일 대비 ${changeDirection}되고 있습니다.`,
+      key: 'macd',
+      label: 'MACD',
+      signal: 'buy',
+      status: '상승 흐름',
+      strength: 0.8,
+      summary: '상승 흐름이 이어지고 있어요.',
+      value,
+    })
+  }
+
+  if (macdState.histogram > 0 && weakening) {
+    return createCoreMetric({
+      description: `${value}: MACD가 Signal 선보다 ${aboveBelow}에 있지만, 전일 대비 ${changeDirection}되는 모습입니다.`,
+      key: 'macd',
+      label: 'MACD',
+      signal: 'buy',
+      status: '상승 둔화',
+      strength: 0.35,
+      summary: '상승 흐름은 있지만 힘은 조금 약해지고 있어요.',
+      value,
+    })
+  }
+
+  if (macdState.histogram < 0 && improving) {
+    return createCoreMetric({
+      description: `${value}: MACD가 Signal 선보다 ${aboveBelow}에 있지만, 전일 대비 ${changeDirection}되며 반등 조짐을 보이고 있습니다.`,
+      key: 'macd',
+      label: 'MACD',
+      signal: 'buy',
+      status: '반등 조짐',
+      strength: 0.45,
+      summary: '하락 흐름이 약해지고 반등 조짐이 보여요.',
+      value,
+    })
+  }
+
+  if (macdState.histogram < 0 && weakening) {
+    return createCoreMetric({
+      description: `${value}: MACD가 Signal 선보다 ${aboveBelow}에 있으며, 전일 대비 ${changeDirection}되고 있습니다.`,
+      key: 'macd',
+      label: 'MACD',
+      signal: 'sell',
+      status: '하락 압력',
+      strength: 0.75,
+      summary: '아직 하락 압력이 남아 있어요.',
+      value,
+    })
+  }
+
+  return createCoreMetric({
+    description: `${value}: MACD가 Signal 선 근처에서 비슷하게 움직여 추세 방향이 뚜렷하지 않습니다.`,
+    key: 'macd',
+    label: 'MACD',
+    signal: 'neutral',
+    status: '중립',
+    strength: 0,
+    summary: '추세 방향이 뚜렷하지 않아요.',
+    value,
+  })
+}
+
+export function evaluateVolume(volumeRatio: number, recentReturn3d: number): TradingSignalMetric {
+  if (volumeRatio < 1.2) {
+    return createCoreMetric({
+      description: `거래량 ${formatNumber(volumeRatio)}배: 최근 20일 평균 거래량 대비 현재 거래량이에요. 최근 3일 수익률은 ${formatSignedPercent(recentReturn3d)}입니다.`,
+      key: 'volume',
+      label: '거래량',
+      signal: 'neutral',
+      status: '평균 수준',
+      strength: 0,
+      summary: '거래량은 평소와 비슷해서 강한 수급 신호는 없어요.',
+      value: `거래량 ${formatNumber(volumeRatio)}배`,
+    })
+  }
+
+  const strength = Math.min(1, (volumeRatio - 1.2) / 1.3)
+  const value = `거래량 ${formatNumber(volumeRatio)}배`
+  const description = `${value}: 최근 20일 평균 거래량 대비 현재 거래량이에요. 최근 3일 수익률은 ${formatSignedPercent(recentReturn3d)}입니다.`
+
+  if (recentReturn3d > 0) {
+    return createCoreMetric({
+      description,
+      key: 'volume',
+      label: '거래량',
+      signal: 'buy',
+      status: '관심 증가',
+      strength,
+      summary: '평소보다 거래가 늘면서 관심이 붙고 있어요.',
+      value,
+    })
+  }
+
+  if (recentReturn3d < 0) {
+    return createCoreMetric({
+      description,
+      key: 'volume',
+      label: '거래량',
+      signal: 'sell',
+      status: '매도 압력',
+      strength,
+      summary: '거래가 늘었지만 가격은 밀리고 있어 매도 압력이 커 보여요.',
+      value,
+    })
+  }
+
+  return createCoreMetric({
+    description,
+    key: 'volume',
+    label: '거래량',
+    signal: 'neutral',
+    status: '방향 대기',
+    strength: 0,
+    summary: '거래량은 늘었지만 가격 방향은 아직 분명하지 않아요.',
+    value,
+  })
+}
+
+export function evaluateWeek52Position(week52Band: number): TradingSignalMetric {
+  const normalizedBand = clamp(week52Band, 0, 1)
+  const percentile = normalizedBand * 100
+  const value = `52주 위치 하위 ${formatNumber(percentile)}%`
+
+  if (normalizedBand <= 0.25) {
+    return createCoreMetric({
+      description: `${value}: 52주 저가와 고가 사이에서 현재가가 위치한 비율입니다. 최근 1년 기준으로 낮은 가격대에 있어요.`,
+      key: 'fiftyTwoWeek',
+      label: '52주 위치',
+      signal: 'buy',
+      status: '저점권 근접',
+      strength: 0.75,
+      summary: '최근 1년 기준으로 낮은 가격대에 있어요.',
+      value,
+    })
+  }
+
+  if (normalizedBand <= 0.4) {
+    return createCoreMetric({
+      description: `${value}: 52주 저가와 고가 사이에서 현재가가 위치한 비율입니다. 1년 가격 범위에서 비교적 낮은 편이에요.`,
+      key: 'fiftyTwoWeek',
+      label: '52주 위치',
+      signal: 'buy',
+      status: '낮은 가격대',
+      strength: 0.35,
+      summary: '1년 가격 범위에서 비교적 낮은 편이에요.',
+      value,
+    })
+  }
+
+  if (normalizedBand < 0.75) {
+    return createCoreMetric({
+      description: `${value}: 52주 저가와 고가 사이에서 현재가가 위치한 비율입니다. 1년 가격 범위에서 중간 구간에 있어요.`,
+      key: 'fiftyTwoWeek',
+      label: '52주 위치',
+      signal: 'neutral',
+      status: '중간 구간',
+      strength: 0,
+      summary: '1년 가격 범위에서 중간 구간에 있어요.',
+      value,
+    })
+  }
+
+  if (normalizedBand < 0.9) {
+    return createCoreMetric({
+      description: `${value}: 52주 저가와 고가 사이에서 현재가가 위치한 비율입니다. 1년 기준으로 꽤 높은 가격대에 있어요.`,
+      key: 'fiftyTwoWeek',
+      label: '52주 위치',
+      signal: 'sell',
+      status: '고점권 경계',
+      strength: 0.35,
+      summary: '1년 기준으로 꽤 높은 가격대에 있어요.',
+      value,
+    })
+  }
+
+  return createCoreMetric({
+    description: `${value}: 52주 저가와 고가 사이에서 현재가가 위치한 비율입니다. 1년 고점에 가까워 단기 부담이 있을 수 있어요.`,
+    key: 'fiftyTwoWeek',
+    label: '52주 위치',
+    signal: 'sell',
+    status: '고점권',
+    strength: 0.75,
+    summary: '1년 고점에 가까워 단기 부담이 있을 수 있어요.',
+    value,
+  })
+}
+
+export function calculateConfidence(
+  metrics: Array<Pick<TradingSignalMetric, 'key' | 'signal'>>,
+  normalizedScore: number,
+): TradingConfidence {
+  const core = metrics.filter(metric => ['rsi', 'macd', 'volume'].includes(metric.key))
+  const positive = core.filter(metric => metric.signal === 'buy').length
+  const negative = core.filter(metric => metric.signal === 'sell').length
+  const aligned = positive >= 2 || negative >= 2
+
+  if (aligned && Math.abs(normalizedScore) >= 0.45) {
+    return 'high'
+  }
+
+  if (aligned && Math.abs(normalizedScore) >= 0.25) {
+    return 'medium'
+  }
+
+  return 'low'
+}
+
+export function analyzeTradingSignalIndicators(input: BuildTradingSignalAnalysisInput): TradingSignalAnalysis {
+  const metrics = [
+    evaluateRsi(input.rsi),
+    evaluateMacd(input.macdState),
+    evaluateVolume(input.volumeRatio, input.recentReturn3d),
+    evaluateWeek52Position(input.week52Band),
+  ]
+  const referenceMetrics = [
+    buildSixMonthMetric(input.diffFromAverage6Month),
+    buildInsiderMetric(input.insiderActivity, input.market),
+  ]
+
+  const rawScore = metrics.reduce((sum, metric) => sum + metric.contribution, 0)
+  const normalizedScore = clamp(rawScore / TOTAL_WEIGHT, -1, 1)
+  const score = Math.round((normalizedScore + 1) * 50)
+  const label = resolveScoreLabel(score)
+  const recommendation = resolveRecommendation(score)
+  const confidence = calculateConfidence(metrics, normalizedScore)
+  const confidenceSummary = resolveConfidenceSummary(confidence)
+
+  return {
+    confidence,
+    confidenceSummary,
+    expertDetails: [...metrics, ...referenceMetrics].map(toExpertDetail),
+    label,
+    metrics,
+    normalizedScore,
+    recommendation,
+    referenceMetrics,
+    score,
+    summary: buildTradingSummary(metrics, label),
+  }
+}
+
 export function buildTradingSignal(input: BuildTradingSignalInput): TradingSignal {
   const closes = input.priceHistory.map(point => point.close)
   const volumes = input.priceHistory.map(point => point.volume)
@@ -199,41 +600,39 @@ export function buildTradingSignal(input: BuildTradingSignalInput): TradingSigna
   const macdState = calculateMacdState(closes)
   const averageVolume20 = average(volumes.slice(-20))
   const latestVolume = volumes[volumes.length - 1] ?? 0
-  const latestClose = closes[closes.length - 1] ?? currentPrice
-  const previousClose = closes[closes.length - 2] ?? latestClose
   const volumeRatio = averageVolume20 > 0 ? latestVolume / averageVolume20 : 1
   const week52Band = input.week52High > input.week52Low
-    ? ((currentPrice - input.week52Low) / (input.week52High - input.week52Low))
+    ? clamp((currentPrice - input.week52Low) / (input.week52High - input.week52Low), 0, 1)
     : 0.5
   const average6Month = average(closes.slice(-126))
   const diffFromAverage6Month = average6Month > 0 ? ((currentPrice - average6Month) / average6Month) * 100 : 0
-
-  const metrics: TradingSignalMetric[] = [
-    buildRsiMetric(rsi),
-    buildMacdMetric(macdState),
-    buildVolumeMetric(volumeRatio, latestClose - previousClose),
-    buildFiftyTwoWeekMetric(week52Band),
-    buildSixMonthMetric(diffFromAverage6Month),
-    buildInsiderMetric(input.insiderActivity, input.market),
-  ]
-
-  const score = metrics.reduce((sum, metric) => sum + scoreSignal(metric.signal), 0)
-  const recommendation = score >= 2 ? 'buy' : score <= -2 ? 'sell' : 'neutral'
-  const strongestMetric = [...metrics]
-    .sort((left, right) => Math.abs(scoreSignal(right.signal)) - Math.abs(scoreSignal(left.signal)))
-    .find(metric => metric.signal !== 'neutral')
+  const recentReturn3d = calculateRecentReturn(closes, 3)
+  const analysis = analyzeTradingSignalIndicators({
+    diffFromAverage6Month,
+    insiderActivity: input.insiderActivity,
+    macdState,
+    market: input.market,
+    recentReturn3d,
+    rsi,
+    volumeRatio,
+    week52Band,
+  })
 
   return {
     companyName: input.companyName,
+    confidence: analysis.confidence,
+    confidenceSummary: analysis.confidenceSummary,
+    expertDetails: analysis.expertDetails,
     fetchedAt: new Date().toISOString(),
-    headline: strongestMetric
-      ? `${input.companyName}은(는) 지금 ${strongestMetric.label} 흐름이 가장 두드러져 보여요.`
-      : `${input.companyName}은(는) 지금 뚜렷한 과열·과매도 신호가 크지 않아요.`,
+    label: analysis.label,
     market: input.market,
     marketSymbol: input.marketSymbol,
-    metrics,
-    recommendation,
-    score,
+    metrics: analysis.metrics,
+    normalizedScore: analysis.normalizedScore,
+    recommendation: analysis.recommendation,
+    referenceMetrics: analysis.referenceMetrics,
+    score: analysis.score,
+    summary: analysis.summary,
     ticker: input.ticker,
   }
 }
@@ -325,210 +724,238 @@ export async function fetchYahooSnapshot(ticker: string, market: TradingMarket):
   throw new Error(`Unable to fetch price history for ${market}:${ticker}`)
 }
 
-function buildRsiMetric(rsi: number): TradingSignalMetric {
-  if (rsi <= 35) {
-    return {
-      key: 'rsi',
-      label: 'RSI',
-      signal: 'buy',
-      summary: `RSI가 ${formatNumber(rsi)}라 많이 눌린 구간이라, 단기 반등을 노리는 매수 관점으로 볼 수 있어요.`,
-      value: `RSI ${formatNumber(rsi)}`,
-    }
-  }
-
-  if (rsi >= 70) {
-    return {
-      key: 'rsi',
-      label: 'RSI',
-      signal: 'sell',
-      summary: `RSI가 ${formatNumber(rsi)}라 단기 과열 신호가 강해서, 추격 매수보다 일부 차익 실현을 생각할 수 있어요.`,
-      value: `RSI ${formatNumber(rsi)}`,
-    }
-  }
-
-  return {
-    key: 'rsi',
-    label: 'RSI',
-    signal: 'neutral',
-    summary: `RSI가 ${formatNumber(rsi)}라 과열도 과매도도 아닌 중간 구간이라, 방향성이 더 모일 때까지 관망 구간이에요.`,
-    value: `RSI ${formatNumber(rsi)}`,
-  }
-}
-
-function buildMacdMetric(macdState: { histogram: number; macd: number; signal: number }): TradingSignalMetric {
-  if (macdState.histogram > 0) {
-    return {
-      key: 'macd',
-      label: 'MACD',
-      signal: 'buy',
-      summary: `MACD가 시그널선 위로 올라와서, 최근 상승 탄력이 붙기 시작한 흐름으로 해석할 수 있어요.`,
-      value: `히스토그램 ${formatSignedNumber(macdState.histogram)}`,
-    }
-  }
-
-  if (macdState.histogram < 0) {
-    return {
-      key: 'macd',
-      label: 'MACD',
-      signal: 'sell',
-      summary: `MACD가 시그널선 아래에 있어, 상승 힘보다 하락 압력이 더 강한 구간으로 볼 수 있어요.`,
-      value: `히스토그램 ${formatSignedNumber(macdState.histogram)}`,
-    }
-  }
-
-  return {
-    key: 'macd',
-    label: 'MACD',
-    signal: 'neutral',
-    summary: 'MACD가 기준선 근처라 매수세와 매도세가 팽팽해서, 추세 확인이 더 필요한 구간이에요.',
-    value: `히스토그램 ${formatSignedNumber(macdState.histogram)}`,
-  }
-}
-
-function buildVolumeMetric(volumeRatio: number, priceDelta: number): TradingSignalMetric {
-  const value = `20일 평균의 ${formatNumber(volumeRatio)}배`
-
-  if (volumeRatio >= 1.3 && priceDelta > 0) {
-    return {
-      key: 'volume',
-      label: '거래량',
-      signal: 'buy',
-      summary: '거래량이 평소보다 크게 늘면서 가격도 같이 올라, 매수세가 실제로 붙는지 확인되는 장면이에요.',
-      value,
-    }
-  }
-
-  if (volumeRatio >= 1.3 && priceDelta < 0) {
-    return {
-      key: 'volume',
-      label: '거래량',
-      signal: 'sell',
-      summary: '거래량이 크게 터졌는데 가격이 밀려서, 매도 압력이 강하게 나오는 구간으로 볼 수 있어요.',
-      value,
-    }
-  }
-
-  return {
-    key: 'volume',
-    label: '거래량',
-    signal: 'neutral',
-    summary: '거래량이 평소와 비슷해서, 아직은 시장 참여가 폭발적으로 몰린 구간은 아니에요.',
-    value,
-  }
-}
-
-function buildFiftyTwoWeekMetric(week52Band: number): TradingSignalMetric {
-  const percentile = week52Band * 100
-
-  if (week52Band <= 0.35) {
-    return {
-      key: 'fiftyTwoWeek',
-      label: '52주 위치',
-      signal: 'buy',
-      summary: `52주 범위의 하단 ${formatNumber(percentile)}% 근처라, 가격이 바닥권에 가까운지 체크해볼 만해요.`,
-      value: `하단에서 ${formatNumber(percentile)}%`,
-    }
-  }
-
-  if (week52Band >= 0.8) {
-    return {
-      key: 'fiftyTwoWeek',
-      label: '52주 위치',
-      signal: 'sell',
-      summary: `52주 범위의 상단 ${formatNumber(percentile)}% 근처라, 이미 많이 오른 자리인지 확인이 필요한 구간이에요.`,
-      value: `하단에서 ${formatNumber(percentile)}%`,
-    }
-  }
-
-  return {
-    key: 'fiftyTwoWeek',
-    label: '52주 위치',
-    signal: 'neutral',
-    summary: '52주 범위의 중간쯤에 있어서, 아직은 극단적으로 싸거나 비싼 자리라고 보긴 어려워요.',
-    value: `하단에서 ${formatNumber(percentile)}%`,
-  }
-}
-
 function buildSixMonthMetric(diffFromAverage6Month: number): TradingSignalMetric {
   const value = `6개월 평균 대비 ${formatSignedPercent(diffFromAverage6Month)}`
 
   if (diffFromAverage6Month <= -8) {
-    return {
+    return createReferenceMetric({
+      description: `${value}: 현재가가 6개월 평균보다 꽤 낮아 평균 회귀 관점의 저가 구간으로 볼 수 있어요.`,
       key: 'sixMonthAverage',
       label: '6개월 평균 대비',
       signal: 'buy',
-      summary: '현재가가 6개월 평균보다 꽤 낮아서, 평균 회귀 관점의 저가 구간으로 볼 수 있어요.',
+      status: '평균 대비 낮음',
+      summary: '현재가가 6개월 평균보다 꽤 낮아요.',
       value,
-    }
+    })
   }
 
   if (diffFromAverage6Month >= 10) {
-    return {
+    return createReferenceMetric({
+      description: `${value}: 현재가가 6개월 평균보다 많이 위에 있어 단기 과열로 되돌림이 나올 수 있어요.`,
       key: 'sixMonthAverage',
       label: '6개월 평균 대비',
       signal: 'sell',
-      summary: '현재가가 6개월 평균보다 많이 위에 있어, 단기 과열로 되돌림이 나올 수 있는 자리예요.',
+      status: '평균 대비 높음',
+      summary: '현재가가 6개월 평균보다 많이 위에 있어요.',
       value,
-    }
+    })
   }
 
-  return {
+  return createReferenceMetric({
+    description: `${value}: 현재가가 6개월 평균과 크게 다르지 않아 중기 기준으로는 중립 구간이에요.`,
     key: 'sixMonthAverage',
     label: '6개월 평균 대비',
     signal: 'neutral',
-    summary: '현재가가 6개월 평균과 크게 다르지 않아, 추세보다 박스권에 가까운 흐름으로 볼 수 있어요.',
+    status: '중립',
+    summary: '현재가가 6개월 평균과 크게 다르지 않아요.',
     value,
-  }
+  })
 }
 
 function buildInsiderMetric(activity: InsiderActivitySummary, market: TradingMarket): TradingSignalMetric {
   if (market !== 'US') {
-    return {
+    return createReferenceMetric({
+      description: '국내 종목은 무료 공개 소스가 제한적이라 내부자 매매는 참고용 중립 값으로 보여드려요.',
       key: 'insider',
       label: '내부자 매매',
       signal: 'neutral',
-      summary: '국내 종목은 무료 공개 소스가 제한적이라 내부자 매매는 참고용 중립 값으로 보여드려요.',
+      status: '데이터 제한',
+      summary: '국내 종목은 내부자 매매를 참고용 중립 값으로 보여드려요.',
       value: '무료 공개 데이터 제한',
-    }
+    })
   }
 
   if (activity.buyCount === 0 && activity.sellCount === 0) {
-    return {
+    return createReferenceMetric({
+      description: '최근 30일 기준으로 눈에 띄는 내부자 매매가 없어, 경영진 신호는 중립으로 볼 수 있어요.',
       key: 'insider',
       label: '내부자 매매',
       signal: 'neutral',
-      summary: '최근 30일 기준으로 눈에 띄는 내부자 매매가 없어, 경영진 신호는 중립으로 볼 수 있어요.',
+      status: '공시 없음',
+      summary: '최근 30일 내부자 공시가 뚜렷하지 않아요.',
       value: '최근 30일 공시 없음',
-    }
+    })
   }
 
   if (activity.netValue > 0) {
-    return {
+    return createReferenceMetric({
+      description: `최근 30일 내부자 순매수가 보여 회사 안쪽 인물들이 주가를 긍정적으로 보는 신호로 읽을 수 있어요.`,
       key: 'insider',
       label: '내부자 매매',
       signal: 'buy',
-      summary: `최근 30일 내부자 순매수가 보여서, 회사 안쪽 인물들이 주가를 긍정적으로 보는 신호로 읽을 수 있어요.`,
+      status: '순매수 우위',
+      summary: '최근 30일 내부자 순매수가 보여요.',
       value: `매수 ${activity.buyCount}건 / 매도 ${activity.sellCount}건`,
-    }
+    })
   }
 
   if (activity.netValue < 0) {
-    return {
+    return createReferenceMetric({
+      description: `최근 30일 내부자 순매도가 우세해 경영진이 일부 차익 실현에 나선 흐름으로 볼 수 있어요.`,
       key: 'insider',
       label: '내부자 매매',
       signal: 'sell',
-      summary: `최근 30일 내부자 순매도가 우세해서, 경영진이 일부 차익 실현에 나선 흐름으로 볼 수 있어요.`,
+      status: '순매도 우위',
+      summary: '최근 30일 내부자 순매도가 우세해요.',
       value: `매수 ${activity.buyCount}건 / 매도 ${activity.sellCount}건`,
-    }
+    })
   }
 
-  return {
+  return createReferenceMetric({
+    description: '내부자 매수와 매도가 비슷하게 섞여 있어 한쪽으로 강한 방향 신호를 주진 않아요.',
     key: 'insider',
     label: '내부자 매매',
     signal: 'neutral',
-    summary: '내부자 매수와 매도가 비슷하게 섞여 있어, 한쪽으로 강한 방향 신호를 주진 않아요.',
+    status: '혼조',
+    summary: '내부자 매수와 매도가 비슷하게 섞여 있어요.',
     value: `매수 ${activity.buyCount}건 / 매도 ${activity.sellCount}건`,
+  })
+}
+
+function buildTradingSummary(metrics: TradingSignalMetric[], label: string): string {
+  const priceMetric = metrics.find(metric => metric.key === 'fiftyTwoWeek')
+  const macdMetric = metrics.find(metric => metric.key === 'macd')
+  const volumeMetric = metrics.find(metric => metric.key === 'volume')
+
+  const pricePhrase = resolvePricePhrase(priceMetric)
+  const trendPhrase = resolveTrendPhrase(macdMetric, volumeMetric)
+  const actionGuide = resolveActionGuide(label)
+
+  return `${pricePhrase} ${trendPhrase} ${actionGuide}`
+}
+
+function resolvePricePhrase(metric?: TradingSignalMetric): string {
+  if (!metric) return '가격은 중간 구간에 있고'
+  if (metric.signal === 'buy' && metric.strength >= 0.7) return '가격 부담은 낮고'
+  if (metric.signal === 'buy') return '가격도 합리적인 편이고'
+  if (metric.signal === 'sell' && metric.strength >= 0.7) return '가격이 1년 고점권에 가까워'
+  if (metric.signal === 'sell') return '가격대가 다소 높아졌고'
+  return '가격은 중간 구간에 있고'
+}
+
+function resolveTrendPhrase(macdMetric?: TradingSignalMetric, volumeMetric?: TradingSignalMetric): string {
+  if (macdMetric?.status === '상승 흐름' && volumeMetric?.signal === 'buy') {
+    return '상승 신호가 나오고 있어요.'
   }
+
+  if (macdMetric?.status === '반등 조짐') {
+    return '하락 흐름이 약해지며 반등 조짐이 보여요.'
+  }
+
+  if (macdMetric?.signal === 'sell' && volumeMetric?.signal === 'sell') {
+    return '가격 흐름과 수급이 모두 약해 보여요.'
+  }
+
+  if (macdMetric?.signal === 'sell') {
+    return '아직 하락 압력이 남아 있어요.'
+  }
+
+  if (volumeMetric?.signal === 'buy') {
+    return '거래도 늘며 관심이 붙고 있어요.'
+  }
+
+  return '아직 뚜렷한 방향성은 강하지 않아요.'
+}
+
+function resolveActionGuide(label: string): string {
+  if (label === '분할매수 고려') {
+    return '한 번에 사기보다 조금씩 나눠서 보는 게 좋아요.'
+  }
+
+  if (label === '관심 종목') {
+    return '조금 더 흐름을 확인하면서 관심 있게 볼 만해요.'
+  }
+
+  if (label === '관망 우세') {
+    return '성급하게 움직이기보다 흐름을 더 지켜보는 게 좋아요.'
+  }
+
+  if (label === '주의 필요') {
+    return '반등 확인 전까지는 보수적으로 보는 편이 좋아요.'
+  }
+
+  return '새로 들어가기보다 반등 신호가 나올 때까지 기다리는 편이 좋아요.'
+}
+
+function resolveConfidenceSummary(confidence: TradingConfidence): string {
+  if (confidence === 'high') {
+    return '여러 핵심 지표가 같은 방향을 가리키고 있어요.'
+  }
+
+  if (confidence === 'medium') {
+    return '일부 핵심 지표가 같은 방향을 보이고 있어요.'
+  }
+
+  return '지표들이 엇갈려 조금 더 확인이 필요해요.'
+}
+
+function resolveScoreLabel(score: number): string {
+  if (score >= 75) return '분할매수 고려'
+  if (score >= 60) return '관심 종목'
+  if (score >= 45) return '관망 우세'
+  if (score >= 30) return '주의 필요'
+  return '리스크 높음'
+}
+
+function resolveRecommendation(score: number): TradingRecommendation {
+  if (score >= 60) return 'buy'
+  if (score < 45) return 'sell'
+  return 'neutral'
+}
+
+function createCoreMetric(
+  input: Omit<TradingSignalMetric, 'contribution' | 'includedInScore' | 'weight'>,
+): TradingSignalMetric {
+  const weight = WEIGHTS[input.key as keyof typeof WEIGHTS]
+  return {
+    ...input,
+    contribution: directionScore(input.signal) * input.strength * weight,
+    includedInScore: true,
+    weight,
+  }
+}
+
+function createReferenceMetric(
+  input: Omit<TradingSignalMetric, 'contribution' | 'includedInScore' | 'strength' | 'weight'>,
+): TradingSignalMetric {
+  return {
+    ...input,
+    contribution: 0,
+    includedInScore: false,
+    strength: 0,
+    weight: 0,
+  }
+}
+
+function toExpertDetail(metric: TradingSignalMetric): TradingSignalExpertDetail {
+  return {
+    contribution: metric.includedInScore ? formatContribution(metric.contribution) : null,
+    description: metric.description,
+    key: metric.key,
+    status: metric.status,
+    title: metric.label,
+    value: metric.value,
+  }
+}
+
+function calculateRecentReturn(closes: number[], days: number): number {
+  if (closes.length <= days) return 0
+
+  const latest = closes[closes.length - 1]
+  const baseline = closes[closes.length - 1 - days]
+  if (!baseline) return 0
+
+  return ((latest - baseline) / baseline) * 100
 }
 
 function average(values: number[]): number {
@@ -550,6 +977,16 @@ function calculateExponentialMovingAverage(values: number[], period: number): nu
   return ema
 }
 
+function directionScore(signal: TradingRecommendation): number {
+  if (signal === 'buy') return 1
+  if (signal === 'sell') return -1
+  return 0
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
 function formatNumber(value: number): string {
   return value.toFixed(1).replace(/\.0$/, '')
 }
@@ -562,16 +999,14 @@ function formatSignedPercent(value: number): string {
   return `${value >= 0 ? '+' : ''}${formatNumber(value)}%`
 }
 
+function formatContribution(value: number): string {
+  return `${value >= 0 ? '+' : ''}${value.toFixed(2)}`
+}
+
 function parseMoney(value: string): number {
   const normalized = value.replace(/[,$]/g, '')
   const parsed = Number(normalized)
   return Number.isFinite(parsed) ? parsed : 0
-}
-
-function scoreSignal(signal: TradingRecommendation): number {
-  if (signal === 'buy') return 1
-  if (signal === 'sell') return -1
-  return 0
 }
 
 function stripHtml(value: string): string {


### PR DESCRIPTION
## What changed
- 종목 시그널 점수를 RSI, MACD, 거래량, 52주 위치 4개 핵심 지표 기반의 0~100 점수 체계로 재구성했습니다.
- 종목 카드를 시장 결합 판단에서 분리하고, 점수·주 라벨·confidence·쉬운 요약 중심으로 다시 구성했습니다.
- 전문 지표 상세를 접힘 영역으로 정리하고, 6개월 평균과 내부자 매매는 참고 지표로 분리했습니다.
- `/signals` 페이지에서 시장 배너와 시장 결합 판단 의존성을 제거했습니다.
- 종목 시그널 계산과 카드 렌더링에 대한 회귀 테스트를 추가했습니다.

## Why
- 사용자가 종목 페이지에서 시장 해석이 아니라 종목 자체 진입 타이밍을 바로 읽을 수 있어야 합니다.
- 시장 정보는 별도 시장 페이지로 분리하기로 했고, 종목 페이지는 자체 점수/설명 모델에 집중해야 합니다.

## Validation
- `COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm@9.15.4 verify`

## Notes
- This is a stacked PR on top of `feat/diagnosis-redesign`.
- Related #88
