### PR TITLE
feat: /market hero를 진입 매력도·시장 건강도 KPI 구조로 재구성

### DIFF
--- a/src/app/market/page.module.css
+++ b/src/app/market/page.module.css
@@ -35,7 +35,7 @@
 
 .heroCard {
   display: grid;
-  gap: 16px;
+  gap: 14px;
   margin-top: 20px;
   padding: 20px;
   border-radius: 24px;
@@ -43,26 +43,109 @@
   border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
-.heroLabel {
-  font-size: 12px;
+/* 메인 KPI: 진입 매력도 */
+.entryBlock { display: grid; gap: 6px; }
+
+.kpiEyebrow {
+  font-size: 11px;
   font-weight: 800;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.68);
+  color: rgba(255, 255, 255, 0.6);
 }
 
-.heroValue {
-  margin-top: 10px;
-  font-size: 34px;
+.kpiLabel {
+  font-size: 28px;
   font-weight: 900;
-  letter-spacing: -0.05em;
+  letter-spacing: -0.04em;
+  line-height: 1.1;
 }
 
-.heroSummary {
-  margin-top: 10px;
-  font-size: 14px;
+.kpiScore {
+  display: flex;
+  align-items: baseline;
+  gap: 3px;
+  margin-top: 2px;
+}
+
+.kpiScoreNum {
+  font-size: 42px;
+  font-weight: 900;
+  letter-spacing: -0.06em;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.kpiScoreUnit {
+  font-size: 16px;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.56);
+}
+
+.kpiSummary {
+  margin-top: 6px;
+  font-size: 13px;
   line-height: 1.65;
-  color: rgba(255, 255, 255, 0.82);
+  color: rgba(255, 255, 255, 0.78);
+}
+
+/* 서브 KPI: 시장 건강도 */
+.healthChip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 14px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.healthEyebrow {
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.56);
+  flex-shrink: 0;
+}
+
+.healthLabel {
+  font-size: 14px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  flex: 1;
+}
+
+.healthScore {
+  font-size: 12px;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.56);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+/* 투자 시사점 */
+.implication {
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  display: grid;
+  gap: 6px;
+}
+
+.implicationLabel {
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.56);
+}
+
+.implicationText {
+  font-size: 13px;
+  line-height: 1.65;
+  color: rgba(255, 255, 255, 0.84);
 }
 
 .heroMeta {
@@ -70,28 +153,6 @@
   flex-wrap: wrap;
   gap: 10px;
   align-items: center;
-}
-
-.badge {
-  border-radius: 999px;
-  padding: 9px 12px;
-  font-size: 12px;
-  font-weight: 800;
-}
-
-.badge_risk_on {
-  background: rgba(5, 150, 105, 0.16);
-  color: #d8fff1;
-}
-
-.badge_neutral {
-  background: rgba(217, 119, 6, 0.16);
-  color: #ffefcf;
-}
-
-.badge_risk_off {
-  background: rgba(220, 38, 38, 0.16);
-  color: #ffd6d6;
 }
 
 .refreshButton,
@@ -206,6 +267,13 @@
   width: 72%;
 }
 
+.source {
+  margin-top: 20px;
+  font-size: 11px;
+  color: var(--text-3);
+  text-align: center;
+}
+
 @media (min-width: 768px) {
   .header {
     padding: 32px 32px 36px;
@@ -219,11 +287,6 @@
 
   .body {
     padding: 0 24px 64px;
-  }
-
-  .heroCard {
-    grid-template-columns: minmax(0, 1fr) auto;
-    align-items: end;
   }
 
   .cardGrid {

--- a/src/app/market/page.tsx
+++ b/src/app/market/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { MarketCard } from '@/components/MarketCard'
-import { formatMacroStateLabel, type MarketResponse } from '@/lib/marketSignals'
+import type { MarketResponse } from '@/lib/marketSignals'
 import { loadMarketSignals } from '@/lib/marketSignalsClient'
 import styles from './page.module.css'
 
@@ -48,29 +48,53 @@ export default function MarketPage() {
     }
   }
 
+  const entry = market?.overview.entry
+  const health = market?.overview.health
+
   return (
     <div className={styles.wrap}>
       <div className={styles.header}>
         <div className={styles.eyebrow}>Macro Market Engine</div>
         <h1 className={styles.title}>오늘 시장 바람이 주식에 우호적인지 한 화면에서 확인해보세요.</h1>
-        <p className={styles.sub}>
-          장단기 금리차, 하이일드 스프레드, M2, Fear&amp;Greed, ERP를 묶어 Risk-On / 중립 / Risk-Off로 정리했어요.
-        </p>
 
         <div className={styles.heroCard}>
-          <div>
-            <div className={styles.heroLabel}>시장 상태</div>
-            <div className={styles.heroValue}>
-              {loading ? '정리 중…' : formatMacroStateLabel(market?.macroState ?? 'neutral')}
+          {/* 메인 KPI: 진입 매력도 */}
+          <div className={styles.entryBlock}>
+            <div className={styles.kpiEyebrow}>진입 매력도</div>
+            <div className={styles.kpiLabel}>
+              {loading ? '분석 중…' : (entry?.label ?? '중립')}
             </div>
-            <p className={styles.heroSummary}>
-              {error ?? market?.headline ?? '외부 시장 데이터를 불러오는 중입니다.'}
+            <div className={styles.kpiScore}>
+              <span className={styles.kpiScoreNum}>
+                {loading ? '--' : (entry?.score ?? 50)}
+              </span>
+              <span className={styles.kpiScoreUnit}>/100</span>
+            </div>
+            <p className={styles.kpiSummary}>
+              {loading ? '' : (entry?.summary ?? '')}
             </p>
           </div>
-          <div className={styles.heroMeta}>
-            <span className={`${styles.badge} ${styles[`badge_${market?.macroState ?? 'neutral'}`]}`}>
-              점수 {loading ? '...' : market?.macroScore ?? 0}
+
+          {/* 서브 KPI: 시장 건강도 */}
+          <div className={styles.healthChip}>
+            <span className={styles.healthEyebrow}>시장 건강도</span>
+            <span className={styles.healthLabel}>
+              {loading ? '--' : (health?.label ?? '중립')}
             </span>
+            <span className={styles.healthScore}>
+              {loading ? '' : `${health?.score ?? 50}/100`}
+            </span>
+          </div>
+
+          {/* 투자 시사점 */}
+          {!loading && entry?.guide && (
+            <div className={styles.implication}>
+              <span className={styles.implicationLabel}>투자 시사점</span>
+              <p className={styles.implicationText}>{entry.guide}</p>
+            </div>
+          )}
+
+          <div className={styles.heroMeta}>
             <button className={styles.refreshButton} onClick={() => void handleRefresh()}>
               최신 시장 다시 보기
             </button>
@@ -121,6 +145,8 @@ export default function MarketPage() {
                 <MarketCard key={indicator.key} indicator={indicator} />
               ))}
             </div>
+
+            <p className={styles.source}>데이터 출처: FRED, onoff.markets, multpl.com</p>
           </>
         )}
       </div>

--- a/src/components/MarketCard.module.css
+++ b/src/components/MarketCard.module.css
@@ -2,29 +2,65 @@
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 20px;
-  padding: 18px;
+  overflow: hidden;
   box-shadow: 0 14px 28px rgba(18, 24, 88, 0.06);
 }
 
-.header {
+.toggle {
+  width: 100%;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 16px 18px;
   display: flex;
   align-items: flex-start;
-  justify-content: space-between;
   gap: 12px;
+  text-align: left;
+  font-family: inherit;
+}
+
+.toggle:active {
+  background: rgba(26, 35, 126, 0.03);
+}
+
+.toggleLeft {
+  flex: 1;
+  min-width: 0;
+}
+
+.toggleRight {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
 }
 
 .title {
-  font-size: 18px;
+  font-size: 15px;
   font-weight: 800;
-  letter-spacing: -0.03em;
+  letter-spacing: -0.02em;
   color: var(--text-1);
+  margin-bottom: 6px;
+}
+
+.summary {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text-2);
+}
+
+.summaryClamp {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .badge {
-  flex-shrink: 0;
   border-radius: 999px;
-  padding: 7px 11px;
-  font-size: 12px;
+  padding: 5px 10px;
+  font-size: 11px;
   font-weight: 800;
 }
 
@@ -48,26 +84,65 @@
   color: var(--navy);
 }
 
-.value {
-  margin-top: 14px;
-  font-size: 28px;
-  font-weight: 900;
-  letter-spacing: -0.05em;
-  color: var(--navy-dark);
+.arrow {
+  font-size: 12px;
+  color: var(--text-3);
+  transition: transform 0.2s;
+  display: inline-block;
+  margin-top: 2px;
 }
 
-.summary {
-  margin-top: 12px;
-  font-size: 14px;
+.arrowOpen {
+  transform: rotate(180deg);
+}
+
+.body {
+  border-top: 1px solid rgba(26, 35, 126, 0.08);
+  padding: 14px 18px 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.guide {
+  font-size: 13px;
   line-height: 1.65;
   color: var(--text-2);
 }
 
-.guide {
-  margin-top: 12px;
-  padding-top: 12px;
-  border-top: 1px solid rgba(26, 35, 126, 0.08);
-  font-size: 13px;
-  line-height: 1.6;
-  color: var(--text-2);
+.techToggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-3);
+  font-family: inherit;
+}
+
+.techArrow {
+  font-size: 10px;
+  transition: transform 0.2s;
+  display: inline-block;
+}
+
+.techArrowOpen {
+  transform: rotate(90deg);
+}
+
+.techBox {
+  background: rgba(232, 234, 246, 0.45);
+  border-radius: 12px;
+  padding: 12px 14px;
+}
+
+.techValue {
+  font-size: 20px;
+  font-weight: 900;
+  letter-spacing: -0.04em;
+  color: var(--navy-dark);
+  font-variant-numeric: tabular-nums;
 }

--- a/src/components/MarketCard.tsx
+++ b/src/components/MarketCard.tsx
@@ -1,3 +1,6 @@
+'use client'
+
+import { useState } from 'react'
 import type { MarketIndicator, MarketIndicatorStatus } from '@/lib/marketSignals'
 import styles from './MarketCard.module.css'
 
@@ -13,18 +16,49 @@ const STATUS_LABEL: Record<MarketIndicatorStatus, string> = {
 }
 
 export function MarketCard({ indicator }: MarketCardProps) {
+  const [open, setOpen] = useState(false)
+  const [techOpen, setTechOpen] = useState(false)
+
   return (
     <article className={styles.card}>
-      <div className={styles.header}>
-        <h2 className={styles.title}>{indicator.label}</h2>
-        <span className={`${styles.badge} ${styles[`badge_${indicator.status}`]}`}>
-          {STATUS_LABEL[indicator.status]}
-        </span>
-      </div>
+      <button
+        type="button"
+        className={styles.toggle}
+        onClick={() => setOpen(o => !o)}
+        aria-expanded={open}
+      >
+        <div className={styles.toggleLeft}>
+          <h2 className={styles.title}>{indicator.label}</h2>
+          <p className={`${styles.summary} ${open ? '' : styles.summaryClamp}`}>
+            {indicator.summary}
+          </p>
+        </div>
+        <div className={styles.toggleRight}>
+          <span className={`${styles.badge} ${styles[`badge_${indicator.status}`]}`}>
+            {STATUS_LABEL[indicator.status]}
+          </span>
+          <span className={`${styles.arrow} ${open ? styles.arrowOpen : ''}`}>▾</span>
+        </div>
+      </button>
 
-      <div className={styles.value}>{indicator.value}</div>
-      <p className={styles.summary}>{indicator.summary}</p>
-      <p className={styles.guide}>초보자 메모: {indicator.guide}</p>
+      {open && (
+        <div className={styles.body}>
+          <p className={styles.guide}>{indicator.guide}</p>
+          <button
+            type="button"
+            className={styles.techToggle}
+            onClick={() => setTechOpen(o => !o)}
+          >
+            <span className={`${styles.techArrow} ${techOpen ? styles.techArrowOpen : ''}`}>▸</span>
+            <span>실제 지표 수치 보기 (금리차, 스프레드 등)</span>
+          </button>
+          {techOpen && (
+            <div className={styles.techBox}>
+              <div className={styles.techValue}>{indicator.value}</div>
+            </div>
+          )}
+        </div>
+      )}
     </article>
   )
 }

--- a/src/lib/marketSignals.ts
+++ b/src/lib/marketSignals.ts
@@ -15,12 +15,25 @@ export interface MarketIndicator {
   value: string
 }
 
+export interface MarketEntryKPI {
+  guide: string
+  label: string
+  score: number
+  summary: string
+}
+
+export interface MarketOverview {
+  entry: MarketEntryKPI
+  health: MarketEntryKPI
+}
+
 export interface MarketResponse {
   fetchedAt: string
   headline: string
   indicators: MarketIndicator[]
   macroScore: number
   macroState: MacroState
+  overview: MarketOverview
 }
 
 interface MarketSnapshotInput {
@@ -98,6 +111,7 @@ export function buildMarketResponse(input: MarketSnapshotInput): MarketResponse 
     indicators,
     macroScore,
     macroState,
+    overview: buildOverview(indicators),
   }
 }
 
@@ -474,4 +488,108 @@ function formatNumber(value: number): string {
 
 function formatSignedNumber(value: number): string {
   return `${value >= 0 ? '+' : ''}${formatNumber(value)}`
+}
+
+function invertStatus(status: MarketIndicatorStatus): MarketIndicatorStatus {
+  if (status === 'positive') return 'negative'
+  if (status === 'negative') return 'positive'
+  return status
+}
+
+function computeKPIScore(
+  indicators: MarketIndicator[],
+  invertFearGreed: boolean,
+): number {
+  const scored = indicators.filter(i => i.status !== 'unavailable')
+  if (scored.length === 0) return 50
+
+  const total = scored.reduce((sum, i) => {
+    const status = (invertFearGreed && i.key === 'fearGreed')
+      ? invertStatus(i.status)
+      : i.status
+    return sum + scoreIndicator(status)
+  }, 0)
+
+  return Math.round(((total / scored.length) + 1) * 50)
+}
+
+function buildEntryKPI(score: number): MarketEntryKPI {
+  if (score >= 70) return {
+    guide: '새로운 자금을 분할 매수로 천천히 진입하거나 비중을 늘려볼 수 있는 환경이에요.',
+    label: '매력적인 환경',
+    score,
+    summary: '주식 기대수익이 채권보다 높고 투자심리도 저점권에 있어 진입 매력도가 높아요.',
+  }
+  if (score >= 55) return {
+    guide: '기존 포트폴리오를 유지하면서 여유 자금은 조금씩 추가해볼 수 있어요.',
+    label: '우호적',
+    score,
+    summary: '시장 환경이 전반적으로 주식에 우호적인 구간이에요.',
+  }
+  if (score >= 45) return {
+    guide: '현재 비중을 유지하면서 방향을 지켜보는 게 좋아요.',
+    label: '중립',
+    score,
+    summary: '매력도가 한쪽으로 크게 기울지 않아 서두를 이유가 없는 구간이에요.',
+  }
+  if (score >= 30) return {
+    guide: '무리한 추가 매수보다 현재 비중 유지나 일부 조정을 고려해보세요.',
+    label: '신중 필요',
+    score,
+    summary: '주식 매력도가 채권 대비 줄어들고 있어 신중한 접근이 필요해요.',
+  }
+  return {
+    guide: '주식 비중을 줄이거나 현금·채권 비중을 높이는 전략을 고려해보세요.',
+    label: '경계 구간',
+    score,
+    summary: '진입 매력도가 낮은 구간이에요. 방어적으로 접근하는 게 좋아요.',
+  }
+}
+
+function buildHealthKPI(score: number): MarketEntryKPI {
+  if (score >= 70) return {
+    guide: '',
+    label: '안정적',
+    score,
+    summary: '금리 구조와 신용·유동성 환경이 모두 양호해 시장 구조가 건강해요.',
+  }
+  if (score >= 55) return {
+    guide: '',
+    label: '양호',
+    score,
+    summary: '시장 구조 지표 대부분이 건강한 편이에요.',
+  }
+  if (score >= 45) return {
+    guide: '',
+    label: '중립',
+    score,
+    summary: '건강 지표들이 혼재되어 있어 중립적인 시장 환경이에요.',
+  }
+  if (score >= 30) return {
+    guide: '',
+    label: '주의',
+    score,
+    summary: '금리나 신용 환경 일부에서 경고 신호가 나오고 있어요.',
+  }
+  return {
+    guide: '',
+    label: '경계',
+    score,
+    summary: '금리 역전, 신용 위험 등 구조적 경고가 복수로 나타나고 있어요.',
+  }
+}
+
+function buildOverview(indicators: MarketIndicator[]): MarketOverview {
+  // 진입 매력도: ERP(주식 vs 채권) + Fear&Greed(역발상 — 공포일수록 매력)
+  const entryIndicators = indicators.filter(i => ['erp', 'fearGreed'].includes(i.key))
+  const entryScore = computeKPIScore(entryIndicators, true)
+
+  // 시장 건강도: 금리 구조 + 신용 환경 + 유동성
+  const healthIndicators = indicators.filter(i => ['yieldCurve', 'creditSpread', 'm2'].includes(i.key))
+  const healthScore = computeKPIScore(healthIndicators, false)
+
+  return {
+    entry: buildEntryKPI(entryScore),
+    health: buildHealthKPI(healthScore),
+  }
 }


### PR DESCRIPTION
## Summary
- `/market` 상단 hero를 진입 매력도(메인 KPI) + 시장 건강도(서브 KPI) 구조로 재구성
- `MarketResponse`에 `overview.entry` / `overview.health` 추가 (기존 `macroState` / `indicators` 호환 유지)
- 5개 지표 카드 → accordion 전환, 내부 수치 토글 문구 변경

## Changes
- `src/lib/marketSignals.ts` — `MarketOverview` 인터페이스 + `buildOverview()` 추가
  - 진입 매력도: ERP(주식 vs 채권) + Fear&Greed 역발상(공포 = 매력) → 0-100점
  - 시장 건강도: 장단기 금리차 + 하이일드 스프레드 + M2 → 0-100점
- `src/app/market/page.tsx` — 진입 매력도 메인 KPI + 시장 건강도 서브 chip + 투자 시사점 박스
- `src/app/market/page.module.css` — 새 hero KPI 레이아웃 스타일
- `src/components/MarketCard.tsx` — accordion 전환, '실제 지표 수치 보기 (금리차, 스프레드 등)' 토글
- `src/components/MarketCard.module.css` — accordion 스타일

## Test plan
- [ ] `pnpm verify` 통과 (22 test files, 131 tests)
- [ ] /market 페이지 로드 시 진입 매력도 KPI 표시 확인
- [ ] 시장 건강도 서브 chip 표시 확인
- [ ] 투자 시사점 박스 표시 확인
- [ ] 각 지표 카드 클릭 시 accordion 펼침/닫힘 확인
- [ ] '실제 지표 수치 보기' 토글 작동 확인
- [ ] 출처 텍스트 페이지 하단 표시 확인

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)