### PR TITLE
[codex] signals stock card redesign and shared nav

### DIFF
--- a/src/app/diagnosis/page.module.css
+++ b/src/app/diagnosis/page.module.css
@@ -64,7 +64,7 @@
   letter-spacing: -0.04em;
 }
 
-.body { padding: 14px 16px 100px; display: flex; flex-direction: column; gap: 8px; }
+.body { padding: 14px 16px 112px; display: flex; flex-direction: column; gap: 8px; }
 
 .improvementSection {
   display: flex;

--- a/src/app/diagnosis/page.tsx
+++ b/src/app/diagnosis/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { ProblemCard } from '@/components/ProblemCard'
 import { AllocationBar } from '@/components/AllocationBar'
 import { ActionItem } from '@/components/ActionItem'
+import { BottomNav } from '@/components/BottomNav'
 import { SectorPieChart } from '@/components/SectorPieChart'
 import { ImprovementSheet } from '@/components/ImprovementSheet'
 import { DIAGNOSIS_DISCLAIMER_LINES } from '@/lib/disclaimers'
@@ -322,6 +323,7 @@ export default function DiagnosisPage() {
         open={sheetOpen}
         onClose={() => setSheetOpen(false)}
       />
+      <BottomNav />
     </div>
   )
 }

--- a/src/app/market/page.module.css
+++ b/src/app/market/page.module.css
@@ -114,7 +114,7 @@
 }
 
 .body {
-  padding: 0 16px 48px;
+  padding: 0 16px 112px;
 }
 
 .actions {
@@ -218,7 +218,7 @@
   }
 
   .body {
-    padding: 0 24px 64px;
+    padding: 0 24px 128px;
   }
 
   .heroCard {

--- a/src/app/market/page.tsx
+++ b/src/app/market/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { BottomNav } from '@/components/BottomNav'
 import { MarketCard } from '@/components/MarketCard'
 import { formatMacroStateLabel, type MarketResponse } from '@/lib/marketSignals'
 import { loadMarketSignals } from '@/lib/marketSignalsClient'
@@ -124,6 +125,7 @@ export default function MarketPage() {
           </>
         )}
       </div>
+      <BottomNav />
     </div>
   )
 }

--- a/src/app/signals/page.module.css
+++ b/src/app/signals/page.module.css
@@ -1,43 +1,42 @@
 .wrap {
   min-height: 100dvh;
   background:
-    radial-gradient(circle at top right, rgba(255, 255, 255, 0.22), transparent 32%),
-    linear-gradient(180deg, var(--navy) 0 240px, var(--bg) 240px 100%);
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.9), transparent 34%),
+    linear-gradient(180deg, #eef1f7 0%, #e8ecf6 100%);
 }
 
 .header {
-  padding: 24px 20px 28px;
-  color: #fff;
+  padding: 18px 20px 10px;
+  color: #111827;
 }
 
 .eyebrow {
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.64);
+  font-size: 13px;
+  font-weight: 700;
+  color: #9aa0aa;
 }
 
 .title {
-  margin-top: 10px;
-  font-size: 31px;
-  line-height: 1.12;
+  margin-top: 8px;
+  font-size: 28px;
+  line-height: 1.05;
+  font-weight: 900;
   letter-spacing: -0.05em;
 }
 
 .sub {
-  margin-top: 12px;
+  margin-top: 14px;
   max-width: 560px;
-  font-size: 14px;
-  line-height: 1.7;
-  color: rgba(255, 255, 255, 0.78);
+  font-size: 12px;
+  line-height: 1.6;
+  color: #a8adb7;
 }
 
 .metaRow {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
-  margin-top: 16px;
+  margin-top: 12px;
 }
 
 .metaBadge,
@@ -49,24 +48,26 @@
 }
 
 .metaBadge {
-  background: rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.8);
+  color: var(--navy);
+  border: 1px solid rgba(26, 35, 126, 0.08);
 }
 
 .metaHint {
-  background: rgba(255, 255, 255, 0.08);
-  color: rgba(255, 255, 255, 0.75);
+  background: rgba(255, 255, 255, 0.55);
+  color: #8e95a3;
 }
 
 .body {
-  padding: 0 16px 40px;
+  padding: 0 16px 112px;
 }
 
 .actions {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
-  margin-top: 16px;
-  margin-bottom: 16px;
+  margin-top: 18px;
+  margin-bottom: 8px;
 }
 
 .primaryButton,
@@ -95,6 +96,75 @@
   gap: 14px;
 }
 
+.summaryCard {
+  margin-bottom: 16px;
+  padding: 18px 16px;
+  border: 1px solid rgba(15, 23, 42, 0.04);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 16px 42px rgba(15, 23, 42, 0.08);
+}
+
+.summaryHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.summaryTitle {
+  font-size: 16px;
+  line-height: 1.2;
+  letter-spacing: -0.04em;
+  color: #111827;
+}
+
+.summaryChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.summaryTiles {
+  display: flex;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.summaryTile {
+  flex: 1;
+  padding: 18px 10px;
+  border-radius: 18px;
+  text-align: center;
+}
+
+.summaryTileValue {
+  font-size: 42px;
+  font-weight: 900;
+  letter-spacing: -0.04em;
+  line-height: 1;
+}
+
+.summaryTileLabel {
+  margin-top: 8px;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.35;
+  white-space: pre-line;
+}
+
+.summaryLegend {
+  margin-top: 18px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: #f7f7fb;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.6;
+  color: #5f6571;
+}
+
 .stateCard {
   background: rgba(255, 255, 255, 0.88);
   border: 1px solid var(--border);
@@ -117,11 +187,25 @@
   .body {
     max-width: 920px;
     margin: 0 auto;
-    padding: 0 24px 56px;
+    padding: 0 24px 128px;
   }
 
   .cardList {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     align-items: start;
+  }
+
+  .summaryCard {
+    padding: 22px;
+  }
+}
+
+@media (max-width: 479px) {
+  .summaryTiles {
+    flex-wrap: wrap;
+  }
+
+  .summaryTile {
+    min-width: calc(33.333% - 6px);
   }
 }

--- a/src/app/signals/page.test.ts
+++ b/src/app/signals/page.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('SignalsPage source', () => {
+  it('시장 배너와 시장 데이터 의존성 없이 종목 점수 화면으로 유지된다', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).not.toContain('MarketBanner')
+    expect(source).not.toContain('loadMarketSignals')
+    expect(source).not.toContain('resolveFinalJudgment')
+    expect(source).toContain('RSI · MACD · 거래량 · 52주 위치, 4가지 지표로 종목 점수를 산출합니다.')
+  })
+})

--- a/src/app/signals/page.tsx
+++ b/src/app/signals/page.tsx
@@ -2,13 +2,10 @@
 
 import { useEffect, useMemo, useState, useSyncExternalStore } from 'react'
 import { useRouter } from 'next/navigation'
-import { resolveFinalJudgment } from '@/lib/finalJudgment'
-import { loadMarketSignals } from '@/lib/marketSignalsClient'
+import { BottomNav } from '@/components/BottomNav'
 import { SignalCard } from '@/components/SignalCard'
-import { MarketBanner } from '@/components/MarketBanner'
 import { listSignalTargets, loadTradingSignals } from '@/lib/tradingSignalsClient'
 import { SESSION_KEYS, type PortfolioPosition } from '@/lib/types'
-import type { MarketResponse } from '@/lib/marketSignals'
 import type { TradingSignal } from '@/lib/tradingSignals'
 import styles from './page.module.css'
 
@@ -46,12 +43,45 @@ export default function SignalsPage() {
   )
   const positions = useMemo(() => (isClient ? readConfirmedPositions() : []), [isClient])
   const [signals, setSignals] = useState<TradingSignal[]>([])
-  const [market, setMarket] = useState<MarketResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [marketLoading, setMarketLoading] = useState(true)
-  const [marketError, setMarketError] = useState<string | null>(null)
   const supportedCount = useMemo(() => listSignalTargets(positions).length, [positions])
+  const sectorByTarget = useMemo(() => {
+    const entries = new Map<string, string>()
+
+    for (const position of positions) {
+      if (
+        (position.assetClass !== '국내주식' && position.assetClass !== '해외주식')
+        || !position.code
+        || !position.sector
+      ) {
+        continue
+      }
+
+      const normalizedTicker = position.assetClass === '국내주식'
+        ? position.code.trim()
+        : position.code.trim().toUpperCase()
+      const market = position.assetClass === '국내주식' ? 'KR' : 'US'
+      const key = `${market}:${normalizedTicker}`
+
+      if (!entries.has(key)) {
+        entries.set(key, position.sector)
+      }
+    }
+
+    return entries
+  }, [positions])
+  const groupedSummaryItems = useMemo(() => {
+    const accumulateCount = signals.filter(signal => signal.score >= 70).length
+    const watchCount = signals.filter(signal => signal.score >= 50 && signal.score < 70).length
+    const cautionCount = signals.filter(signal => signal.score >= 30 && signal.score < 50).length
+
+    return [
+      { color: 'var(--green)', count: accumulateCount, label: '분할매수\n고려' },
+      { color: 'var(--amber)', count: watchCount, label: '관심\n종목' },
+      { color: '#9ca3af', count: cautionCount, label: '관망 우세' },
+    ]
+  }, [signals])
   const unsupportedCount = Math.max(
     positions.filter(position => position.assetClass === '국내주식' || position.assetClass === '해외주식').length - supportedCount,
     0,
@@ -60,8 +90,6 @@ export default function SignalsPage() {
   async function handleRefresh() {
     setLoading(true)
     setError(null)
-    setMarketLoading(true)
-    setMarketError(null)
 
     try {
       setSignals(await loadTradingSignals(positions))
@@ -69,14 +97,6 @@ export default function SignalsPage() {
       setError('종목 시그널을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.')
     } finally {
       setLoading(false)
-    }
-
-    try {
-      setMarket(await loadMarketSignals(true))
-    } catch {
-      setMarketError('거시 지표를 바로 불러오지 못했어요.')
-    } finally {
-      setMarketLoading(false)
     }
   }
 
@@ -102,15 +122,6 @@ export default function SignalsPage() {
       } finally {
         if (active) setLoading(false)
       }
-
-      try {
-        const nextMarket = await loadMarketSignals()
-        if (active) setMarket(nextMarket)
-      } catch {
-        if (active) setMarketError('거시 지표를 바로 불러오지 못했어요.')
-      } finally {
-        if (active) setMarketLoading(false)
-      }
     }
 
     void hydrateSignals()
@@ -125,29 +136,14 @@ export default function SignalsPage() {
   return (
     <div className={styles.wrap}>
       <div className={styles.header}>
-        <div className={styles.eyebrow}>종목 시그널 분석</div>
-        <h1 className={styles.title}>각 종목이 지금 보내는 신호를 한 번에 확인해보세요.</h1>
+        <div className={styles.eyebrow}>Stock Analysis</div>
+        <h1 className={styles.title}>종목 분석</h1>
         <p className={styles.sub}>
-          RSI, MACD, 거래량, 52주 위치, 6개월 평균, 내부자 매매를 종목 카드에 담고, 위에는 오늘 시장 온도를 따로 얹어 보여드려요.
+          RSI · MACD · 거래량 · 52주 위치, 4가지 지표로 종목 점수를 산출합니다.
         </p>
-        <div className={styles.metaRow}>
-          <span className={styles.metaBadge}>분석 가능 {supportedCount}종목</span>
-          {unsupportedCount > 0 && <span className={styles.metaHint}>코드 없는 {unsupportedCount}종목은 제외됐어요.</span>}
-        </div>
       </div>
 
       <div className={styles.body}>
-        <MarketBanner error={marketError} loading={marketLoading} market={market} />
-
-        <div className={styles.actions}>
-          <button className={styles.secondaryButton} onClick={() => router.push('/diagnosis')}>
-            ← 진단 결과로 돌아가기
-          </button>
-          <button className={styles.primaryButton} onClick={() => void handleRefresh()}>
-            최신 신호 다시 보기
-          </button>
-        </div>
-
         {loading && <div className={styles.stateCard}>종목별 시그널을 계산하고 있습니다…</div>}
 
         {error && (
@@ -165,16 +161,55 @@ export default function SignalsPage() {
           </div>
         )}
 
+        {!loading && !error && signals.length > 0 && (
+          <section className={styles.summaryCard} aria-labelledby="signals-summary-title">
+            <div className={styles.summaryHeader}>
+              <div>
+                <h2 id="signals-summary-title" className={styles.summaryTitle}>보유 종목 상태 요약</h2>
+              </div>
+            </div>
+
+            <div className={styles.summaryTiles}>
+              {groupedSummaryItems.map(item => (
+                <div key={item.label} className={styles.summaryTile} style={{ background: `${item.color}12` }}>
+                  <div className={styles.summaryTileValue} style={{ color: item.color }}>{item.count}</div>
+                  <div className={styles.summaryTileLabel} style={{ color: item.color }}>{item.label}</div>
+                </div>
+              ))}
+            </div>
+
+            <p className={styles.summaryLegend}>
+              점수 기준: 70+ 분할매수 고려 · 50~69 관심 종목 · 30~49 관망 우세 · ~29 주의 필요
+            </p>
+            <div className={styles.metaRow}>
+              <span className={styles.metaBadge}>분석 가능 {supportedCount}종목</span>
+              {unsupportedCount > 0 && <span className={styles.metaHint}>코드 없는 {unsupportedCount}종목은 제외됐어요.</span>}
+            </div>
+          </section>
+        )}
+
         <div className={styles.cardList}>
           {signals.map(signal => (
             <SignalCard
               key={`${signal.market}:${signal.ticker}`}
-              judgment={resolveFinalJudgment(market?.macroState ?? 'neutral', signal)}
+              sector={sectorByTarget.get(`${signal.market}:${signal.ticker}`)}
               signal={signal}
             />
           ))}
         </div>
+
+        {!loading && !error && signals.length > 0 && (
+          <div className={styles.actions}>
+            <button className={styles.secondaryButton} onClick={() => router.push('/diagnosis')}>
+              진단으로 돌아가기
+            </button>
+            <button className={styles.primaryButton} onClick={() => void handleRefresh()}>
+              최신 신호 다시 보기
+            </button>
+          </div>
+        )}
       </div>
+      <BottomNav />
     </div>
   )
 }

--- a/src/components/BottomNav.module.css
+++ b/src/components/BottomNav.module.css
@@ -1,0 +1,54 @@
+.nav {
+  position: fixed;
+  left: 50%;
+  bottom: 0;
+  z-index: 100;
+  display: flex;
+  width: 100%;
+  max-width: 440px;
+  padding-bottom: env(safe-area-inset-bottom, 0);
+  border-top: 1px solid #ebebef;
+  background: rgba(255, 255, 255, 0.96);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 -12px 32px rgba(15, 23, 42, 0.06);
+  transform: translateX(-50%);
+}
+
+.item {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  padding: 10px 0 12px;
+  color: #b7bac2;
+}
+
+.itemActive {
+  color: var(--navy);
+}
+
+.icon {
+  width: 20px;
+  height: 20px;
+}
+
+.icon svg {
+  width: 20px;
+  height: 20px;
+  overflow: visible;
+}
+
+.label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  margin-top: -1px;
+  border-radius: 50%;
+  background: var(--navy);
+}

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import styles from './BottomNav.module.css'
+
+type NavItem = {
+  href: string
+  icon: ReactNode
+  key: 'diagnosis' | 'market' | 'signals'
+  label: string
+}
+
+const NAV_ITEMS: NavItem[] = [
+  {
+    key: 'diagnosis',
+    href: '/diagnosis',
+    label: '진단',
+    icon: (
+      <svg viewBox="0 0 20 20" aria-hidden="true">
+        <rect x="3" y="10" width="3" height="7" rx="1" fill="currentColor" />
+        <rect x="8.5" y="6" width="3" height="11" rx="1" fill="currentColor" />
+        <rect x="14" y="3" width="3" height="14" rx="1" fill="currentColor" />
+      </svg>
+    ),
+  },
+  {
+    key: 'market',
+    href: '/market',
+    label: '시장',
+    icon: (
+      <svg viewBox="0 0 20 20" aria-hidden="true">
+        <circle cx="10" cy="10" r="7" stroke="currentColor" strokeWidth="1.8" fill="none" />
+        <path d="M10 3C10 3 13 7 13 10C13 13 10 17 10 17" stroke="currentColor" strokeWidth="1.5" fill="none" />
+        <path d="M3 10H17" stroke="currentColor" strokeWidth="1.5" />
+        <path d="M4 7H16M4 13H16" stroke="currentColor" strokeWidth="1" opacity="0.5" />
+      </svg>
+    ),
+  },
+  {
+    key: 'signals',
+    href: '/signals',
+    label: '종목',
+    icon: (
+      <svg viewBox="0 0 20 20" aria-hidden="true">
+        <polyline
+          points="2,14 6,9 9,12 13,6 18,8"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          fill="none"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <circle cx="6" cy="9" r="1.5" fill="currentColor" />
+        <circle cx="9" cy="12" r="1.5" fill="currentColor" />
+        <circle cx="13" cy="6" r="1.5" fill="currentColor" />
+        <circle cx="18" cy="8" r="1.5" fill="currentColor" />
+      </svg>
+    ),
+  },
+]
+
+export function BottomNav() {
+  const pathname = usePathname()
+
+  return (
+    <nav className={styles.nav} aria-label="하단 주요 탐색">
+      {NAV_ITEMS.map(item => {
+        const active = pathname === item.href
+
+        return (
+          <Link
+            key={item.key}
+            href={item.href}
+            aria-current={active ? 'page' : undefined}
+            className={`${styles.item} ${active ? styles.itemActive : ''}`}
+          >
+            <span className={styles.icon}>{item.icon}</span>
+            <span className={styles.label}>{item.label}</span>
+            {active && <span className={styles.dot} aria-hidden="true" />}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/src/components/SignalCard.module.css
+++ b/src/components/SignalCard.module.css
@@ -1,132 +1,418 @@
 .card {
-  background: var(--surface);
-  border: 1px solid var(--border);
+  overflow: hidden;
+  background: #fff;
+  border: 1px solid rgba(15, 23, 42, 0.04);
   border-radius: 18px;
-  padding: 18px;
-  box-shadow: 0 12px 24px rgba(18, 24, 88, 0.05);
+  box-shadow: 0 12px 34px rgba(15, 23, 42, 0.08);
 }
 
-.header {
+.toggle {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-}
-
-.marketRow {
-  display: inline-flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 6px;
+  gap: 12px;
+  width: 100%;
+  padding: 18px 20px;
+  text-align: left;
+  border: none;
+  background: transparent;
 }
 
-.market,
-.ticker {
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-3);
+.scoreRing {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.scoreRingLabel {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 900;
+  letter-spacing: -0.04em;
+}
+
+.info {
+  flex: 1;
+  min-width: 0;
+}
+
+.nameRow {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
 }
 
 .name {
-  font-size: 20px;
+  min-width: 0;
+  font-size: 18px;
   font-weight: 800;
+  color: #111827;
   letter-spacing: -0.03em;
-  color: var(--text-1);
 }
 
-.badge {
+.sector {
   flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 700;
+  color: #c7cad3;
+}
+
+.badgeRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+
+.labelBadge {
+  display: inline-flex;
+  align-items: center;
   border-radius: 999px;
-  padding: 8px 12px;
-  font-size: 12px;
+  padding: 7px 12px;
+  font-size: 11px;
   font-weight: 800;
 }
 
-.badge_accumulate {
-  background: var(--green-bg);
-  color: var(--green);
-}
-
-.badge_wait {
-  background: var(--amber-bg);
-  color: var(--amber);
-}
-
-.badge_caution {
-  background: var(--red-bg);
-  color: var(--red);
-}
-
-.headline {
-  margin-top: 14px;
-  font-size: 14px;
-  line-height: 1.6;
-  font-weight: 700;
-  color: var(--text-1);
-}
-
-.decisionMeta {
-  margin-top: 8px;
+.confidenceDot {
   font-size: 12px;
+  font-weight: 800;
+  color: #d4a13a;
+}
+
+.confidenceText {
+  font-size: 11px;
   font-weight: 700;
-  color: var(--text-3);
 }
 
-.headlineSub {
+.summaryClamp {
   margin-top: 10px;
-  font-size: 13px;
-  line-height: 1.6;
-  color: var(--text-2);
+  overflow: hidden;
+  font-size: 12px;
+  line-height: 1.45;
+  color: #969aa4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.metricList {
-  display: grid;
-  gap: 10px;
+.arrow,
+.expertArrow {
+  flex-shrink: 0;
+  color: #9ca3af;
+  transition: transform 0.18s ease;
+}
+
+.arrowOpen,
+.expertArrowOpen {
+  transform: rotate(180deg);
+}
+
+.body {
+  padding: 18px 20px 18px;
+  border-top: 1px solid rgba(15, 23, 42, 0.06);
+}
+
+.summary {
+  font-size: 16px;
+  line-height: 1.7;
+  font-weight: 700;
+  color: #444953;
+}
+
+.priceRange {
   margin-top: 16px;
 }
 
-.metric {
-  background: linear-gradient(180deg, rgba(232, 234, 246, 0.65), rgba(244, 246, 255, 0.3));
-  border: 1px solid rgba(26, 35, 126, 0.08);
-  border-radius: 14px;
-  padding: 14px;
+.priceRangeHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 4px;
 }
 
-.metricTop {
+.priceRangeLabel {
+  font-size: 11px;
+  font-weight: 700;
+  color: #777d89;
+}
+
+.priceRangeValue {
+  font-size: 15px;
+  font-weight: 800;
+  color: #111827;
+}
+
+.priceRangeTrack {
+  position: relative;
+  height: 6px;
+  border-radius: 999px;
+  background: #ececf4;
+}
+
+.priceRangeFill {
+  height: 100%;
+  border-radius: inherit;
+  background: rgba(28, 43, 94, 0.16);
+}
+
+.priceRangeThumb {
+  position: absolute;
+  top: -3px;
+  width: 12px;
+  height: 12px;
+  border: 2px solid #fff;
+  border-radius: 50%;
+  background: var(--navy);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
+  transform: translateX(-50%);
+}
+
+.priceRangeScale {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 7px;
+  font-size: 10px;
+  color: #b9bec8;
+}
+
+.dotRow {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.dotItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-height: 80px;
+  padding: 16px 8px;
+  text-align: center;
+  border-radius: 14px;
+  background: #f7f7fb;
+}
+
+.dot {
+  display: block;
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+}
+
+.dotLabel {
+  font-size: 11px;
+  font-weight: 700;
+  color: #777d89;
+}
+
+.expertSection {
+  margin-top: 16px;
+  border-top: 1px solid #f3f4f6;
+}
+
+.expertToggle {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  width: 100%;
+  padding: 22px 0 20px;
+  border: none;
+  background: transparent;
+  font-size: 18px;
+  font-weight: 800;
+  color: #333842;
+}
+
+.expertToggleRight {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.expertHint {
+  font-size: 12px;
+  font-weight: 600;
+  color: #b3b8c4;
+}
+
+.tableHeader {
+  display: flex;
+  align-items: center;
+  padding: 10px 0 9px;
+  background: #fbfbfe;
+  border-top: 1px solid #f3f4f6;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.thLabel,
+.thStatus,
+.thContrib {
+  font-size: 11px;
+  font-weight: 700;
+  color: #b7bcc8;
+}
+
+.thLabel {
+  flex: 1;
+}
+
+.thStatus {
+  width: 108px;
+  text-align: center;
+}
+
+.thContrib {
+  width: 132px;
+  text-align: right;
+}
+
+.metricRow {
+  padding: 18px 0 16px;
+}
+
+.metricMain {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
   gap: 12px;
 }
 
+.metricLeft {
+  flex: 1;
+  min-width: 0;
+}
+
 .metricLabel {
-  font-size: 13px;
+  font-size: 15px;
   font-weight: 800;
-  color: var(--navy);
+  color: #222631;
 }
 
-.metricSignal {
+.metricValue {
+  margin-left: 8px;
+  font-size: 10px;
+  font-weight: 700;
+  color: #c4c7cf;
+}
+
+.metricStatus {
+  width: 108px;
+  text-align: center;
+}
+
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.metricContrib {
+  width: 132px;
+  font-size: 10px;
+  text-align: right;
+  color: #ccc;
+}
+
+.metricDesc {
+  margin-top: 10px;
   font-size: 12px;
+  line-height: 1.45;
+  color: #7e838d;
+}
+
+.contribBar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.contribSegment {
+  height: 6px;
+  border-radius: 999px;
+}
+
+.contribValue {
+  min-width: 40px;
+  font-size: 11px;
   font-weight: 800;
+  text-align: center;
 }
 
-.metricSignal_buy {
-  color: var(--green);
+.referenceSection {
+  padding-top: 20px;
+  border-top: 1px solid #f3f4f6;
 }
 
-.metricSignal_neutral {
-  color: var(--amber);
-}
-
-.metricSignal_sell {
-  color: var(--red);
-}
-
-.metricSummary {
-  margin-top: 8px;
+.referenceTitle {
+  margin-bottom: 18px;
   font-size: 13px;
-  line-height: 1.6;
-  color: var(--text-2);
+  font-weight: 800;
+  color: #b7bcc8;
+}
+
+.referenceItem {
+  display: flex;
+  gap: 10px;
+}
+
+.referenceItem + .referenceItem {
+  margin-top: 18px;
+}
+
+.referenceDot {
+  width: 8px;
+  height: 8px;
+  margin-top: 8px;
+  flex-shrink: 0;
+  border-radius: 2px;
+  background: #ddd;
+}
+
+.referenceBody {
+  min-width: 0;
+}
+
+.referenceName {
+  margin-right: 4px;
+  font-size: 14px;
+  font-weight: 700;
+  color: #555;
+}
+
+.referenceValue {
+  font-size: 14px;
+  color: #888;
+}
+
+.referenceNote {
+  margin-top: 6px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #b3b8c4;
+}
+
+@media (max-width: 479px) {
+  .metricStatus {
+    width: 92px;
+  }
+
+  .metricContrib {
+    width: 118px;
+  }
+
+  .thStatus,
+  .thContrib {
+    display: none;
+  }
 }

--- a/src/components/SignalCard.test.ts
+++ b/src/components/SignalCard.test.ts
@@ -1,0 +1,171 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { SignalCard } from './SignalCard'
+
+describe('SignalCard', () => {
+  it('닫힌 상태의 요약 카드 헤더를 렌더링한다', () => {
+    const html = renderToStaticMarkup(
+      createElement(SignalCard, {
+        sector: '반도체',
+        signal: {
+          companyName: '현대차',
+          confidence: 'high',
+          confidenceSummary: '여러 핵심 지표가 같은 방향을 가리키고 있어요.',
+          currentPrice: 123_500,
+          expertDetails: [
+            {
+              contribution: '+0.42',
+              description: 'RSI 42.3: 최근 상승폭과 하락폭을 비교한 지표예요. 현재는 비교적 부담이 낮은 구간으로 해석됩니다.',
+              key: 'rsi',
+              status: '완만한 저점권',
+              title: 'RSI',
+              value: 'RSI 42.3',
+            },
+            {
+              contribution: '+1.20',
+              description: 'MACD Histogram +0.82: MACD가 Signal 선보다 위에 있으며, 전일 대비 개선되고 있습니다.',
+              key: 'macd',
+              status: '상승 흐름',
+              title: 'MACD',
+              value: 'MACD Histogram +0.82',
+            },
+            {
+              contribution: '+0.60',
+              description: '거래량 1.8배: 최근 20일 평균 거래량 대비 현재 거래량이에요. 최근 3일 수익률은 +2.1%입니다.',
+              key: 'volume',
+              status: '관심 증가',
+              title: '거래량',
+              value: '거래량 1.8배',
+            },
+            {
+              contribution: '+0.32',
+              description: '52주 위치 하위 35%: 52주 저가와 고가 사이에서 현재가가 위치한 비율입니다. 1년 가격 범위에서 비교적 낮은 편이에요.',
+              key: 'fiftyTwoWeek',
+              status: '낮은 가격대',
+              title: '52주 위치',
+              value: '52주 위치 하위 35%',
+            },
+            {
+              contribution: null,
+              description: '6개월 평균 대비 -4.2%: 현재가가 6개월 평균과 크게 다르지 않아 중기 기준으로는 중립 구간이에요.',
+              key: 'sixMonthAverage',
+              status: '중립',
+              title: '6개월 평균 대비',
+              value: '6개월 평균 대비 -4.2%',
+            },
+            {
+              contribution: null,
+              description: '최근 30일 내부자 순매수가 보여 회사 안쪽 인물들이 주가를 긍정적으로 보는 신호로 읽을 수 있어요.',
+              key: 'insider',
+              status: '순매수 우위',
+              title: '내부자 매매',
+              value: '매수 2건 / 매도 0건',
+            },
+          ],
+          fetchedAt: '2026-04-24T00:00:00.000Z',
+          label: '분할매수 고려',
+          market: 'KR',
+          marketSymbol: '005380.KS',
+          metrics: [
+            {
+              contribution: 0.42,
+              description: 'RSI 42.3: 최근 상승폭과 하락폭을 비교한 지표예요. 현재는 비교적 부담이 낮은 구간으로 해석됩니다.',
+              includedInScore: true,
+              key: 'rsi',
+              label: '단기 과열 여부',
+              signal: 'buy',
+              status: '완만한 저점권',
+              strength: 0.35,
+              summary: '과열은 아니고, 비교적 부담이 낮은 구간이에요.',
+              value: 'RSI 42.3',
+              weight: 1.2,
+            },
+            {
+              contribution: 1.2,
+              description: 'MACD Histogram +0.82: MACD가 Signal 선보다 위에 있으며, 전일 대비 개선되고 있습니다.',
+              includedInScore: true,
+              key: 'macd',
+              label: '추세 방향',
+              signal: 'buy',
+              status: '상승 흐름',
+              strength: 0.8,
+              summary: '상승 흐름이 이어지고 있어요.',
+              value: 'MACD Histogram +0.82',
+              weight: 1.5,
+            },
+            {
+              contribution: 0.6,
+              description: '거래량 1.8배: 최근 20일 평균 거래량 대비 현재 거래량이에요. 최근 3일 수익률은 +2.1%입니다.',
+              includedInScore: true,
+              key: 'volume',
+              label: '거래 활발도',
+              signal: 'buy',
+              status: '관심 증가',
+              strength: 0.46,
+              summary: '평소보다 거래가 늘면서 관심이 붙고 있어요.',
+              value: '거래량 1.8배',
+              weight: 1.3,
+            },
+            {
+              contribution: 0.32,
+              description: '52주 위치 하위 35%: 52주 저가와 고가 사이에서 현재가가 위치한 비율입니다. 1년 가격 범위에서 비교적 낮은 편이에요.',
+              includedInScore: true,
+              key: 'fiftyTwoWeek',
+              label: '가격 위치',
+              signal: 'buy',
+              status: '낮은 가격대',
+              strength: 0.35,
+              summary: '1년 가격 범위에서 비교적 낮은 편이에요.',
+              value: '52주 위치 하위 35%',
+              weight: 0.9,
+            },
+          ],
+          normalizedScore: 0.52,
+          recommendation: 'buy',
+          referenceMetrics: [
+            {
+              contribution: 0,
+              description: '6개월 평균 대비 -4.2%: 현재가가 6개월 평균과 크게 다르지 않아 중기 기준으로는 중립 구간이에요.',
+              includedInScore: false,
+              key: 'sixMonthAverage',
+              label: '6개월 평균 대비',
+              signal: 'neutral',
+              status: '중립',
+              strength: 0,
+              summary: '현재가가 6개월 평균과 크게 다르지 않아요.',
+              value: '6개월 평균 대비 -4.2%',
+              weight: 0,
+            },
+            {
+              contribution: 0,
+              description: '최근 30일 내부자 순매수가 보여 회사 안쪽 인물들이 주가를 긍정적으로 보는 신호로 읽을 수 있어요.',
+              includedInScore: false,
+              key: 'insider',
+              label: '내부자 매매',
+              signal: 'buy',
+              status: '순매수 우위',
+              strength: 0,
+              summary: '최근 30일 내부자 순매수가 보여요.',
+              value: '매수 2건 / 매도 0건',
+              weight: 0,
+            },
+          ],
+          score: 76,
+          summary: '가격도 합리적인 편이고 상승 신호가 나오고 있어요. 한 번에 사기보다 조금씩 나눠서 보는 게 좋아요.',
+          ticker: '005380',
+          week52High: 180_000,
+          week52Low: 88_000,
+        },
+      }),
+    )
+
+    expect(html).toContain('현대차')
+    expect(html).toContain('76')
+    expect(html).toContain('분할매수 고려')
+    expect(html).toContain('반도체')
+    expect(html).toContain('신뢰도 높음')
+    expect(html).toContain('aria-expanded="false"')
+    expect(html).toContain('가격도 합리적인 편이고 상승 신호가 나오고 있어요.')
+  })
+})

--- a/src/components/SignalCard.tsx
+++ b/src/components/SignalCard.tsx
@@ -1,53 +1,307 @@
-import type { FinalJudgment } from '@/lib/finalJudgment'
-import type { TradingRecommendation, TradingSignal } from '@/lib/tradingSignals'
+'use client'
+
+import { useState } from 'react'
+import type {
+  TradingConfidence,
+  TradingRecommendation,
+  TradingSignal,
+  TradingSignalMetric,
+} from '@/lib/tradingSignals'
 import styles from './SignalCard.module.css'
 
 interface SignalCardProps {
-  judgment: FinalJudgment
+  sector?: string
   signal: TradingSignal
 }
 
-const TECHNICAL_LABEL: Record<TradingRecommendation, string> = {
-  buy: '매수 관점',
-  neutral: '중립',
-  sell: '매도 관점',
+type ScoreStyle = {
+  color: string
+  label: string
+  min: number
 }
 
-export function SignalCard({ judgment, signal }: SignalCardProps) {
+export const SCORE_STYLES: ScoreStyle[] = [
+  { min: 70, label: '분할매수 고려', color: 'var(--green)' },
+  { min: 50, label: '관심 종목', color: 'var(--amber)' },
+  { min: 30, label: '관망 우세', color: '#9ca3af' },
+  { min: 0, label: '주의 필요', color: 'var(--red)' },
+]
+
+const CONFIDENCE_LABEL: Record<TradingConfidence, string> = {
+  high: '신뢰도 높음',
+  low: '신뢰도 낮음',
+  medium: '신뢰도 보통',
+}
+
+const CONFIDENCE_COLOR: Record<TradingConfidence, string> = {
+  high: 'var(--green)',
+  low: '#9ca3af',
+  medium: 'var(--amber)',
+}
+
+const PRICE_FORMATTER = new Intl.NumberFormat('ko-KR', {
+  maximumFractionDigits: 2,
+})
+
+export function resolveScoreStyle(score: number): ScoreStyle {
+  return SCORE_STYLES.find(style => score >= style.min) ?? SCORE_STYLES[SCORE_STYLES.length - 1]
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+function formatPrice(value: number): string {
+  return PRICE_FORMATTER.format(value)
+}
+
+function resolveMetricColors(signal: TradingRecommendation): { background: string; color: string } {
+  if (signal === 'buy') {
+    return {
+      background: 'var(--green-bg)',
+      color: 'var(--green)',
+    }
+  }
+
+  if (signal === 'sell') {
+    return {
+      background: 'var(--red-bg)',
+      color: 'var(--red)',
+    }
+  }
+
+  return {
+    background: '#f3f4f6',
+    color: '#9ca3af',
+  }
+}
+
+function ScoreRing({ color, score, size = 52 }: { color: string; score: number; size?: number }) {
+  const strokeWidth = 5
+  const radius = 22
+  const circumference = 2 * Math.PI * radius
+  const dash = (clamp(score, 0, 100) / 100) * circumference
+
+  return (
+    <div className={styles.scoreRing} style={{ width: size, height: size }}>
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} aria-hidden="true">
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke="#f0f0f5"
+          strokeWidth={strokeWidth}
+        />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke={color}
+          strokeDasharray={`${dash} ${circumference}`}
+          strokeLinecap="round"
+          strokeWidth={strokeWidth}
+          transform={`rotate(-90 ${size / 2} ${size / 2})`}
+        />
+      </svg>
+      <span className={styles.scoreRingLabel} style={{ color }}>
+        {score}
+      </span>
+    </div>
+  )
+}
+
+function PriceRange52({ cur, hi, lo }: { cur: number; hi: number; lo: number }) {
+  const ratio = hi > lo ? ((cur - lo) / (hi - lo)) * 100 : 50
+  const pct = Math.round(clamp(ratio, 0, 100))
+
+  return (
+    <section className={styles.priceRange}>
+      <div className={styles.priceRangeHeader}>
+        <span className={styles.priceRangeLabel}>1년 가격 범위 내 위치</span>
+        <span className={styles.priceRangeValue}>{formatPrice(cur)}</span>
+      </div>
+      <div className={styles.priceRangeTrack} aria-hidden="true">
+        <div className={styles.priceRangeFill} style={{ width: `${pct}%` }} />
+        <div className={styles.priceRangeThumb} style={{ left: `${pct}%` }} />
+      </div>
+      <div className={styles.priceRangeScale}>
+        <span>{formatPrice(lo)}</span>
+        <span>{formatPrice(hi)}</span>
+      </div>
+    </section>
+  )
+}
+
+function ContribBar({ contribution }: { contribution: number }) {
+  const abs = Math.abs(contribution)
+  const width = contribution === 0 ? 0 : Math.max(8, Math.min((abs / 1.5) * 60, 60))
+  const colors = resolveMetricColors(contribution > 0 ? 'buy' : contribution < 0 ? 'sell' : 'neutral')
+  const text = contribution === 0 ? '±0' : `${contribution > 0 ? '+' : ''}${contribution.toFixed(2)}`
+
+  return (
+    <div className={styles.contribBar}>
+      {contribution < 0 && (
+        <div className={styles.contribSegment} style={{ background: colors.color, width }} />
+      )}
+      <span className={styles.contribValue} style={{ color: contribution === 0 ? '#9ca3af' : colors.color }}>
+        {text}
+      </span>
+      {contribution > 0 && (
+        <div className={styles.contribSegment} style={{ background: colors.color, width }} />
+      )}
+    </div>
+  )
+}
+
+function MetricDot({ metric }: { metric: TradingSignalMetric }) {
+  const colors = resolveMetricColors(metric.signal)
+
+  return (
+    <div className={styles.dotItem}>
+      <span className={styles.dot} style={{ background: colors.color }} aria-hidden="true" />
+      <span className={styles.dotLabel}>{metric.label}</span>
+    </div>
+  )
+}
+
+export function SignalCard({ sector, signal }: SignalCardProps) {
+  const [open, setOpen] = useState(false)
+  const [expertOpen, setExpertOpen] = useState(true)
+  const scoreStyle = resolveScoreStyle(signal.score)
+  const coreMetrics = signal.metrics.filter(metric => metric.includedInScore).slice(0, 4)
+
   return (
     <article className={styles.card}>
-      <div className={styles.header}>
-        <div>
-          <div className={styles.marketRow}>
-            <span className={styles.market}>{signal.market}</span>
-            <span className={styles.ticker}>{signal.ticker}</span>
+      <button
+        type="button"
+        className={styles.toggle}
+        onClick={() => setOpen(current => !current)}
+        aria-expanded={open}
+      >
+        <ScoreRing color={scoreStyle.color} score={signal.score} />
+        <div className={styles.info}>
+          <div className={styles.nameRow}>
+            <span className={styles.name}>{signal.companyName}</span>
+            {sector && <span className={styles.sector}>{sector}</span>}
           </div>
-          <h2 className={styles.name}>{signal.companyName}</h2>
+          <div className={styles.badgeRow}>
+            <span
+              className={styles.labelBadge}
+              style={{
+                background: `${scoreStyle.color}18`,
+                color: scoreStyle.color,
+              }}
+            >
+              {scoreStyle.label}
+            </span>
+            <span className={styles.confidenceDot}>·</span>
+            <span className={styles.confidenceText} style={{ color: CONFIDENCE_COLOR[signal.confidence] }}>
+              {CONFIDENCE_LABEL[signal.confidence]}
+            </span>
+          </div>
+          <p className={styles.summaryClamp}>{signal.summary}</p>
         </div>
-        <span className={`${styles.badge} ${styles[`badge_${judgment.key}`]}`}>
-          {judgment.label}
+        <span className={`${styles.arrow} ${open ? styles.arrowOpen : ''}`} aria-hidden="true">
+          ▾
         </span>
-      </div>
+      </button>
 
-      <p className={styles.headline}>{judgment.summary}</p>
-      <p className={styles.decisionMeta}>
-        기술 시그널 {TECHNICAL_LABEL[signal.recommendation]} · 점수 {signal.score >= 0 ? '+' : ''}{signal.score}
-      </p>
-      <p className={styles.headlineSub}>{signal.headline}</p>
+      {open && (
+        <div className={styles.body}>
+          <p className={styles.summary}>{signal.summary}</p>
 
-      <div className={styles.metricList}>
-        {signal.metrics.map(metric => (
-          <section key={metric.key} className={styles.metric}>
-            <div className={styles.metricTop}>
-              <span className={styles.metricLabel}>{metric.label}</span>
-              <span className={`${styles.metricSignal} ${styles[`metricSignal_${metric.signal}`]}`}>
-                {metric.value}
+          <PriceRange52 cur={signal.currentPrice} hi={signal.week52High} lo={signal.week52Low} />
+
+          <div className={styles.dotRow}>
+            {coreMetrics.map(metric => (
+              <MetricDot key={metric.key} metric={metric} />
+            ))}
+          </div>
+
+          <section className={styles.expertSection}>
+            <button
+              type="button"
+              className={styles.expertToggle}
+              onClick={() => setExpertOpen(current => !current)}
+              aria-expanded={expertOpen}
+            >
+              <span>전문 지표 상세</span>
+              <span className={styles.expertToggleRight}>
+                <span className={styles.expertHint}>점수 기여도 포함</span>
+                <span className={`${styles.expertArrow} ${expertOpen ? styles.expertArrowOpen : ''}`} aria-hidden="true">
+                  ▾
+                </span>
               </span>
-            </div>
-            <p className={styles.metricSummary}>{metric.summary}</p>
+            </button>
+
+            {expertOpen && (
+              <>
+                <div className={styles.tableHeader}>
+                  <span className={styles.thLabel}>지표</span>
+                  <span className={styles.thStatus}>상태</span>
+                  <span className={styles.thContrib}>점수 기여</span>
+                </div>
+
+                {signal.metrics.map((metric, index) => {
+                  const colors = resolveMetricColors(metric.signal)
+
+                  return (
+                    <div
+                      key={metric.key}
+                      className={styles.metricRow}
+                      style={{ borderBottom: index < signal.metrics.length - 1 ? '1px solid #f3f4f6' : 'none' }}
+                    >
+                      <div className={styles.metricMain}>
+                        <div className={styles.metricLeft}>
+                          <span className={styles.metricLabel}>{metric.label}</span>
+                          <span className={styles.metricValue}>{metric.value}</span>
+                        </div>
+
+                        <div className={styles.metricStatus}>
+                          <span
+                            className={styles.statusBadge}
+                            style={{
+                              background: colors.background,
+                              color: colors.color,
+                            }}
+                          >
+                            {metric.status}
+                          </span>
+                        </div>
+
+                        <div className={styles.metricContrib}>
+                          {metric.includedInScore ? <ContribBar contribution={metric.contribution} /> : <span>미반영</span>}
+                        </div>
+                      </div>
+                      <p className={styles.metricDesc}>{metric.description}</p>
+                    </div>
+                  )
+                })}
+              </>
+            )}
           </section>
-        ))}
-      </div>
+
+          {signal.referenceMetrics.length > 0 && (
+            <section className={styles.referenceSection}>
+              <div className={styles.referenceTitle}>참고 지표 (점수 미반영)</div>
+              {signal.referenceMetrics.map(metric => (
+                <div key={metric.key} className={styles.referenceItem}>
+                  <span className={styles.referenceDot} aria-hidden="true" />
+                  <div className={styles.referenceBody}>
+                    <div>
+                      <span className={styles.referenceName}>{metric.label}</span>
+                      <span className={styles.referenceValue}>{metric.value}</span>
+                    </div>
+                    <div className={styles.referenceNote}>{metric.summary}</div>
+                  </div>
+                </div>
+              ))}
+            </section>
+          )}
+        </div>
+      )}
     </article>
   )
 }

--- a/src/lib/tradingSignals.test.ts
+++ b/src/lib/tradingSignals.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import {
+  analyzeTradingSignalIndicators,
   buildTradingSignal,
+  calculateConfidence,
   calculateMacdState,
   calculateRsi,
+  evaluateMacd,
+  evaluateRsi,
+  evaluateVolume,
+  evaluateWeek52Position,
   parseOpenInsiderActivity,
   resolveTradingSignalTarget,
 } from './tradingSignals'
@@ -90,8 +96,124 @@ describe('parseOpenInsiderActivity', () => {
   })
 })
 
+describe('metric evaluation', () => {
+  it('RSI 경계값을 새 설계대로 해석한다', () => {
+    expect(evaluateRsi(29).signal).toBe('buy')
+    expect(evaluateRsi(29).strength).toBe(0.85)
+    expect(evaluateRsi(42.3).strength).toBe(0.35)
+    expect(evaluateRsi(58).signal).toBe('neutral')
+    expect(evaluateRsi(74).signal).toBe('sell')
+    expect(evaluateRsi(84).strength).toBe(0.85)
+  })
+
+  it('MACD phase를 상승/반등/약세로 나눈다', () => {
+    expect(evaluateMacd({
+      histogram: 0.82,
+      macd: 1.2,
+      previousHistogram: 0.4,
+      signal: 0.38,
+    }).status).toBe('상승 흐름')
+
+    expect(evaluateMacd({
+      histogram: 0.32,
+      macd: 0.9,
+      previousHistogram: 0.5,
+      signal: 0.58,
+    }).status).toBe('상승 둔화')
+
+    expect(evaluateMacd({
+      histogram: -0.18,
+      macd: -0.8,
+      previousHistogram: -0.45,
+      signal: -0.62,
+    }).status).toBe('반등 조짐')
+
+    expect(evaluateMacd({
+      histogram: -0.72,
+      macd: -1.4,
+      previousHistogram: -0.5,
+      signal: -0.68,
+    }).signal).toBe('sell')
+  })
+
+  it('거래량은 최근 3일 수익률과 결합해 신호를 낸다', () => {
+    expect(evaluateVolume(1.1, 2.1).signal).toBe('neutral')
+    expect(evaluateVolume(1.8, 2.1).signal).toBe('buy')
+    expect(evaluateVolume(1.8, -2.1).signal).toBe('sell')
+  })
+
+  it('52주 위치는 설계안의 구간대로 점수를 준다', () => {
+    expect(evaluateWeek52Position(0.2).status).toBe('저점권 근접')
+    expect(evaluateWeek52Position(0.35).signal).toBe('buy')
+    expect(evaluateWeek52Position(0.6).signal).toBe('neutral')
+    expect(evaluateWeek52Position(0.82).status).toBe('고점권 경계')
+    expect(evaluateWeek52Position(0.93).signal).toBe('sell')
+  })
+})
+
+describe('calculateConfidence', () => {
+  it('핵심 지표 정렬도가 높고 점수 폭이 크면 high를 준다', () => {
+    expect(calculateConfidence([
+      { key: 'rsi', signal: 'buy' },
+      { key: 'macd', signal: 'buy' },
+      { key: 'volume', signal: 'buy' },
+      { key: 'fiftyTwoWeek', signal: 'buy' },
+    ], 0.52)).toBe('high')
+  })
+
+  it('방향은 맞지만 점수 폭이 약하면 medium을 준다', () => {
+    expect(calculateConfidence([
+      { key: 'rsi', signal: 'buy' },
+      { key: 'macd', signal: 'buy' },
+      { key: 'volume', signal: 'neutral' },
+      { key: 'fiftyTwoWeek', signal: 'neutral' },
+    ], 0.3)).toBe('medium')
+  })
+
+  it('지표가 엇갈리면 low를 준다', () => {
+    expect(calculateConfidence([
+      { key: 'rsi', signal: 'buy' },
+      { key: 'macd', signal: 'sell' },
+      { key: 'volume', signal: 'neutral' },
+      { key: 'fiftyTwoWeek', signal: 'buy' },
+    ], 0.18)).toBe('low')
+  })
+})
+
+describe('analyzeTradingSignalIndicators', () => {
+  it('설계안 예시 입력을 76점 / 분할매수 고려 / high로 변환한다', () => {
+    const analysis = analyzeTradingSignalIndicators({
+      diffFromAverage6Month: -4.2,
+      insiderActivity: { buyCount: 0, netValue: 0, sellCount: 0 },
+      macdState: {
+        histogram: 0.82,
+        macd: 1.1,
+        previousHistogram: 0.38,
+        signal: 0.28,
+      },
+      market: 'US',
+      recentReturn3d: 2.1,
+      rsi: 42.3,
+      volumeRatio: 1.8,
+      week52Band: 0.35,
+    })
+
+    expect(analysis.score).toBe(76)
+    expect(analysis.label).toBe('분할매수 고려')
+    expect(analysis.confidence).toBe('high')
+    expect(analysis.metrics.map(metric => metric.contribution.toFixed(2))).toEqual([
+      '0.42',
+      '1.20',
+      '0.60',
+      '0.32',
+    ])
+    expect(analysis.summary).toContain('가격도 합리적인 편이고')
+    expect(analysis.summary).toContain('상승 신호가 나오고 있어요.')
+  })
+})
+
 describe('buildTradingSignal', () => {
-  it('과매도 + 바닥권 조합이면 매수 추천을 준다', () => {
+  it('핵심 지표와 참고 지표를 분리해 반환한다', () => {
     const signal = buildTradingSignal({
       companyName: 'Apple',
       currentPrice: 92,
@@ -100,36 +222,20 @@ describe('buildTradingSignal', () => {
       marketSymbol: 'AAPL',
       priceHistory: Array.from({ length: 260 }, (_, index) => ({
         close: 150 - index * 0.22,
-        volume: 100_000 + index * 100,
+        volume: 100_000 + index * 150,
       })).reverse(),
       ticker: 'AAPL',
       week52High: 180,
       week52Low: 88,
     })
 
-    expect(signal.metrics).toHaveLength(6)
-    expect(signal.recommendation).toBe('buy')
-    expect(signal.metrics[0].summary).toContain('RSI')
-    expect(signal.metrics[5].label).toBe('내부자 매매')
-  })
-
-  it('과열 지표가 많으면 매도 추천을 준다', () => {
-    const signal = buildTradingSignal({
-      companyName: 'Samsung Electronics',
-      currentPrice: 220,
-      insiderActivity: { buyCount: 0, netValue: -5_000_000, sellCount: 3 },
-      market: 'KR',
-      marketSymbol: '005930.KS',
-      priceHistory: Array.from({ length: 260 }, (_, index) => ({
-        close: 100 + index * 0.5,
-        volume: 100_000 + index * 50,
-      })),
-      ticker: '005930',
-      week52High: 225,
-      week52Low: 95,
-    })
-
-    expect(signal.recommendation).toBe('sell')
-    expect(signal.metrics.some(metric => metric.signal === 'sell')).toBe(true)
+    expect(signal.metrics).toHaveLength(4)
+    expect(signal.referenceMetrics).toHaveLength(2)
+    expect(signal.expertDetails).toHaveLength(6)
+    expect(signal.currentPrice).toBe(92)
+    expect(signal.label).toMatch(/분할매수 고려|관심 종목|관망 우세|주의 필요|리스크 높음/)
+    expect(signal.summary.length).toBeGreaterThan(0)
+    expect(signal.week52High).toBe(180)
+    expect(signal.week52Low).toBe(88)
   })
 })

--- a/src/lib/tradingSignals.ts
+++ b/src/lib/tradingSignals.ts
@@ -2,6 +2,14 @@ import type { PortfolioPosition } from './types'
 
 export type TradingMarket = 'US' | 'KR'
 export type TradingRecommendation = 'buy' | 'neutral' | 'sell'
+export type TradingConfidence = 'low' | 'medium' | 'high'
+export type TradingSignalMetricKey =
+  | 'rsi'
+  | 'macd'
+  | 'volume'
+  | 'fiftyTwoWeek'
+  | 'sixMonthAverage'
+  | 'insider'
 
 export interface TradingSignalTarget {
   market: TradingMarket
@@ -21,23 +29,47 @@ export interface InsiderActivitySummary {
 }
 
 export interface TradingSignalMetric {
-  key: 'rsi' | 'macd' | 'volume' | 'fiftyTwoWeek' | 'sixMonthAverage' | 'insider'
+  contribution: number
+  description: string
+  includedInScore: boolean
+  key: TradingSignalMetricKey
   label: string
   signal: TradingRecommendation
+  strength: number
   summary: string
+  value: string
+  weight: number
+  status: string
+}
+
+export interface TradingSignalExpertDetail {
+  contribution: string | null
+  description: string
+  key: TradingSignalMetricKey
+  status: string
+  title: string
   value: string
 }
 
 export interface TradingSignal {
   companyName: string
+  confidence: TradingConfidence
+  confidenceSummary: string
+  currentPrice: number
+  expertDetails: TradingSignalExpertDetail[]
   fetchedAt: string
-  headline: string
+  label: string
   market: TradingMarket
   marketSymbol: string
   metrics: TradingSignalMetric[]
+  normalizedScore: number
   recommendation: TradingRecommendation
+  referenceMetrics: TradingSignalMetric[]
   score: number
+  summary: string
   ticker: string
+  week52High: number
+  week52Low: number
 }
 
 export interface BuildTradingSignalInput {
@@ -52,6 +84,30 @@ export interface BuildTradingSignalInput {
   week52Low: number
 }
 
+export interface BuildTradingSignalAnalysisInput {
+  diffFromAverage6Month: number
+  insiderActivity: InsiderActivitySummary
+  market: TradingMarket
+  macdState: MacdState
+  recentReturn3d: number
+  rsi: number
+  volumeRatio: number
+  week52Band: number
+}
+
+export interface TradingSignalAnalysis {
+  confidence: TradingConfidence
+  confidenceSummary: string
+  expertDetails: TradingSignalExpertDetail[]
+  label: string
+  metrics: TradingSignalMetric[]
+  normalizedScore: number
+  recommendation: TradingRecommendation
+  referenceMetrics: TradingSignalMetric[]
+  score: number
+  summary: string
+}
+
 export interface YahooSnapshot {
   companyName: string
   currentPrice: number
@@ -59,6 +115,13 @@ export interface YahooSnapshot {
   priceHistory: PriceHistoryPoint[]
   week52High: number
   week52Low: number
+}
+
+export interface MacdState {
+  histogram: number
+  macd: number
+  previousHistogram: number
+  signal: number
 }
 
 type YahooChartResponse = {
@@ -93,6 +156,15 @@ const SEC_HEADERS = {
   Accept: 'application/atom+xml, text/html;q=0.9, application/xhtml+xml;q=0.8, */*;q=0.5',
   'User-Agent': 'portfolio-doctor/1.0 help@example.com',
 }
+
+const WEIGHTS = {
+  fiftyTwoWeek: 0.9,
+  macd: 1.5,
+  rsi: 1.2,
+  volume: 1.3,
+} as const
+
+const TOTAL_WEIGHT = WEIGHTS.rsi + WEIGHTS.macd + WEIGHTS.volume + WEIGHTS.fiftyTwoWeek
 
 export const SIGNAL_CACHE_SECONDS = DAY_IN_SECONDS
 
@@ -146,21 +218,25 @@ export function calculateRsi(closes: number[], period = 14): number {
   return 100 - (100 / (1 + relativeStrength))
 }
 
-export function calculateMacdState(closes: number[]): { histogram: number; macd: number; signal: number } {
+export function calculateMacdState(closes: number[]): MacdState {
   if (closes.length < 35) {
-    return { histogram: 0, macd: 0, signal: 0 }
+    return { histogram: 0, macd: 0, previousHistogram: 0, signal: 0 }
   }
 
   const ema12 = calculateExponentialMovingAverage(closes, 12)
   const ema26 = calculateExponentialMovingAverage(closes, 26)
   const macdSeries = ema12.map((value, index) => value - ema26[index])
   const signalSeries = calculateExponentialMovingAverage(macdSeries, 9)
+  const histogramSeries = macdSeries.map((value, index) => value - signalSeries[index])
   const macd = macdSeries[macdSeries.length - 1]
   const signal = signalSeries[signalSeries.length - 1]
+  const histogram = histogramSeries[histogramSeries.length - 1]
+  const previousHistogram = histogramSeries[histogramSeries.length - 2] ?? histogram
 
   return {
-    histogram: macd - signal,
+    histogram,
     macd,
+    previousHistogram,
     signal,
   }
 }
@@ -191,6 +267,334 @@ export function parseOpenInsiderActivity(html: string): InsiderActivitySummary {
   return { buyCount, sellCount, netValue }
 }
 
+export function evaluateRsi(rsi: number): TradingSignalMetric {
+  if (rsi < 30) {
+    return createCoreMetric({
+      description: `RSI ${formatNumber(rsi)}: 최근 상승폭과 하락폭을 비교한 지표예요. 현재는 많이 눌린 저점권으로 해석됩니다.`,
+      key: 'rsi',
+      label: '단기 과열 여부',
+      signal: 'buy',
+      status: '저점권',
+      strength: 0.85,
+      summary: '많이 눌린 구간이라 반등 가능성을 볼 수 있어요.',
+      value: `RSI ${formatNumber(rsi)}`,
+    })
+  }
+
+  if (rsi < 45) {
+    return createCoreMetric({
+      description: `RSI ${formatNumber(rsi)}: 최근 상승폭과 하락폭을 비교한 지표예요. 현재는 비교적 부담이 낮은 구간으로 해석됩니다.`,
+      key: 'rsi',
+      label: '단기 과열 여부',
+      signal: 'buy',
+      status: '완만한 저점권',
+      strength: 0.35,
+      summary: '과열은 아니고, 비교적 부담이 낮은 구간이에요.',
+      value: `RSI ${formatNumber(rsi)}`,
+    })
+  }
+
+  if (rsi < 60) {
+    return createCoreMetric({
+      description: `RSI ${formatNumber(rsi)}: 최근 상승폭과 하락폭을 비교한 지표예요. 현재는 과열도 과매도도 아닌 중립 구간입니다.`,
+      key: 'rsi',
+      label: '단기 과열 여부',
+      signal: 'neutral',
+      status: '중립',
+      strength: 0,
+      summary: '가격이 과하게 싸거나 비싼 구간은 아니에요.',
+      value: `RSI ${formatNumber(rsi)}`,
+    })
+  }
+
+  if (rsi < 70) {
+    return createCoreMetric({
+      description: `RSI ${formatNumber(rsi)}: 최근 상승폭과 하락폭을 비교한 지표예요. 현재는 다소 올라왔지만 아직 극단적 과열은 아닌 중립 구간입니다.`,
+      key: 'rsi',
+      label: '단기 과열 여부',
+      signal: 'neutral',
+      status: '중립',
+      strength: 0,
+      summary: '가격이 과하게 싸거나 비싼 구간은 아니에요.',
+      value: `RSI ${formatNumber(rsi)}`,
+    })
+  }
+
+  if (rsi < 80) {
+    return createCoreMetric({
+      description: `RSI ${formatNumber(rsi)}: 최근 상승폭과 하락폭을 비교한 지표예요. 현재는 단기 과열 경계 구간으로 해석됩니다.`,
+      key: 'rsi',
+      label: '단기 과열 여부',
+      signal: 'sell',
+      status: '과열 경계',
+      strength: 0.45,
+      summary: '조금 많이 오른 상태라 쉬어갈 수 있어요.',
+      value: `RSI ${formatNumber(rsi)}`,
+    })
+  }
+
+  return createCoreMetric({
+    description: `RSI ${formatNumber(rsi)}: 최근 상승폭과 하락폭을 비교한 지표예요. 현재는 단기 과열 구간으로 해석됩니다.`,
+    key: 'rsi',
+    label: '단기 과열 여부',
+    signal: 'sell',
+    status: '강한 과열',
+    strength: 0.85,
+    summary: '단기 과열 구간이라 추격 매수는 주의가 필요해요.',
+    value: `RSI ${formatNumber(rsi)}`,
+  })
+}
+
+export function evaluateMacd(macdState: MacdState): TradingSignalMetric {
+  const improving = macdState.histogram > macdState.previousHistogram
+  const weakening = macdState.histogram < macdState.previousHistogram
+  const aboveBelow = macdState.macd >= macdState.signal ? '위' : '아래'
+  const changeDirection = improving ? '개선' : weakening ? '둔화' : '유지'
+  const value = `MACD Histogram ${formatSignedNumber(macdState.histogram)}`
+
+  if (macdState.histogram > 0 && improving) {
+    return createCoreMetric({
+      description: `${value}: MACD가 Signal 선보다 ${aboveBelow}에 있으며, 전일 대비 ${changeDirection}되고 있습니다.`,
+      key: 'macd',
+      label: '추세 방향',
+      signal: 'buy',
+      status: '상승 흐름',
+      strength: 0.8,
+      summary: '상승 흐름이 이어지고 있어요.',
+      value,
+    })
+  }
+
+  if (macdState.histogram > 0 && weakening) {
+    return createCoreMetric({
+      description: `${value}: MACD가 Signal 선보다 ${aboveBelow}에 있지만, 전일 대비 ${changeDirection}되는 모습입니다.`,
+      key: 'macd',
+      label: '추세 방향',
+      signal: 'buy',
+      status: '상승 둔화',
+      strength: 0.35,
+      summary: '상승 흐름은 있지만 힘은 조금 약해지고 있어요.',
+      value,
+    })
+  }
+
+  if (macdState.histogram < 0 && improving) {
+    return createCoreMetric({
+      description: `${value}: MACD가 Signal 선보다 ${aboveBelow}에 있지만, 전일 대비 ${changeDirection}되며 반등 조짐을 보이고 있습니다.`,
+      key: 'macd',
+      label: '추세 방향',
+      signal: 'buy',
+      status: '반등 조짐',
+      strength: 0.45,
+      summary: '하락 흐름이 약해지고 반등 조짐이 보여요.',
+      value,
+    })
+  }
+
+  if (macdState.histogram < 0 && weakening) {
+    return createCoreMetric({
+      description: `${value}: MACD가 Signal 선보다 ${aboveBelow}에 있으며, 전일 대비 ${changeDirection}되고 있습니다.`,
+      key: 'macd',
+      label: '추세 방향',
+      signal: 'sell',
+      status: '하락 압력',
+      strength: 0.75,
+      summary: '아직 하락 압력이 남아 있어요.',
+      value,
+    })
+  }
+
+  return createCoreMetric({
+    description: `${value}: MACD가 Signal 선 근처에서 비슷하게 움직여 추세 방향이 뚜렷하지 않습니다.`,
+    key: 'macd',
+    label: '추세 방향',
+    signal: 'neutral',
+    status: '중립',
+    strength: 0,
+    summary: '추세 방향이 뚜렷하지 않아요.',
+    value,
+  })
+}
+
+export function evaluateVolume(volumeRatio: number, recentReturn3d: number): TradingSignalMetric {
+  if (volumeRatio < 1.2) {
+    return createCoreMetric({
+      description: `거래량 ${formatNumber(volumeRatio)}배: 최근 20일 평균 거래량 대비 현재 거래량이에요. 최근 3일 수익률은 ${formatSignedPercent(recentReturn3d)}입니다.`,
+      key: 'volume',
+      label: '거래 활발도',
+      signal: 'neutral',
+      status: '평균 수준',
+      strength: 0,
+      summary: '거래량은 평소와 비슷해서 강한 수급 신호는 없어요.',
+      value: `거래량 ${formatNumber(volumeRatio)}배`,
+    })
+  }
+
+  const strength = Math.min(1, (volumeRatio - 1.2) / 1.3)
+  const value = `거래량 ${formatNumber(volumeRatio)}배`
+  const description = `${value}: 최근 20일 평균 거래량 대비 현재 거래량이에요. 최근 3일 수익률은 ${formatSignedPercent(recentReturn3d)}입니다.`
+
+  if (recentReturn3d > 0) {
+    return createCoreMetric({
+      description,
+      key: 'volume',
+      label: '거래 활발도',
+      signal: 'buy',
+      status: '관심 증가',
+      strength,
+      summary: '평소보다 거래가 늘면서 관심이 붙고 있어요.',
+      value,
+    })
+  }
+
+  if (recentReturn3d < 0) {
+    return createCoreMetric({
+      description,
+      key: 'volume',
+      label: '거래 활발도',
+      signal: 'sell',
+      status: '매도 압력',
+      strength,
+      summary: '거래가 늘었지만 가격은 밀리고 있어 매도 압력이 커 보여요.',
+      value,
+    })
+  }
+
+  return createCoreMetric({
+    description,
+    key: 'volume',
+    label: '거래 활발도',
+    signal: 'neutral',
+    status: '방향 대기',
+    strength: 0,
+    summary: '거래량은 늘었지만 가격 방향은 아직 분명하지 않아요.',
+    value,
+  })
+}
+
+export function evaluateWeek52Position(week52Band: number): TradingSignalMetric {
+  const normalizedBand = clamp(week52Band, 0, 1)
+  const percentile = normalizedBand * 100
+  const value = `52주 위치 하위 ${formatNumber(percentile)}%`
+
+  if (normalizedBand <= 0.25) {
+    return createCoreMetric({
+      description: `${value}: 52주 저가와 고가 사이에서 현재가가 위치한 비율입니다. 최근 1년 기준으로 낮은 가격대에 있어요.`,
+      key: 'fiftyTwoWeek',
+      label: '가격 위치',
+      signal: 'buy',
+      status: '저점권 근접',
+      strength: 0.75,
+      summary: '최근 1년 기준으로 낮은 가격대에 있어요.',
+      value,
+    })
+  }
+
+  if (normalizedBand <= 0.4) {
+    return createCoreMetric({
+      description: `${value}: 52주 저가와 고가 사이에서 현재가가 위치한 비율입니다. 1년 가격 범위에서 비교적 낮은 편이에요.`,
+      key: 'fiftyTwoWeek',
+      label: '가격 위치',
+      signal: 'buy',
+      status: '낮은 가격대',
+      strength: 0.35,
+      summary: '1년 가격 범위에서 비교적 낮은 편이에요.',
+      value,
+    })
+  }
+
+  if (normalizedBand < 0.75) {
+    return createCoreMetric({
+      description: `${value}: 52주 저가와 고가 사이에서 현재가가 위치한 비율입니다. 1년 가격 범위에서 중간 구간에 있어요.`,
+      key: 'fiftyTwoWeek',
+      label: '가격 위치',
+      signal: 'neutral',
+      status: '중간 구간',
+      strength: 0,
+      summary: '1년 가격 범위에서 중간 구간에 있어요.',
+      value,
+    })
+  }
+
+  if (normalizedBand < 0.9) {
+    return createCoreMetric({
+      description: `${value}: 52주 저가와 고가 사이에서 현재가가 위치한 비율입니다. 1년 기준으로 꽤 높은 가격대에 있어요.`,
+      key: 'fiftyTwoWeek',
+      label: '가격 위치',
+      signal: 'sell',
+      status: '고점권 경계',
+      strength: 0.35,
+      summary: '1년 기준으로 꽤 높은 가격대에 있어요.',
+      value,
+    })
+  }
+
+  return createCoreMetric({
+    description: `${value}: 52주 저가와 고가 사이에서 현재가가 위치한 비율입니다. 1년 고점에 가까워 단기 부담이 있을 수 있어요.`,
+    key: 'fiftyTwoWeek',
+    label: '가격 위치',
+    signal: 'sell',
+    status: '고점권',
+    strength: 0.75,
+    summary: '1년 고점에 가까워 단기 부담이 있을 수 있어요.',
+    value,
+  })
+}
+
+export function calculateConfidence(
+  metrics: Array<Pick<TradingSignalMetric, 'key' | 'signal'>>,
+  normalizedScore: number,
+): TradingConfidence {
+  const core = metrics.filter(metric => ['rsi', 'macd', 'volume'].includes(metric.key))
+  const positive = core.filter(metric => metric.signal === 'buy').length
+  const negative = core.filter(metric => metric.signal === 'sell').length
+  const aligned = positive >= 2 || negative >= 2
+
+  if (aligned && Math.abs(normalizedScore) >= 0.45) {
+    return 'high'
+  }
+
+  if (aligned && Math.abs(normalizedScore) >= 0.25) {
+    return 'medium'
+  }
+
+  return 'low'
+}
+
+export function analyzeTradingSignalIndicators(input: BuildTradingSignalAnalysisInput): TradingSignalAnalysis {
+  const metrics = [
+    evaluateRsi(input.rsi),
+    evaluateMacd(input.macdState),
+    evaluateVolume(input.volumeRatio, input.recentReturn3d),
+    evaluateWeek52Position(input.week52Band),
+  ]
+  const referenceMetrics = [
+    buildSixMonthMetric(input.diffFromAverage6Month),
+    buildInsiderMetric(input.insiderActivity, input.market),
+  ]
+
+  const rawScore = metrics.reduce((sum, metric) => sum + metric.contribution, 0)
+  const normalizedScore = clamp(rawScore / TOTAL_WEIGHT, -1, 1)
+  const score = Math.round((normalizedScore + 1) * 50)
+  const label = resolveScoreLabel(score)
+  const recommendation = resolveRecommendation(score)
+  const confidence = calculateConfidence(metrics, normalizedScore)
+  const confidenceSummary = resolveConfidenceSummary(confidence)
+
+  return {
+    confidence,
+    confidenceSummary,
+    expertDetails: [...metrics, ...referenceMetrics].map(toExpertDetail),
+    label,
+    metrics,
+    normalizedScore,
+    recommendation,
+    referenceMetrics,
+    score,
+    summary: buildTradingSummary(metrics, label),
+  }
+}
+
 export function buildTradingSignal(input: BuildTradingSignalInput): TradingSignal {
   const closes = input.priceHistory.map(point => point.close)
   const volumes = input.priceHistory.map(point => point.volume)
@@ -199,42 +603,43 @@ export function buildTradingSignal(input: BuildTradingSignalInput): TradingSigna
   const macdState = calculateMacdState(closes)
   const averageVolume20 = average(volumes.slice(-20))
   const latestVolume = volumes[volumes.length - 1] ?? 0
-  const latestClose = closes[closes.length - 1] ?? currentPrice
-  const previousClose = closes[closes.length - 2] ?? latestClose
   const volumeRatio = averageVolume20 > 0 ? latestVolume / averageVolume20 : 1
   const week52Band = input.week52High > input.week52Low
-    ? ((currentPrice - input.week52Low) / (input.week52High - input.week52Low))
+    ? clamp((currentPrice - input.week52Low) / (input.week52High - input.week52Low), 0, 1)
     : 0.5
   const average6Month = average(closes.slice(-126))
   const diffFromAverage6Month = average6Month > 0 ? ((currentPrice - average6Month) / average6Month) * 100 : 0
-
-  const metrics: TradingSignalMetric[] = [
-    buildRsiMetric(rsi),
-    buildMacdMetric(macdState),
-    buildVolumeMetric(volumeRatio, latestClose - previousClose),
-    buildFiftyTwoWeekMetric(week52Band),
-    buildSixMonthMetric(diffFromAverage6Month),
-    buildInsiderMetric(input.insiderActivity, input.market),
-  ]
-
-  const score = metrics.reduce((sum, metric) => sum + scoreSignal(metric.signal), 0)
-  const recommendation = score >= 2 ? 'buy' : score <= -2 ? 'sell' : 'neutral'
-  const strongestMetric = [...metrics]
-    .sort((left, right) => Math.abs(scoreSignal(right.signal)) - Math.abs(scoreSignal(left.signal)))
-    .find(metric => metric.signal !== 'neutral')
+  const recentReturn3d = calculateRecentReturn(closes, 3)
+  const analysis = analyzeTradingSignalIndicators({
+    diffFromAverage6Month,
+    insiderActivity: input.insiderActivity,
+    macdState,
+    market: input.market,
+    recentReturn3d,
+    rsi,
+    volumeRatio,
+    week52Band,
+  })
 
   return {
     companyName: input.companyName,
+    confidence: analysis.confidence,
+    confidenceSummary: analysis.confidenceSummary,
+    currentPrice,
+    expertDetails: analysis.expertDetails,
     fetchedAt: new Date().toISOString(),
-    headline: strongestMetric
-      ? `${input.companyName}은(는) 지금 ${strongestMetric.label} 흐름이 가장 두드러져 보여요.`
-      : `${input.companyName}은(는) 지금 뚜렷한 과열·과매도 신호가 크지 않아요.`,
+    label: analysis.label,
     market: input.market,
     marketSymbol: input.marketSymbol,
-    metrics,
-    recommendation,
-    score,
+    metrics: analysis.metrics,
+    normalizedScore: analysis.normalizedScore,
+    recommendation: analysis.recommendation,
+    referenceMetrics: analysis.referenceMetrics,
+    score: analysis.score,
+    summary: analysis.summary,
     ticker: input.ticker,
+    week52High: input.week52High,
+    week52Low: input.week52Low,
   }
 }
 
@@ -325,210 +730,238 @@ export async function fetchYahooSnapshot(ticker: string, market: TradingMarket):
   throw new Error(`Unable to fetch price history for ${market}:${ticker}`)
 }
 
-function buildRsiMetric(rsi: number): TradingSignalMetric {
-  if (rsi <= 35) {
-    return {
-      key: 'rsi',
-      label: 'RSI',
-      signal: 'buy',
-      summary: `RSI가 ${formatNumber(rsi)}라 많이 눌린 구간이라, 단기 반등을 노리는 매수 관점으로 볼 수 있어요.`,
-      value: `RSI ${formatNumber(rsi)}`,
-    }
-  }
-
-  if (rsi >= 70) {
-    return {
-      key: 'rsi',
-      label: 'RSI',
-      signal: 'sell',
-      summary: `RSI가 ${formatNumber(rsi)}라 단기 과열 신호가 강해서, 추격 매수보다 일부 차익 실현을 생각할 수 있어요.`,
-      value: `RSI ${formatNumber(rsi)}`,
-    }
-  }
-
-  return {
-    key: 'rsi',
-    label: 'RSI',
-    signal: 'neutral',
-    summary: `RSI가 ${formatNumber(rsi)}라 과열도 과매도도 아닌 중간 구간이라, 방향성이 더 모일 때까지 관망 구간이에요.`,
-    value: `RSI ${formatNumber(rsi)}`,
-  }
-}
-
-function buildMacdMetric(macdState: { histogram: number; macd: number; signal: number }): TradingSignalMetric {
-  if (macdState.histogram > 0) {
-    return {
-      key: 'macd',
-      label: 'MACD',
-      signal: 'buy',
-      summary: `MACD가 시그널선 위로 올라와서, 최근 상승 탄력이 붙기 시작한 흐름으로 해석할 수 있어요.`,
-      value: `히스토그램 ${formatSignedNumber(macdState.histogram)}`,
-    }
-  }
-
-  if (macdState.histogram < 0) {
-    return {
-      key: 'macd',
-      label: 'MACD',
-      signal: 'sell',
-      summary: `MACD가 시그널선 아래에 있어, 상승 힘보다 하락 압력이 더 강한 구간으로 볼 수 있어요.`,
-      value: `히스토그램 ${formatSignedNumber(macdState.histogram)}`,
-    }
-  }
-
-  return {
-    key: 'macd',
-    label: 'MACD',
-    signal: 'neutral',
-    summary: 'MACD가 기준선 근처라 매수세와 매도세가 팽팽해서, 추세 확인이 더 필요한 구간이에요.',
-    value: `히스토그램 ${formatSignedNumber(macdState.histogram)}`,
-  }
-}
-
-function buildVolumeMetric(volumeRatio: number, priceDelta: number): TradingSignalMetric {
-  const value = `20일 평균의 ${formatNumber(volumeRatio)}배`
-
-  if (volumeRatio >= 1.3 && priceDelta > 0) {
-    return {
-      key: 'volume',
-      label: '거래량',
-      signal: 'buy',
-      summary: '거래량이 평소보다 크게 늘면서 가격도 같이 올라, 매수세가 실제로 붙는지 확인되는 장면이에요.',
-      value,
-    }
-  }
-
-  if (volumeRatio >= 1.3 && priceDelta < 0) {
-    return {
-      key: 'volume',
-      label: '거래량',
-      signal: 'sell',
-      summary: '거래량이 크게 터졌는데 가격이 밀려서, 매도 압력이 강하게 나오는 구간으로 볼 수 있어요.',
-      value,
-    }
-  }
-
-  return {
-    key: 'volume',
-    label: '거래량',
-    signal: 'neutral',
-    summary: '거래량이 평소와 비슷해서, 아직은 시장 참여가 폭발적으로 몰린 구간은 아니에요.',
-    value,
-  }
-}
-
-function buildFiftyTwoWeekMetric(week52Band: number): TradingSignalMetric {
-  const percentile = week52Band * 100
-
-  if (week52Band <= 0.35) {
-    return {
-      key: 'fiftyTwoWeek',
-      label: '52주 위치',
-      signal: 'buy',
-      summary: `52주 범위의 하단 ${formatNumber(percentile)}% 근처라, 가격이 바닥권에 가까운지 체크해볼 만해요.`,
-      value: `하단에서 ${formatNumber(percentile)}%`,
-    }
-  }
-
-  if (week52Band >= 0.8) {
-    return {
-      key: 'fiftyTwoWeek',
-      label: '52주 위치',
-      signal: 'sell',
-      summary: `52주 범위의 상단 ${formatNumber(percentile)}% 근처라, 이미 많이 오른 자리인지 확인이 필요한 구간이에요.`,
-      value: `하단에서 ${formatNumber(percentile)}%`,
-    }
-  }
-
-  return {
-    key: 'fiftyTwoWeek',
-    label: '52주 위치',
-    signal: 'neutral',
-    summary: '52주 범위의 중간쯤에 있어서, 아직은 극단적으로 싸거나 비싼 자리라고 보긴 어려워요.',
-    value: `하단에서 ${formatNumber(percentile)}%`,
-  }
-}
-
 function buildSixMonthMetric(diffFromAverage6Month: number): TradingSignalMetric {
   const value = `6개월 평균 대비 ${formatSignedPercent(diffFromAverage6Month)}`
 
   if (diffFromAverage6Month <= -8) {
-    return {
+    return createReferenceMetric({
+      description: `${value}: 현재가가 6개월 평균보다 꽤 낮아 평균 회귀 관점의 저가 구간으로 볼 수 있어요.`,
       key: 'sixMonthAverage',
       label: '6개월 평균 대비',
       signal: 'buy',
-      summary: '현재가가 6개월 평균보다 꽤 낮아서, 평균 회귀 관점의 저가 구간으로 볼 수 있어요.',
+      status: '평균 대비 낮음',
+      summary: '현재가가 6개월 평균보다 꽤 낮아요.',
       value,
-    }
+    })
   }
 
   if (diffFromAverage6Month >= 10) {
-    return {
+    return createReferenceMetric({
+      description: `${value}: 현재가가 6개월 평균보다 많이 위에 있어 단기 과열로 되돌림이 나올 수 있어요.`,
       key: 'sixMonthAverage',
       label: '6개월 평균 대비',
       signal: 'sell',
-      summary: '현재가가 6개월 평균보다 많이 위에 있어, 단기 과열로 되돌림이 나올 수 있는 자리예요.',
+      status: '평균 대비 높음',
+      summary: '현재가가 6개월 평균보다 많이 위에 있어요.',
       value,
-    }
+    })
   }
 
-  return {
+  return createReferenceMetric({
+    description: `${value}: 현재가가 6개월 평균과 크게 다르지 않아 중기 기준으로는 중립 구간이에요.`,
     key: 'sixMonthAverage',
     label: '6개월 평균 대비',
     signal: 'neutral',
-    summary: '현재가가 6개월 평균과 크게 다르지 않아, 추세보다 박스권에 가까운 흐름으로 볼 수 있어요.',
+    status: '중립',
+    summary: '현재가가 6개월 평균과 크게 다르지 않아요.',
     value,
-  }
+  })
 }
 
 function buildInsiderMetric(activity: InsiderActivitySummary, market: TradingMarket): TradingSignalMetric {
   if (market !== 'US') {
-    return {
+    return createReferenceMetric({
+      description: '국내 종목은 무료 공개 소스가 제한적이라 내부자 매매는 참고용 중립 값으로 보여드려요.',
       key: 'insider',
       label: '내부자 매매',
       signal: 'neutral',
-      summary: '국내 종목은 무료 공개 소스가 제한적이라 내부자 매매는 참고용 중립 값으로 보여드려요.',
+      status: '데이터 제한',
+      summary: '국내 종목은 내부자 매매를 참고용 중립 값으로 보여드려요.',
       value: '무료 공개 데이터 제한',
-    }
+    })
   }
 
   if (activity.buyCount === 0 && activity.sellCount === 0) {
-    return {
+    return createReferenceMetric({
+      description: '최근 30일 기준으로 눈에 띄는 내부자 매매가 없어, 경영진 신호는 중립으로 볼 수 있어요.',
       key: 'insider',
       label: '내부자 매매',
       signal: 'neutral',
-      summary: '최근 30일 기준으로 눈에 띄는 내부자 매매가 없어, 경영진 신호는 중립으로 볼 수 있어요.',
+      status: '공시 없음',
+      summary: '최근 30일 내부자 공시가 뚜렷하지 않아요.',
       value: '최근 30일 공시 없음',
-    }
+    })
   }
 
   if (activity.netValue > 0) {
-    return {
+    return createReferenceMetric({
+      description: `최근 30일 내부자 순매수가 보여 회사 안쪽 인물들이 주가를 긍정적으로 보는 신호로 읽을 수 있어요.`,
       key: 'insider',
       label: '내부자 매매',
       signal: 'buy',
-      summary: `최근 30일 내부자 순매수가 보여서, 회사 안쪽 인물들이 주가를 긍정적으로 보는 신호로 읽을 수 있어요.`,
+      status: '순매수 우위',
+      summary: '최근 30일 내부자 순매수가 보여요.',
       value: `매수 ${activity.buyCount}건 / 매도 ${activity.sellCount}건`,
-    }
+    })
   }
 
   if (activity.netValue < 0) {
-    return {
+    return createReferenceMetric({
+      description: `최근 30일 내부자 순매도가 우세해 경영진이 일부 차익 실현에 나선 흐름으로 볼 수 있어요.`,
       key: 'insider',
       label: '내부자 매매',
       signal: 'sell',
-      summary: `최근 30일 내부자 순매도가 우세해서, 경영진이 일부 차익 실현에 나선 흐름으로 볼 수 있어요.`,
+      status: '순매도 우위',
+      summary: '최근 30일 내부자 순매도가 우세해요.',
       value: `매수 ${activity.buyCount}건 / 매도 ${activity.sellCount}건`,
-    }
+    })
   }
 
-  return {
+  return createReferenceMetric({
+    description: '내부자 매수와 매도가 비슷하게 섞여 있어 한쪽으로 강한 방향 신호를 주진 않아요.',
     key: 'insider',
     label: '내부자 매매',
     signal: 'neutral',
-    summary: '내부자 매수와 매도가 비슷하게 섞여 있어, 한쪽으로 강한 방향 신호를 주진 않아요.',
+    status: '혼조',
+    summary: '내부자 매수와 매도가 비슷하게 섞여 있어요.',
     value: `매수 ${activity.buyCount}건 / 매도 ${activity.sellCount}건`,
+  })
+}
+
+function buildTradingSummary(metrics: TradingSignalMetric[], label: string): string {
+  const priceMetric = metrics.find(metric => metric.key === 'fiftyTwoWeek')
+  const macdMetric = metrics.find(metric => metric.key === 'macd')
+  const volumeMetric = metrics.find(metric => metric.key === 'volume')
+
+  const pricePhrase = resolvePricePhrase(priceMetric)
+  const trendPhrase = resolveTrendPhrase(macdMetric, volumeMetric)
+  const actionGuide = resolveActionGuide(label)
+
+  return `${pricePhrase} ${trendPhrase} ${actionGuide}`
+}
+
+function resolvePricePhrase(metric?: TradingSignalMetric): string {
+  if (!metric) return '가격은 중간 구간에 있고'
+  if (metric.signal === 'buy' && metric.strength >= 0.7) return '가격 부담은 낮고'
+  if (metric.signal === 'buy') return '가격도 합리적인 편이고'
+  if (metric.signal === 'sell' && metric.strength >= 0.7) return '가격이 1년 고점권에 가까워'
+  if (metric.signal === 'sell') return '가격대가 다소 높아졌고'
+  return '가격은 중간 구간에 있고'
+}
+
+function resolveTrendPhrase(macdMetric?: TradingSignalMetric, volumeMetric?: TradingSignalMetric): string {
+  if (macdMetric?.status === '상승 흐름' && volumeMetric?.signal === 'buy') {
+    return '상승 신호가 나오고 있어요.'
   }
+
+  if (macdMetric?.status === '반등 조짐') {
+    return '하락 흐름이 약해지며 반등 조짐이 보여요.'
+  }
+
+  if (macdMetric?.signal === 'sell' && volumeMetric?.signal === 'sell') {
+    return '가격 흐름과 수급이 모두 약해 보여요.'
+  }
+
+  if (macdMetric?.signal === 'sell') {
+    return '아직 하락 압력이 남아 있어요.'
+  }
+
+  if (volumeMetric?.signal === 'buy') {
+    return '거래도 늘며 관심이 붙고 있어요.'
+  }
+
+  return '아직 뚜렷한 방향성은 강하지 않아요.'
+}
+
+function resolveActionGuide(label: string): string {
+  if (label === '분할매수 고려') {
+    return '한 번에 사기보다 조금씩 나눠서 보는 게 좋아요.'
+  }
+
+  if (label === '관심 종목') {
+    return '조금 더 흐름을 확인하면서 관심 있게 볼 만해요.'
+  }
+
+  if (label === '관망 우세') {
+    return '성급하게 움직이기보다 흐름을 더 지켜보는 게 좋아요.'
+  }
+
+  if (label === '주의 필요') {
+    return '반등 확인 전까지는 보수적으로 보는 편이 좋아요.'
+  }
+
+  return '새로 들어가기보다 반등 신호가 나올 때까지 기다리는 편이 좋아요.'
+}
+
+function resolveConfidenceSummary(confidence: TradingConfidence): string {
+  if (confidence === 'high') {
+    return '여러 핵심 지표가 같은 방향을 가리키고 있어요.'
+  }
+
+  if (confidence === 'medium') {
+    return '일부 핵심 지표가 같은 방향을 보이고 있어요.'
+  }
+
+  return '지표들이 엇갈려 조금 더 확인이 필요해요.'
+}
+
+function resolveScoreLabel(score: number): string {
+  if (score >= 75) return '분할매수 고려'
+  if (score >= 60) return '관심 종목'
+  if (score >= 45) return '관망 우세'
+  if (score >= 30) return '주의 필요'
+  return '리스크 높음'
+}
+
+function resolveRecommendation(score: number): TradingRecommendation {
+  if (score >= 60) return 'buy'
+  if (score < 45) return 'sell'
+  return 'neutral'
+}
+
+function createCoreMetric(
+  input: Omit<TradingSignalMetric, 'contribution' | 'includedInScore' | 'weight'>,
+): TradingSignalMetric {
+  const weight = WEIGHTS[input.key as keyof typeof WEIGHTS]
+  return {
+    ...input,
+    contribution: directionScore(input.signal) * input.strength * weight,
+    includedInScore: true,
+    weight,
+  }
+}
+
+function createReferenceMetric(
+  input: Omit<TradingSignalMetric, 'contribution' | 'includedInScore' | 'strength' | 'weight'>,
+): TradingSignalMetric {
+  return {
+    ...input,
+    contribution: 0,
+    includedInScore: false,
+    strength: 0,
+    weight: 0,
+  }
+}
+
+function toExpertDetail(metric: TradingSignalMetric): TradingSignalExpertDetail {
+  return {
+    contribution: metric.includedInScore ? formatContribution(metric.contribution) : null,
+    description: metric.description,
+    key: metric.key,
+    status: metric.status,
+    title: metric.label,
+    value: metric.value,
+  }
+}
+
+function calculateRecentReturn(closes: number[], days: number): number {
+  if (closes.length <= days) return 0
+
+  const latest = closes[closes.length - 1]
+  const baseline = closes[closes.length - 1 - days]
+  if (!baseline) return 0
+
+  return ((latest - baseline) / baseline) * 100
 }
 
 function average(values: number[]): number {
@@ -550,6 +983,16 @@ function calculateExponentialMovingAverage(values: number[], period: number): nu
   return ema
 }
 
+function directionScore(signal: TradingRecommendation): number {
+  if (signal === 'buy') return 1
+  if (signal === 'sell') return -1
+  return 0
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
 function formatNumber(value: number): string {
   return value.toFixed(1).replace(/\.0$/, '')
 }
@@ -562,16 +1005,14 @@ function formatSignedPercent(value: number): string {
   return `${value >= 0 ? '+' : ''}${formatNumber(value)}%`
 }
 
+function formatContribution(value: number): string {
+  return `${value >= 0 ? '+' : ''}${value.toFixed(2)}`
+}
+
 function parseMoney(value: string): number {
   const normalized = value.replace(/[,$]/g, '')
   const parsed = Number(normalized)
   return Number.isFinite(parsed) ? parsed : 0
-}
-
-function scoreSignal(signal: TradingRecommendation): number {
-  if (signal === 'buy') return 1
-  if (signal === 'sell') return -1
-  return 0
 }
 
 function stripHtml(value: string): string {


### PR DESCRIPTION
## What changed
- Redesigned `/signals` stock cards and shared the bottom navigation across `/diagnosis`, `/market`, and `/signals`.
- Aligned signal metric labels with product language: `RSI` → `단기 과열 여부`, `MACD` → `추세 방향`, `거래량` → `거래 활발도`, `52주 위치` → `가격 위치`.
- Added and updated tests for the new card structure and metric labels.

## Why
- The UI needed to match the issue screenshot and the updated terminology had to be consistent across the app.

## Validation
- `COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm@9.15.4 verify`
- Result: 22 test files passed, 131 tests passed
