### PR TITLE
[codex] 시장 진입 점수 규칙을 명시적으로 고정

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -7,14 +7,14 @@
 
 ## 1. Visual Theme & Atmosphere
 
-포트폴리오 닥터는 의사 리포트 느낌의 진단 도구다 — 마케팅 랜딩 페이지가 아니다. 디자인 언어는 "당신의 포트폴리오를 정확하게 읽겠다"는 신뢰를 딥 네이비(`#1A237E`)로 전달한다. 배경은 네이비 틴트(`#F4F6FF`)로 미묘하게 브랜드를 물들이고, 카드와 패널은 흰색 표면 위에 올라앉아 정보 밀도를 높인다.
+포트폴리오 닥터는 의사 리포트 느낌의 진단 도구다. 디자인 언어는 "당신의 포트폴리오를 정확하게 읽겠다"는 신뢰를 딥 네이비 `rgb(28, 43, 94)` (`#1C2B5E`)로 전달한다. 배경은 네이비 틴트(`#F4F6FF`)로 미묘하게 브랜드를 물들이고, 카드와 패널은 흰색 표면 위에 올라앉아 정보 밀도를 높인다.
 
 타이포그래피는 Pretendard Variable 단일 패밀리로 구성된다. 진단 숫자는 42px weight 800, 자간 -2px로 숫자가 화면을 압도한다. 이건 의도적이다 — 유저는 숫자를 먼저 읽고, 맥락을 뒤에 읽는다. 버튼은 border-radius 12px의 둥근 직사각형. 풀 필이 아닌 이유는 앱 도구의 정밀함을 표현하기 위해서다.
 
 시맨틱 컬러는 진단 결과에 직접 매핑된다. 빨강(`--red`)은 심각한 편중, 앰버(`--amber`)는 개선 권고, 초록(`--green`)은 양호 상태. 그림자 없음 — 깊이는 색상 대비와 보더로 표현한다.
 
 **핵심 특성:**
-- 딥 네이비(`#1A237E`) 단일 브랜드 액센트 — 그라디언트 없음
+- 딥 네이비(`rgb(28, 43, 94)` / `#1C2B5E`) 단일 브랜드 액센트
 - `#F4F6FF` 배경 + 흰색 카드 표면 — 정보 계층 분리
 - 버튼 radius 12px — 도구적 정밀함, 풀 필 아님
 - Pretendard Variable 단일 패밀리, weight 400–800
@@ -30,10 +30,10 @@
 
 | 토큰 | 값 | 역할 |
 |------|-----|------|
-| `--navy` | `#1A237E` | 메인 브랜드, CTA, 헤드라인, 진단 대형 숫자 |
-| `--navy-dark` | `#121858` | 버튼 호버, 눌림 상태 |
-| `--navy-mid` | `#3949AB` | 보조 강조, 링크 |
-| `--navy-tint` | `#E8EAF6` | 배지 배경, 하이라이트 |
+| `--navy` | `#1C2B5E` | 메인 브랜드, CTA, 헤더 카드, 진단 핵심 숫자 |
+| `--navy-dark` | `#16224A` | 버튼 호버, 눌림 상태 |
+| `--navy-mid` | `#30457F` | 보조 강조, 링크 |
+| `--navy-tint` | `#E9EDF6` | 배지 배경, 하이라이트 |
 
 ### 레이아웃
 
@@ -81,7 +81,7 @@
 | 인라인 에러 텍스트 | `--red` |
 | 섹션 레이블 | `--text-3` |
 
-**금지:** 네이비 그라디언트. `--navy`를 배경 전체에 깔기. 텍스트에 `--navy-tint` 사용.
+**금지:** 헤더 바 전체를 네이비로 꽉 채우는 처리. 텍스트에 `--navy-tint` 사용.
 
 ---
 
@@ -200,16 +200,33 @@ padding: 16px
 ```
 배경: --surface
 border: 1px solid --border
-border-radius: 14px
-padding: 18px 20px 18px 22px
-border-left: 3px solid (--red 심각 | --amber 주의)
+border-radius: 28px~36px
+padding: 26px~36px
+shadow: 0 18px 36px rgba(15, 23, 42, 0.06)
 
-[번호] 01 · 자산 편중         10px 800 uppercase --text-3
-[제목] 국내주식에 너무 쏠려 있습니다   17px 800 --text-1
-[수치] 81%  →  40% 목표
-        ↑ 36px 800 tabular-nums (--red or --amber)
-               ↑ 18px 700 --text-2
-[설명] 13px 400 --text-2 line-height 1.6
+[상단 배지] ● 01 · 섹터 집중
+  - 심각: pale red pill + red dot/text
+  - 주의: pale amber pill + amber dot/text
+
+[제목] 반도체 섹터 비중이 높습니다
+  - 26px~33px / 800 / tight tracking
+
+[수치 패널]
+  background: #F6F7FC
+  border-radius: 24px~28px
+  2열 중앙 정렬
+  가운데 1px divider
+
+  현재        | 적정 상한
+  46.7%       | 50%
+
+  - label: 13px~15px / 700 / muted gray
+  - current value: semantic red or amber
+  - target value: neutral gray
+
+[설명]
+  14px~18px / 600 / line-height 1.55
+  섹터 분산을 위해 일부 비중 조정이 필요합니다.
 ```
 
 ---

--- a/src/app/diagnosis/page.module.css
+++ b/src/app/diagnosis/page.module.css
@@ -1,70 +1,166 @@
 /* src/app/diagnosis/page.module.css */
-.wrap { display: flex; flex-direction: column; min-height: 100dvh; }
+.wrap {
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+  background: var(--bg);
+}
 
-.header { background: var(--navy); padding: 20px 20px 20px; }
+.header {
+  padding: 0;
+}
+
+.headerCard {
+  overflow: hidden;
+  margin: 16px 16px 0;
+  border-radius: 20px;
+  background: var(--navy);
+}
+
+.headerTopRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 18px 0;
+}
+
 .date {
   font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(255,255,255,.5);
-  margin-bottom: 10px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.4);
 }
-.headline { font-size: 14px; font-weight: 600; color: rgba(255,255,255,.75); margin-bottom: 2px; }
+
+.retryBtn {
+  border: none;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.1);
+  padding: 5px 10px;
+  font-size: 11px;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.retryBtn:active {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.headerBody {
+  padding: 16px 18px 0;
+}
+
+.headline {
+  margin-bottom: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.45);
+}
+
 .bigNum {
-  font-size: 42px;
-  font-weight: 800;
+  margin-bottom: 4px;
+  font-size: 52px;
+  font-weight: 900;
   letter-spacing: -2px;
   line-height: 1;
   color: #fff;
-  margin-bottom: 4px;
 }
+
 .bigNum em {
   margin-left: 6px;
   font-style: normal;
-  font-size: 18px;
+  font-size: 20px;
   font-weight: 700;
-  color: rgba(255,255,255,.7);
-  vertical-align: middle;
+  color: rgba(255, 255, 255, 0.85);
+  vertical-align: 8px;
 }
-.subline { font-size: 14px; font-weight: 600; color: rgba(255,255,255,.75); margin-bottom: 10px; }
+
+.healthyTitle {
+  margin-bottom: 6px;
+  font-size: 30px;
+  font-weight: 900;
+  letter-spacing: -0.05em;
+  line-height: 1.04;
+  color: #fff;
+}
+
+.subline {
+  margin-bottom: 14px;
+  font-size: 13px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.healthScore {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  padding: 5px 12px;
+  margin-bottom: 20px;
+}
+
+.healthScoreDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #f2ae34;
+}
+
+.healthScoreLabel {
+  font-size: 12px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.healthScoreValue {
+  font-size: 16px;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: #fff;
+}
+
+.allocationPanel {
+  margin: 0 12px 12px;
+  border-radius: 14px;
+  background: rgba(0, 0, 0, 0.16);
+  padding: 14px 16px;
+}
+
+.allocationPanelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.allocationPanelTitle {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.allocationPanelMeta {
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.25);
+}
+
 .targetError {
   margin-top: 10px;
+  padding: 0 4px;
   font-size: 12px;
   font-weight: 700;
   color: #ffb4b4;
 }
 
-/* 양호 상태 */
-.healthy { margin-bottom: 12px; }
-.checkIcon { font-size: 32px; color: var(--green); margin-bottom: 8px; }
-.healthyTitle { font-size: 22px; font-weight: 800; color: #fff; }
-
-.healthScore {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 8px;
-  padding: 10px 14px;
-  margin-bottom: 20px;
-  border: 1px solid rgba(255,255,255,0.16);
-  border-radius: 999px;
-  background: rgba(255,255,255,0.08);
-  color: #fff;
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px 16px 112px;
 }
-
-.healthScoreLabel {
-  font-size: 12px;
-  font-weight: 700;
-  color: rgba(255,255,255,0.72);
-}
-
-.healthScoreValue {
-  font-size: 20px;
-  font-weight: 800;
-  letter-spacing: -0.04em;
-}
-
-.body { padding: 14px 16px 112px; display: flex; flex-direction: column; gap: 8px; }
 
 .improvementSection {
   display: flex;
@@ -73,12 +169,12 @@
 }
 
 .sectionLabel {
+  padding: 10px 4px 2px;
   font-size: 11px;
   font-weight: 800;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--text-3);
-  padding: 10px 4px 4px;
 }
 
 .problemList {
@@ -87,105 +183,56 @@
   gap: 8px;
 }
 
-.actionCard {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-card);
-  overflow: hidden;
-}
-
-.fineLine {
-  margin-top: -2px;
-  padding: 0 4px;
-  font-size: 11px;
-  line-height: 1.5;
-  color: var(--text-3);
-}
-
-.improvementBtn {
+.improvementBtn,
+.signalBtn,
+.explainBtn {
   width: 100%;
-  background: var(--surface);
-  border: 1.5px solid var(--border-2);
   border-radius: var(--radius-card);
-  padding: 16px 18px;
-  font-size: 14px;
-  font-weight: 800;
-  color: var(--navy);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 14px;
-  letter-spacing: -0.2px;
+  background: var(--surface);
   text-align: left;
 }
 
-.improvementBtn:active {
-  background: var(--navy-tint);
-}
-
-.improvementBtnText {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  min-width: 0;
-}
-
-.improvementBtnTitle {
-  font-size: 14px;
-  font-weight: 800;
-  color: var(--navy);
-}
-
-.improvementBtnMeta {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-2);
-  line-height: 1.45;
-}
-
-.improvementBtnArrow {
-  font-size: 16px;
-  line-height: 1;
-  flex-shrink: 0;
-}
-
+.improvementBtn,
 .signalBtn {
-  width: 100%;
-  background: var(--surface);
-  border: 1.5px solid var(--border-2);
-  border-radius: var(--radius-card);
+  border: 1px solid var(--border);
   padding: 16px 18px;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 14px;
-  text-align: left;
 }
 
-.signalBtn:active {
-  background: var(--navy-tint);
+.improvementBtn:active,
+.signalBtn:active,
+.explainBtn:active {
+  background: #f7f8fc;
 }
 
+.improvementBtnText,
 .signalBtnText {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 4px;
   min-width: 0;
 }
 
+.improvementBtnTitle,
 .signalBtnTitle {
   font-size: 14px;
   font-weight: 800;
-  color: var(--navy);
+  letter-spacing: -0.02em;
+  color: var(--text-1);
 }
 
+.improvementBtnMeta,
 .signalBtnMeta {
   font-size: 12px;
   font-weight: 600;
+  line-height: 1.5;
   color: var(--text-2);
-  line-height: 1.45;
 }
 
+.improvementBtnArrow,
 .signalBtnArrow {
   font-size: 16px;
   font-weight: 800;
@@ -194,10 +241,7 @@
 }
 
 .explainBtn {
-  width: 100%;
-  background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: var(--radius-card);
   padding: 16px 18px;
   font-size: 14px;
   font-weight: 700;
@@ -205,57 +249,50 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  letter-spacing: -0.2px;
-  transition: background 0.1s;
+  letter-spacing: -0.02em;
 }
-.explainBtn:active { background: var(--bg); }
-.explainIcon { font-size: 11px; transition: transform 0.2s; }
-.explainOpen .explainIcon { transform: rotate(180deg); }
+
+.explainIcon {
+  font-size: 11px;
+  transition: transform 0.2s;
+}
+
+.explainOpen .explainIcon {
+  transform: rotate(180deg);
+}
 
 .explainBody {
-  background: var(--surface);
+  margin-top: -10px;
   border: 1px solid var(--border);
   border-top: none;
   border-radius: 0 0 var(--radius-card) var(--radius-card);
+  background: var(--surface);
   padding: 18px;
   font-size: 13px;
-  color: var(--text-2);
   line-height: 1.7;
-  margin-top: -8px;
-}
-.explainBody p + p { margin-top: 12px; }
-.explainBody button { background: none; border: none; color: var(--navy); text-decoration: underline; font-size: 13px; }
-
-.disclaimer {
-  font-size: 11px;
-  color: var(--text-3);
-  text-align: center;
-  line-height: 1.6;
-  padding: 4px 8px;
-}
-
-.disclaimer p + p { margin-top: 4px; }
-
-.resetBtn {
-  width: 100%;
-  background: none;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-btn);
-  padding: 14px;
-  font-size: 13px;
-  font-weight: 600;
   color: var(--text-2);
 }
-.resetBtn:active { background: var(--border); }
 
-/* 투자 MBTI 카드 */
+.explainBody p + p {
+  margin-top: 12px;
+}
+
+.explainBody button {
+  border: none;
+  background: none;
+  padding: 0;
+  font-size: 13px;
+  color: var(--navy);
+  text-decoration: underline;
+}
+
 .mbtiCard {
   border-radius: var(--radius-card);
   padding: 20px 18px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  box-shadow: 0 6px 24px rgba(28,43,94,0.25);
+  gap: 12px;
+  box-shadow: 0 6px 24px rgba(28, 43, 94, 0.25);
 }
 
 .mbtiEyebrow {
@@ -263,7 +300,7 @@
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(255,255,255,0.45);
+  color: rgba(255, 255, 255, 0.45);
 }
 
 .mbtiTop {
@@ -275,60 +312,82 @@
 .mbtiEmojiBox {
   width: 50px;
   height: 50px;
+  flex-shrink: 0;
   border-radius: 14px;
-  background: rgba(255,255,255,0.12);
+  background: rgba(255, 255, 255, 0.12);
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 24px;
-  flex-shrink: 0;
 }
 
 .mbtiCode {
-  font-size: 22px;
-  font-weight: 800;
-  letter-spacing: -0.5px;
+  font-size: 30px;
+  font-weight: 900;
+  letter-spacing: -0.05em;
   line-height: 1;
-  color: white;
+  color: #fff;
 }
 
 .mbtiName {
-  font-size: 14px;
+  margin-top: 3px;
+  font-size: 12px;
   font-weight: 600;
-  color: rgba(255,255,255,0.7);
-  margin-top: 4px;
+  color: rgba(255, 255, 255, 0.52);
 }
 
 .mbtiTagline {
   font-size: 14px;
-  font-weight: 600;
-  color: white;
+  font-weight: 700;
   line-height: 1.5;
+  color: #fff;
 }
 
 .mbtiDesc {
-  font-size: 13px;
-  color: rgba(255,255,255,0.65);
-  line-height: 1.55;
+  font-size: 12.5px;
+  line-height: 1.65;
+  color: rgba(255, 255, 255, 0.72);
 }
 
-/* 그룹별 그라디언트 */
-.mbtiGroup_analyst  { background: linear-gradient(140deg, #1C2B5E 0%, #2d479b 100%); }
-.mbtiGroup_diplomat { background: linear-gradient(140deg, #4c1d95 0%, #7c3aed 100%); }
-.mbtiGroup_sentinel { background: linear-gradient(140deg, #064e3b 0%, #059669 100%); }
-.mbtiGroup_explorer { background: linear-gradient(140deg, #7c2d12 0%, #ea580c 100%); }
+.mbtiGroup_analyst {
+  background: linear-gradient(140deg, #1c2b5e 0%, #2d479b 100%);
+}
 
-/* 공유 버튼 */
+.mbtiGroup_diplomat {
+  background: linear-gradient(140deg, #4c1d95 0%, #7c3aed 100%);
+}
+
+.mbtiGroup_sentinel {
+  background: linear-gradient(140deg, #064e3b 0%, #059669 100%);
+}
+
+.mbtiGroup_explorer {
+  background: linear-gradient(140deg, #7c2d12 0%, #ea580c 100%);
+}
+
 .shareBtn {
-  align-self: flex-start;
-  margin-top: 4px;
-  background: rgba(255,255,255,0.12);
-  border: 1.5px solid rgba(255,255,255,0.35);
-  border-radius: var(--radius-btn);
-  padding: 8px 16px;
+  align-self: stretch;
+  border: 1.5px solid rgba(255, 255, 255, 0.2);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.12);
+  padding: 13px 16px;
   font-size: 13px;
   font-weight: 700;
-  color: white;
-  transition: background 0.1s;
+  color: #fff;
 }
-.shareBtn:active { background: rgba(255,255,255,0.22); }
+
+.shareBtn:active {
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.disclaimer {
+  padding: 4px 8px;
+  font-size: 11px;
+  line-height: 1.6;
+  text-align: center;
+  color: var(--text-3);
+}
+
+.disclaimer p + p {
+  margin-top: 4px;
+}

--- a/src/app/diagnosis/page.test.ts
+++ b/src/app/diagnosis/page.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('DiagnosisPage source', () => {
+  it('removes action-item based buy/sell recommendations and keeps prototype-style sections', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).not.toContain("from '@/components/ActionItem'")
+    expect(source).not.toContain('권장 조치')
+    expect(source).toContain('포트폴리오 개선 보기')
+    expect(source).toContain('종목 시그널 분석 보기')
+    expect(source).toContain('다시 진단')
+  })
+
+  it('uses the diagnosis page styles that keep the navy header and allocation panel', () => {
+    const css = readFileSync(new URL('./page.module.css', import.meta.url), 'utf8')
+
+    expect(css).toContain('.allocationPanel')
+    expect(css).toContain('.retryBtn')
+    expect(css).toContain('.healthScoreDot')
+  })
+})

--- a/src/app/diagnosis/page.tsx
+++ b/src/app/diagnosis/page.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useState, useSyncExternalStore } from 'react'
 import { useRouter } from 'next/navigation'
 import { ProblemCard } from '@/components/ProblemCard'
 import { AllocationBar } from '@/components/AllocationBar'
-import { ActionItem } from '@/components/ActionItem'
 import { BottomNav } from '@/components/BottomNav'
 import { SectorPieChart } from '@/components/SectorPieChart'
 import { ImprovementSheet } from '@/components/ImprovementSheet'
@@ -67,6 +66,13 @@ function readStoredDiagnosis(): DiagnosisResult | null {
 
 function isStyleKey(value: unknown): value is StyleKey {
   return typeof value === 'string' && STYLE_KEYS.includes(value as StyleKey)
+}
+
+function formatDiagnosisDate(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}.${month}.${day}`
 }
 
 function readDesiredStyle(positions: PortfolioPosition[]): StyleKey {
@@ -157,40 +163,60 @@ export default function DiagnosisPage() {
 
   if (!isClient || !diagnosis) return null
 
-  const today = new Date().toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' })
+  const today = formatDiagnosisDate(new Date())
   const isHealthy = diagnosis.problems.length === 0
   const target = diagnosis.targetAllocation
   const targetErrorMessage = getTargetAllocationErrorMessage(target)
   const sectorSlices = buildSectorAllocation(positions)
   const currentScore = computeHealthScore(diagnosis.currentAllocation, target, positions, desiredStyle)
   const idealScore = computeIdealScore(diagnosis.currentAllocation, positions, desiredStyle)
-  const hasActions = diagnosis.actions.length > 0
   const scorePreview = idealScore > currentScore
     ? `건강점수 ${currentScore}점 → ${idealScore}점`
     : `건강점수 ${currentScore}점 기준으로 전체 비중 확인`
 
   return (
     <div className={styles.wrap}>
-      {/* 네이비 헤더 */}
       <div className={styles.header}>
-        <div className={styles.date}>포트폴리오 진단 결과 · {today}</div>
-        {isHealthy ? (
-          <div className={styles.healthy}>
-            <div className={styles.checkIcon}>✓</div>
-            <div className={styles.healthyTitle}>포트폴리오가 양호합니다</div>
+        <div className={styles.headerCard}>
+          <div className={styles.headerTopRow}>
+            <div className={styles.date}>포트폴리오 진단 결과 · {today}</div>
+            <button className={styles.retryBtn} type="button" onClick={() => router.push('/')}>
+              다시 진단
+            </button>
           </div>
-        ) : (
-          <>
-            <div className={styles.headline}>최적화할 수 있는</div>
-            <div className={styles.bigNum}>{diagnosis.problems.length}<em>가지</em></div>
-            <div className={styles.subline}>포인트가 있습니다</div>
-          </>
-        )}
-        <div className={styles.healthScore}>
-          <span className={styles.healthScoreLabel}>건강점수</span>
-          <strong className={styles.healthScoreValue}>{currentScore}점</strong>
+          <div className={styles.headerBody}>
+            {isHealthy ? (
+              <>
+                <div className={styles.headline}>현재 포트폴리오는</div>
+                <div className={styles.healthyTitle}>전반적으로 안정적입니다</div>
+                <div className={styles.subline}>큰 편중 없이 자산 배분이 유지되고 있어요</div>
+              </>
+            ) : (
+              <>
+                <div className={styles.headline}>최적화할 수 있는</div>
+                <div className={styles.bigNum}>{diagnosis.problems.length}<em>가지</em></div>
+                <div className={styles.healthScore}>
+                  <span className={styles.healthScoreDot} aria-hidden="true" />
+                  <span className={styles.healthScoreLabel}>포인트가 있습니다</span>
+                </div>
+              </>
+            )}
+            {isHealthy && (
+              <div className={styles.healthScore}>
+                <span className={styles.healthScoreDot} aria-hidden="true" />
+                <span className={styles.healthScoreLabel}>건강점수</span>
+                <strong className={styles.healthScoreValue}>{currentScore}점</strong>
+              </div>
+            )}
+          </div>
+          <div className={styles.allocationPanel}>
+            <div className={styles.allocationPanelHeader}>
+              <span className={styles.allocationPanelTitle}>자산 배분</span>
+              <span className={styles.allocationPanelMeta}>세로선은 목표 비중</span>
+            </div>
+            <AllocationBar current={diagnosis.currentAllocation} target={target} />
+          </div>
         </div>
-        <AllocationBar current={diagnosis.currentAllocation} target={target} />
         {targetErrorMessage && (
           <p className={styles.targetError} role="alert">
             {targetErrorMessage}
@@ -211,23 +237,6 @@ export default function DiagnosisPage() {
             </>
           )}
 
-          {hasActions && (
-            <>
-              <div className={styles.sectionLabel}>권장 조치</div>
-              <div className={styles.actionCard}>
-                {diagnosis.actions.map(action => (
-                  <ActionItem
-                    key={`${action.action}-${action.ticker}-${action.quantity}`}
-                    action={action}
-                  />
-                ))}
-              </div>
-              <p className={styles.fineLine}>
-                현재가는 캡처 시점 기준입니다. 실제 주문 전 가격과 세금은 다시 확인하세요.
-              </p>
-            </>
-          )}
-
           <button
             className={styles.improvementBtn}
             type="button"
@@ -236,7 +245,7 @@ export default function DiagnosisPage() {
             <div className={styles.improvementBtnText}>
               <span className={styles.improvementBtnTitle}>포트폴리오 개선 보기</span>
               <span className={styles.improvementBtnMeta}>
-                {scorePreview} · 현재/목표 비중 상세
+                {scorePreview} · 현재/목표 비중과 점수 차이를 확인할 수 있어요
               </span>
             </div>
             <span className={styles.improvementBtnArrow} aria-hidden="true">→</span>
@@ -255,7 +264,6 @@ export default function DiagnosisPage() {
 
         {sectorSlices.length > 0 && <SectorPieChart slices={sectorSlices} />}
 
-        {/* 왜 이 조언인가요? */}
         <button
           className={`${styles.explainBtn} ${explainOpen ? styles.explainOpen : ''}`}
           type="button"
@@ -310,10 +318,6 @@ export default function DiagnosisPage() {
             <p key={line}>{line}</p>
           ))}
         </div>
-
-        <button className={styles.resetBtn} type="button" onClick={() => router.push('/')}>
-          ↩ 다시 진단하기
-        </button>
       </div>
       <ImprovementSheet
         currentAllocation={diagnosis.currentAllocation}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,10 +1,10 @@
 @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css');
 
 :root {
-  --navy:         #1A237E;
-  --navy-dark:    #121858;
-  --navy-mid:     #3949AB;
-  --navy-tint:    #E8EAF6;
+  --navy:         #1C2B5E;
+  --navy-dark:    #16224a;
+  --navy-mid:     #30457f;
+  --navy-tint:    #e9edf6;
 
   --bg:           #F4F6FF;
   --surface:      #FFFFFF;

--- a/src/app/market/page.module.css
+++ b/src/app/market/page.module.css
@@ -1,222 +1,253 @@
 .wrap {
   min-height: 100dvh;
-  background:
-    radial-gradient(circle at top right, rgba(255, 255, 255, 0.18), transparent 30%),
-    linear-gradient(180deg, var(--navy-dark) 0 280px, var(--bg) 280px 100%);
+  background: #edeef3;
+}
+
+.page {
+  min-height: 100dvh;
+  padding-bottom: 88px;
 }
 
 .header {
-  padding: 24px 20px 28px;
-  color: #fff;
+  padding: 20px 18px 14px;
 }
 
 .eyebrow {
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.64);
+  margin-bottom: 3px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #999;
 }
 
 .title {
-  margin-top: 10px;
-  font-size: 32px;
-  line-height: 1.12;
-  letter-spacing: -0.05em;
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  color: #111;
 }
 
-.sub {
-  margin-top: 12px;
-  max-width: 680px;
-  font-size: 14px;
-  line-height: 1.7;
-  color: rgba(255, 255, 255, 0.8);
+.description {
+  margin-top: 5px;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: #aaa;
+}
+
+.content {
+  padding: 0 0 16px;
+}
+
+.heroCard,
+.stateCard,
+.skeletonCard {
+  margin: 0 16px 12px;
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
 }
 
 .heroCard {
-  display: grid;
-  gap: 14px;
-  margin-top: 20px;
-  padding: 20px;
-  border-radius: 24px;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 20px 18px 16px;
 }
 
-/* 메인 KPI: 진입 매력도 */
-.entryBlock { display: grid; gap: 6px; }
-
-.kpiEyebrow {
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.6);
-}
-
-.kpiLabel {
-  font-size: 28px;
-  font-weight: 900;
-  letter-spacing: -0.04em;
-  line-height: 1.1;
-}
-
-.kpiScore {
-  display: flex;
-  align-items: baseline;
-  gap: 3px;
-  margin-top: 2px;
-}
-
-.kpiScoreNum {
-  font-size: 42px;
-  font-weight: 900;
-  letter-spacing: -0.06em;
-  line-height: 1;
-  font-variant-numeric: tabular-nums;
-}
-
-.kpiScoreUnit {
-  font-size: 16px;
-  font-weight: 700;
-  color: rgba(255, 255, 255, 0.56);
-}
-
-.kpiSummary {
-  margin-top: 6px;
+.sectionTitle {
+  margin-bottom: 4px;
   font-size: 13px;
-  line-height: 1.65;
-  color: rgba(255, 255, 255, 0.78);
+  font-weight: 700;
+  color: #111;
 }
 
-/* 서브 KPI: 시장 건강도 */
-.healthChip {
+.heroIntro {
+  margin-bottom: 18px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #aaa;
+}
+
+.heroBody {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 11px 14px;
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  gap: 20px;
 }
 
-.healthEyebrow {
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.56);
+.gauge {
+  width: 116px;
+  height: 66px;
   flex-shrink: 0;
 }
 
-.healthLabel {
-  font-size: 14px;
+.gaugeLabel {
+  font-size: 11px;
   font-weight: 800;
-  letter-spacing: -0.02em;
-  flex: 1;
 }
 
-.healthScore {
+.gaugeCaption {
+  font-size: 8px;
+  fill: #aaa;
+}
+
+.legend {
+  flex: 1;
+  min-width: 0;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 7px;
+}
+
+.legendItem:last-child {
+  margin-bottom: 0;
+}
+
+.legendDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  background: #e8e8ec;
+}
+
+.legendLabel {
+  font-size: 12px;
+  font-weight: 400;
+  color: #bbb;
+}
+
+.legendActiveLabel {
   font-size: 12px;
   font-weight: 700;
-  color: rgba(255, 255, 255, 0.56);
-  font-variant-numeric: tabular-nums;
-  flex-shrink: 0;
+  color: #111;
 }
 
-/* 투자 시사점 */
-.implication {
-  padding: 12px 14px;
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.07);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  display: grid;
-  gap: 6px;
+.accentGreen {
+  fill: #23b26d;
+  stroke: #23b26d;
+  background: #23b26d;
+  color: #23b26d;
 }
 
-.implicationLabel {
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.56);
+.accentNavy {
+  fill: #1c2b5e;
+  stroke: #1c2b5e;
+  background: #1c2b5e;
+  color: #1c2b5e;
 }
 
-.implicationText {
-  font-size: 13px;
-  line-height: 1.65;
-  color: rgba(255, 255, 255, 0.84);
+.accentAmber {
+  fill: #e8a838;
+  stroke: #e8a838;
+  background: #e8a838;
+  color: #e8a838;
 }
 
-.heroMeta {
+.accentRed {
+  fill: #e24d4d;
+  stroke: #e24d4d;
+  background: #e24d4d;
+  color: #e24d4d;
+}
+
+.callout {
+  margin-top: 14px;
+  border-radius: 12px;
+  padding: 10px 14px;
+  font-size: 12px;
+  line-height: 1.6;
+  color: #666;
+}
+
+.calloutLabel {
+  font-weight: 700;
+}
+
+.accentGreenBackground {
+  background: rgba(35, 178, 109, 0.08);
+}
+
+.accentGreenBackground .calloutLabel {
+  color: #23b26d;
+}
+
+.accentNavyBackground {
+  background: rgba(28, 43, 94, 0.08);
+}
+
+.accentNavyBackground .calloutLabel {
+  color: #1c2b5e;
+}
+
+.accentAmberBackground {
+  background: rgba(232, 168, 56, 0.08);
+}
+
+.accentAmberBackground .calloutLabel {
+  color: #e8a838;
+}
+
+.accentRedBackground {
+  background: rgba(226, 77, 77, 0.08);
+}
+
+.accentRedBackground .calloutLabel {
+  color: #e24d4d;
+}
+
+.sectionHeader {
   display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
   align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 18px 10px;
+}
+
+.sectionEyebrow {
+  font-size: 12px;
+  font-weight: 700;
+  color: #888;
 }
 
 .refreshButton,
-.secondaryLink,
 .inlineRetry {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 44px;
-  border-radius: var(--radius-btn);
-  font-size: 13px;
-  font-weight: 800;
-}
-
-.refreshButton {
   border: none;
-  padding: 0 16px;
-  background: #fff;
-  color: var(--navy-dark);
+  background: rgba(28, 43, 94, 0.08);
+  color: #1c2b5e;
+  min-height: 34px;
+  padding: 0 12px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
 }
 
-.body {
-  padding: 0 16px 112px;
-}
-
-.actions {
-  margin-top: -10px;
-  margin-bottom: 16px;
-}
-
-.secondaryLink {
-  padding: 0 16px;
-  background: rgba(255, 255, 255, 0.85);
-  color: var(--navy);
-  border: 1px solid rgba(26, 35, 126, 0.12);
+.cardList {
+  display: grid;
+  gap: 0;
 }
 
 .metaRow {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
-  margin-bottom: 16px;
+  gap: 8px;
+  padding: 6px 16px 0;
 }
 
 .metaBadge {
   border-radius: 999px;
-  padding: 9px 12px;
-  background: rgba(255, 255, 255, 0.85);
-  border: 1px solid var(--border);
-  font-size: 12px;
+  padding: 6px 10px;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid #e3e5ea;
+  font-size: 11px;
   font-weight: 700;
-  color: var(--text-2);
+  color: #7b7f89;
 }
 
-.cardGrid {
-  display: grid;
-  gap: 14px;
-}
-
-.stateCard,
-.skeletonCard {
-  border-radius: 20px;
-  border: 1px solid var(--border);
-  background: rgba(255, 255, 255, 0.88);
+.source {
+  margin: 6px 16px 0;
+  font-size: 11px;
+  line-height: 1.7;
+  text-align: center;
+  color: #bbb;
 }
 
 .stateCard {
@@ -228,69 +259,130 @@
 
 .inlineRetry {
   margin-top: 12px;
-  padding: 0 16px;
-  border: 1px solid rgba(26, 35, 126, 0.14);
-  background: var(--surface);
-  color: var(--navy);
 }
 
-.skeletonCard {
-  padding: 18px;
+.heroSkeletonBody,
+.skeletonRow {
+  display: flex;
+  align-items: center;
+}
+
+.heroSkeletonBody {
+  gap: 20px;
+}
+
+.skeletonGauge,
+.skeletonTitle,
+.skeletonLine,
+.skeletonLineLong,
+.skeletonTitleShort,
+.skeletonLegendRow,
+.skeletonLegendRowShort,
+.skeletonCallout,
+.skeletonIcon,
+.skeletonBadge {
+  background: linear-gradient(90deg, #f2f3f7, #e7e9ef, #f2f3f7);
+  background-size: 200% 100%;
+  animation: shimmer 1.4s linear infinite;
 }
 
 .skeletonTitle,
-.skeletonValue,
 .skeletonLine,
-.skeletonLineShort {
+.skeletonLineLong,
+.skeletonTitleShort,
+.skeletonLegendRow,
+.skeletonLegendRowShort {
   border-radius: 999px;
-  background: linear-gradient(90deg, rgba(232, 234, 246, 0.9), rgba(244, 246, 255, 0.9));
 }
 
 .skeletonTitle {
-  width: 110px;
-  height: 14px;
+  width: 92px;
+  height: 13px;
+  margin-bottom: 8px;
 }
 
-.skeletonValue {
-  width: 140px;
-  height: 34px;
-  margin-top: 16px;
-}
-
-.skeletonLine,
-.skeletonLineShort {
+.skeletonLineLong {
+  width: 180px;
   height: 12px;
+  margin-bottom: 18px;
+}
+
+.skeletonGauge {
+  width: 116px;
+  height: 66px;
+  border-radius: 16px;
+}
+
+.skeletonLegend {
+  flex: 1;
+}
+
+.skeletonLegendRow,
+.skeletonLegendRowShort {
+  height: 12px;
+  margin-bottom: 8px;
+}
+
+.skeletonLegendRow {
+  width: 76px;
+}
+
+.skeletonLegendRowShort {
+  width: 58px;
+  margin-bottom: 0;
+}
+
+.skeletonCallout {
+  width: 100%;
+  height: 44px;
+  border-radius: 12px;
   margin-top: 14px;
 }
 
-.skeletonLineShort {
-  width: 72%;
+.skeletonCard {
+  padding: 14px 16px;
+  margin-bottom: 8px;
 }
 
-.source {
-  margin-top: 20px;
-  font-size: 11px;
-  color: var(--text-3);
-  text-align: center;
+.skeletonRow {
+  gap: 12px;
 }
 
-@media (min-width: 768px) {
-  .header {
-    padding: 32px 32px 36px;
+.skeletonIcon {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  flex-shrink: 0;
+}
+
+.skeletonText {
+  flex: 1;
+}
+
+.skeletonTitleShort {
+  width: 74px;
+  height: 13px;
+  margin-bottom: 8px;
+}
+
+.skeletonLine {
+  width: 180px;
+  height: 11px;
+}
+
+.skeletonBadge {
+  width: 44px;
+  height: 22px;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+
+@keyframes shimmer {
+  from {
+    background-position: 200% 0;
   }
 
-  .heroCard,
-  .body {
-    max-width: 980px;
-    margin: 0 auto;
-  }
-
-  .body {
-    padding: 0 24px 128px;
-  }
-
-  .cardGrid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    align-items: start;
+  to {
+    background-position: -200% 0;
   }
 }

--- a/src/app/market/page.test.ts
+++ b/src/app/market/page.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('MarketPage source', () => {
+  it('시장 페이지를 경기 사이클 카드와 5가지 신호 상세 구조로 유지한다', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain("const CYCLE_STAGES = ['회복', '확장', '둔화', '침체'] as const")
+    expect(source).toContain('경기 사이클 위치')
+    expect(source).toContain('5가지 신호 상세')
+    expect(source).toContain("const INDICATOR_ORDER = ['fearGreed', 'yieldCurve', 'erp', 'creditSpread', 'm2'] as const")
+  })
+})

--- a/src/app/market/page.tsx
+++ b/src/app/market/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import Link from 'next/link'
 import { BottomNav } from '@/components/BottomNav'
 import { MarketCard } from '@/components/MarketCard'
 import type { MarketResponse } from '@/lib/marketSignals'
@@ -9,6 +8,18 @@ import { loadMarketSignals } from '@/lib/marketSignalsClient'
 import styles from './page.module.css'
 
 const SKELETON_COUNT = 5
+const CYCLE_STAGES = ['회복', '확장', '둔화', '침체'] as const
+const INDICATOR_ORDER = ['fearGreed', 'yieldCurve', 'erp', 'creditSpread', 'm2'] as const
+
+type CycleStage = {
+  accentClassName: string
+  caption: string
+  description: string
+  label: typeof CYCLE_STAGES[number]
+  point: { x: number; y: number }
+  progress: number
+  summary: string
+}
 
 export default function MarketPage() {
   const [market, setMarket] = useState<MarketResponse | null>(null)
@@ -49,109 +60,212 @@ export default function MarketPage() {
     }
   }
 
-  const entry = market?.overview.entry
-  const health = market?.overview.health
+  const cycle = market ? deriveCycleStage(market) : null
+  const orderedIndicators = market
+    ? [...market.indicators].sort(
+      (left, right) => INDICATOR_ORDER.indexOf(left.key) - INDICATOR_ORDER.indexOf(right.key),
+    )
+    : []
 
   return (
     <div className={styles.wrap}>
-      <div className={styles.header}>
-        <div className={styles.eyebrow}>Macro Market Engine</div>
-        <h1 className={styles.title}>오늘 시장 바람이 주식에 우호적인지 한 화면에서 확인해보세요.</h1>
+      <div className={styles.page}>
+        <header className={styles.header}>
+          <div className={styles.eyebrow}>Market Context</div>
+          <h1 className={styles.title}>시장 분위기</h1>
+          <p className={styles.description}>
+            지금 투자하기 좋은 환경인지 5가지 신호로 알아봐요.
+          </p>
+        </header>
 
-        <div className={styles.heroCard}>
-          {/* 메인 KPI: 진입 매력도 */}
-          <div className={styles.entryBlock}>
-            <div className={styles.kpiEyebrow}>진입 매력도</div>
-            <div className={styles.kpiLabel}>
-              {loading ? '분석 중…' : (entry?.label ?? '중립')}
-            </div>
-            <div className={styles.kpiScore}>
-              <span className={styles.kpiScoreNum}>
-                {loading ? '--' : (entry?.score ?? 50)}
-              </span>
-              <span className={styles.kpiScoreUnit}>/100</span>
-            </div>
-            <p className={styles.kpiSummary}>
-              {loading ? '' : (entry?.summary ?? '')}
-            </p>
-          </div>
+        <main className={styles.content}>
+          {loading && (
+            <section className={styles.heroCard} aria-hidden="true">
+              <div className={styles.skeletonTitle} />
+              <div className={styles.skeletonLineLong} />
+              <div className={styles.heroSkeletonBody}>
+                <div className={styles.skeletonGauge} />
+                <div className={styles.skeletonLegend}>
+                  <div className={styles.skeletonLegendRow} />
+                  <div className={styles.skeletonLegendRow} />
+                  <div className={styles.skeletonLegendRow} />
+                  <div className={styles.skeletonLegendRowShort} />
+                </div>
+              </div>
+              <div className={styles.skeletonCallout} />
+            </section>
+          )}
 
-          {/* 서브 KPI: 시장 건강도 */}
-          <div className={styles.healthChip}>
-            <span className={styles.healthEyebrow}>시장 건강도</span>
-            <span className={styles.healthLabel}>
-              {loading ? '--' : (health?.label ?? '중립')}
-            </span>
-            <span className={styles.healthScore}>
-              {loading ? '' : `${health?.score ?? 50}/100`}
-            </span>
-          </div>
-
-          {/* 투자 시사점 */}
-          {!loading && entry?.guide && (
-            <div className={styles.implication}>
-              <span className={styles.implicationLabel}>투자 시사점</span>
-              <p className={styles.implicationText}>{entry.guide}</p>
+          {error && !market && (
+            <div className={styles.stateCard}>
+              <p>{error}</p>
+              <button className={styles.inlineRetry} onClick={() => void handleRefresh()}>
+                다시 시도
+              </button>
             </div>
           )}
 
-          <div className={styles.heroMeta}>
-            <button className={styles.refreshButton} onClick={() => void handleRefresh()}>
-              최신 시장 다시 보기
-            </button>
-          </div>
-        </div>
-      </div>
+          {!loading && market && cycle && (
+            <>
+              <section className={styles.heroCard}>
+                <div className={styles.sectionTitle}>경기 사이클 위치</div>
+                <p className={styles.heroIntro}>{cycle.description}</p>
 
-      <div className={styles.body}>
-        <div className={styles.actions}>
-          <Link className={styles.secondaryLink} href="/signals">
-            ← 종목 시그널로 돌아가기
-          </Link>
-        </div>
+                <div className={styles.heroBody}>
+                  <CycleGauge cycle={cycle} />
 
-        {loading && (
-          <div className={styles.cardGrid}>
-            {Array.from({ length: SKELETON_COUNT }, (_, index) => (
-              <div key={index} className={styles.skeletonCard} aria-hidden="true">
-                <div className={styles.skeletonTitle} />
-                <div className={styles.skeletonValue} />
-                <div className={styles.skeletonLine} />
-                <div className={styles.skeletonLineShort} />
+                  <div className={styles.legend}>
+                    {CYCLE_STAGES.map(stage => {
+                      const active = stage === cycle.label
+
+                      return (
+                        <div key={stage} className={styles.legendItem}>
+                          <span
+                            className={`${styles.legendDot} ${active ? styles[cycle.accentClassName] : ''}`}
+                            aria-hidden="true"
+                          />
+                          <span className={active ? styles.legendActiveLabel : styles.legendLabel}>
+                            {stage}
+                          </span>
+                        </div>
+                      )
+                    })}
+                  </div>
+                </div>
+
+                <div className={`${styles.callout} ${styles[`${cycle.accentClassName}Background`]}`}>
+                  <strong className={styles.calloutLabel}>투자 시사점:</strong> {cycle.summary}
+                </div>
+              </section>
+
+              <div className={styles.sectionHeader}>
+                <div className={styles.sectionEyebrow}>5가지 신호 상세</div>
+                <button className={styles.refreshButton} onClick={() => void handleRefresh()}>
+                  새로고침
+                </button>
               </div>
-            ))}
-          </div>
-        )}
 
-        {error && !market && (
-          <div className={styles.stateCard}>
-            <p>{error}</p>
-            <button className={styles.inlineRetry} onClick={() => void handleRefresh()}>
-              다시 시도
-            </button>
-          </div>
-        )}
+              <div className={styles.cardList}>
+                {orderedIndicators.map(indicator => (
+                  <MarketCard key={indicator.key} indicator={indicator} />
+                ))}
+              </div>
 
-        {!loading && market && (
-          <>
-            <div className={styles.metaRow}>
-              <span className={styles.metaBadge}>지표 {market.indicators.length}개</span>
-              <span className={styles.metaBadge}>
-                기준 시각 {new Date(market.fetchedAt).toLocaleString('ko-KR')}
-              </span>
-            </div>
+              <div className={styles.metaRow}>
+                <span className={styles.metaBadge}>지표 {market.indicators.length}개</span>
+                <span className={styles.metaBadge}>
+                  기준 시각 {new Date(market.fetchedAt).toLocaleString('ko-KR')}
+                </span>
+              </div>
 
-            <div className={styles.cardGrid}>
-              {market.indicators.map(indicator => (
-                <MarketCard key={indicator.key} indicator={indicator} />
-              ))}
-            </div>
+              <p className={styles.source}>데이터 출처: FRED, onoff.markets, multpl.com</p>
+            </>
+          )}
 
-            <p className={styles.source}>데이터 출처: FRED, onoff.markets, multpl.com</p>
-          </>
-        )}
+          {loading && (
+            <>
+              <div className={styles.sectionHeader}>
+                <div className={styles.sectionEyebrow}>5가지 신호 상세</div>
+              </div>
+
+              <div className={styles.cardList}>
+                {Array.from({ length: SKELETON_COUNT }, (_, index) => (
+                  <div key={index} className={styles.skeletonCard} aria-hidden="true">
+                    <div className={styles.skeletonRow}>
+                      <div className={styles.skeletonIcon} />
+                      <div className={styles.skeletonText}>
+                        <div className={styles.skeletonTitleShort} />
+                        <div className={styles.skeletonLine} />
+                      </div>
+                      <div className={styles.skeletonBadge} />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </main>
       </div>
+
       <BottomNav />
     </div>
+  )
+}
+
+function deriveCycleStage(market: MarketResponse): CycleStage {
+  const healthScore = market.overview.health.score
+  const entryGuide = market.overview.entry.guide
+  const stageIndex = healthScore >= 75 ? 1 : healthScore >= 55 ? 0 : healthScore >= 35 ? 2 : 3
+  const label = CYCLE_STAGES[stageIndex]
+  const captions = ['회복 초입 국면', '확장 지속 국면', '둔화 초입 국면', '침체 방어 국면'] as const
+  const descriptions = [
+    '시장 구조가 서서히 회복되며 위험자산을 다시 점검해볼 수 있는 구간입니다.',
+    '시장 구조가 비교적 안정적이라 공격 자산이 힘을 받기 쉬운 구간입니다.',
+    '현재 시장은 둔화 초입 국면으로 추정됩니다.',
+    '시장 전반의 방어 심리가 강해 보수적인 비중 관리가 필요한 구간입니다.',
+  ] as const
+  const accentClassNames = ['accentGreen', 'accentNavy', 'accentAmber', 'accentRed'] as const
+  const progress = [0.22, 0.48, 0.74, 1] as const
+
+  return {
+    accentClassName: accentClassNames[stageIndex],
+    caption: captions[stageIndex],
+    description: descriptions[stageIndex],
+    label,
+    point: polarToCartesian(progress[stageIndex]),
+    progress: progress[stageIndex],
+    summary: entryGuide,
+  }
+}
+
+function polarToCartesian(progress: number) {
+  const clamped = Math.min(Math.max(progress, 0), 1)
+  const radius = 48
+  const centerX = 58
+  const centerY = 58
+  const angle = Math.PI * (1 - clamped)
+
+  return {
+    x: centerX + (radius * Math.cos(angle)),
+    y: centerY - (radius * Math.sin(angle)),
+  }
+}
+
+function CycleGauge({ cycle }: { cycle: CycleStage }) {
+  const dashLength = 151
+  const progressLength = dashLength * cycle.progress
+
+  return (
+    <svg className={styles.gauge} viewBox="0 0 116 66" aria-label={`현재 경기 사이클은 ${cycle.label}`}>
+      <path
+        d="M 10,58 A 48,48 0 0 1 106,58"
+        fill="none"
+        stroke="#f0f0f5"
+        strokeWidth="10"
+        strokeLinecap="round"
+      />
+      <path
+        d="M 10,58 A 48,48 0 0 1 106,58"
+        fill="none"
+        className={styles[cycle.accentClassName]}
+        strokeWidth="10"
+        strokeLinecap="round"
+        strokeDasharray={`${progressLength} ${dashLength}`}
+      />
+      <circle
+        cx={cycle.point.x}
+        cy={cycle.point.y}
+        r="6"
+        className={styles[cycle.accentClassName]}
+        stroke="white"
+        strokeWidth="2"
+      />
+      <text x="58" y="52" textAnchor="middle" className={`${styles.gaugeLabel} ${styles[cycle.accentClassName]}`}>
+        {cycle.label}
+      </text>
+      <text x="58" y="63" textAnchor="middle" className={styles.gaugeCaption}>
+        {cycle.caption}
+      </text>
+    </svg>
   )
 }

--- a/src/components/AllocationBar.module.css
+++ b/src/components/AllocationBar.module.css
@@ -1,26 +1,80 @@
 /* src/components/AllocationBar.module.css */
-.wrap { display: flex; flex-direction: column; gap: 7px; }
-.row { display: flex; align-items: center; gap: 10px; }
-.label { font-size: 11px; font-weight: 700; color: rgba(255,255,255,.6); width: 48px; flex-shrink: 0; }
-.track { flex: 1; height: 7px; background: rgba(255,255,255,.2); border-radius: 4px; position: relative; overflow: visible; }
-.fill { height: 100%; border-radius: 4px; transition: width 0.6s ease; }
-.targetLine { position: absolute; top: -4px; width: 2px; height: 15px; background: rgba(255,255,255,.5); border-radius: 1px; }
-.pct { font-size: 12px; font-weight: 700; font-variant-numeric: tabular-nums; color: rgba(255,255,255,.8); width: 32px; text-align: right; flex-shrink: 0; }
+.wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.row {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.rowHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.label {
+  font-size: 12px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.pct {
+  font-size: 13px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: #fff;
+}
+
 .targetLabel {
+  border-radius: 99px;
+  background: transparent;
+  padding: 0;
   font-size: 10px;
   font-weight: 600;
-  color: rgba(255,255,255,0.4);
-  width: 52px;
-  text-align: right;
-  flex-shrink: 0;
-  border-radius: 99px;
-  padding: 2px 0;
   white-space: nowrap;
+  color: rgba(255, 255, 255, 0.4);
 }
+
 .targetOver {
-  color: var(--amber);
-  background: rgba(232,168,56,0.18);
+  color: rgb(232, 168, 56);
+  background: rgba(232, 168, 56, 0.18);
   padding: 2px 6px;
 }
-.legend { font-size: 10px; color: rgba(255,255,255,.45); margin-top: 4px; display: flex; align-items: center; gap: 6px; }
-.legendLine { display: inline-block; width: 12px; height: 2px; background: rgba(255,255,255,.5); vertical-align: middle; border-radius: 1px; }
+
+.track {
+  position: relative;
+  height: 5px;
+  border-radius: 99px;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  border-radius: 99px;
+  transition: width 1s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.targetLine {
+  position: absolute;
+  top: -3px;
+  width: 1.5px;
+  height: 11px;
+  border-radius: 1px;
+  transform: translateX(-50%);
+  background: rgba(255, 255, 255, 0.4);
+}

--- a/src/components/AllocationBar.test.ts
+++ b/src/components/AllocationBar.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { AllocationBar } from './AllocationBar'
 
 describe('AllocationBar', () => {
-  it('채권과 현금 행을 분리해 표시한다', () => {
+  it('채권과 현금은 채권·기타 한 행으로 묶어 표시한다', () => {
     const html = renderToStaticMarkup(
       createElement(AllocationBar, {
         current: { '국내주식': 40, '해외주식': 30, '채권': 10, '현금': 20, '기타': 0 },
@@ -12,7 +12,8 @@ describe('AllocationBar', () => {
       })
     )
 
-    expect(html).toMatch(/채권.*?>10%<\/div>/)
-    expect(html).toMatch(/현금.*?>20%<\/div>/)
+    expect(html).toContain('채권·기타')
+    expect(html).toContain('30%')
+    expect(html).toContain('목표 30%')
   })
 })

--- a/src/components/AllocationBar.tsx
+++ b/src/components/AllocationBar.tsx
@@ -10,8 +10,7 @@ interface Props {
 const ROWS: { key: keyof TargetAllocation; label: string; currentKeys: AllocationBucket[] }[] = [
   { key: '국내주식', label: '국내주식', currentKeys: ['국내주식'] },
   { key: '해외주식', label: '해외주식', currentKeys: ['해외주식'] },
-  { key: '채권', label: '채권', currentKeys: ['채권'] },
-  { key: '현금', label: '현금', currentKeys: ['현금'] },
+  { key: '채권', label: '채권·기타', currentKeys: ['채권', '기타', '현금'] },
 ]
 
 export function AllocationBar({ current, target }: Props) {
@@ -19,14 +18,24 @@ export function AllocationBar({ current, target }: Props) {
     <div className={styles.wrap}>
       {ROWS.map(({ key, label, currentKeys }) => {
         const cur = currentKeys.reduce((sum, assetClass) => sum + (current[assetClass] ?? 0), 0)
-        const tgt = target[key] ?? 0
+        const tgt = key === '채권'
+          ? (target['채권'] ?? 0) + (target['현금'] ?? 0)
+          : (target[key] ?? 0)
         const isOver = cur > tgt + 5
         const isUnder = cur < tgt - 5
-        const fillColor = isOver ? 'var(--red)' : isUnder ? 'var(--amber)' : 'var(--green)'
+        const fillColor = isOver ? 'var(--amber)' : isUnder ? 'var(--green)' : 'var(--green)'
 
         return (
           <div key={key} className={styles.row}>
-            <div className={styles.label}>{label}</div>
+            <div className={styles.rowHeader}>
+              <span className={styles.label}>{label}</span>
+              <div className={styles.meta}>
+                <span className={styles.pct}>{cur}%</span>
+                <span className={`${styles.targetLabel} ${isOver ? styles.targetOver : ''}`}>
+                  목표 {tgt}%
+                </span>
+              </div>
+            </div>
             <div className={styles.track}>
               <div
                 className={styles.fill}
@@ -34,16 +43,9 @@ export function AllocationBar({ current, target }: Props) {
               />
               <div className={styles.targetLine} style={{ left: `${tgt}%` }} />
             </div>
-            <div className={styles.pct}>{cur}%</div>
-            <div className={`${styles.targetLabel} ${isOver ? styles.targetOver : ''}`}>
-              목표 {tgt}%
-            </div>
           </div>
         )
       })}
-      <div className={styles.legend}>
-        <span className={styles.legendLine} /> 세로선은 목표 비중
-      </div>
     </div>
   )
 }

--- a/src/components/ProblemCard.module.css
+++ b/src/components/ProblemCard.module.css
@@ -1,114 +1,111 @@
 /* src/components/ProblemCard.module.css */
 .card {
-  background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: var(--radius-card);
-  padding: 16px 18px 16px 20px;
-  position: relative;
-  overflow: hidden;
-}
-.card::before {
-  content: '';
-  position: absolute;
-  left: 0; top: 0; bottom: 0;
-  width: 3px;
-}
-.red::before { background: var(--red); }
-.amber::before { background: var(--amber); }
-
-.top {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 12px;
+  border-radius: 18px;
+  background: var(--surface);
+  padding: 18px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
 }
 
-.num {
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: 8px;
+  border-radius: 999px;
+  padding: 3px 10px;
   font-size: 10px;
-  font-weight: 800;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--text-3);
-  margin-bottom: 6px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.badgeHigh {
+  background: #fef2f2;
+  color: #e6514a;
+}
+
+.badgeMedium {
+  background: #fff8ea;
+  color: #d97706;
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dotHigh {
+  background: #e6514a;
+}
+
+.dotMedium {
+  background: #d97706;
 }
 
 .title {
-  font-size: 16px;
+  margin-bottom: 14px;
+  font-size: 17px;
   font-weight: 800;
-  letter-spacing: -0.3px;
+  letter-spacing: -0.03em;
   line-height: 1.3;
-}
-
-.severityBadge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 6px 10px;
-  border-radius: 999px;
-  font-size: 11px;
-  font-weight: 800;
-  white-space: nowrap;
-}
-
-.severityHigh {
-  background: var(--red-bg);
-  color: var(--red);
-}
-
-.severityMedium {
-  background: rgba(245, 158, 11, 0.14);
-  color: #b45309;
+  color: var(--text-1);
 }
 
 .metrics {
   display: flex;
   align-items: stretch;
-  gap: 0;
-  padding: 14px;
-  border: 1px solid rgba(15, 23, 42, 0.06);
+  gap: 8px;
+  margin-bottom: 12px;
   border-radius: 14px;
   background: #f7f8fc;
-  margin-bottom: 2px;
+  padding: 14px;
 }
 
 .metric {
   display: flex;
+  flex: 1;
   flex-direction: column;
+  align-items: center;
+  justify-content: center;
   gap: 4px;
-}
-
-.metric:last-child {
-  align-items: flex-end;
-  text-align: right;
+  text-align: center;
 }
 
 .metricLabel {
   font-size: 11px;
-  font-weight: 700;
-  color: var(--text-3);
+  font-weight: 500;
+  color: #aaa;
 }
 
 .metricValue {
-  font-size: 24px;
-  font-weight: 800;
-  font-variant-numeric: tabular-nums;
-  letter-spacing: -0.9px;
+  font-size: 32px;
+  font-weight: 900;
   line-height: 1;
+  letter-spacing: -0.04em;
+  font-variant-numeric: tabular-nums;
+  color: #bbb;
 }
 
-.currentRed { color: var(--red); }
-.currentAmber { color: var(--amber); }
+.currentRed {
+  color: #e24d4d;
+}
+
+.currentAmber {
+  color: #d97706;
+}
 
 .metricDivider {
   width: 1px;
+  margin: 0;
   background: #e8e8ec;
-  margin: 0 8px;
   border-radius: 1px;
 }
 
 .desc {
-  font-size: 12px;
-  color: var(--text-2);
-  line-height: 1.6;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.7;
+  color: #666;
 }

--- a/src/components/ProblemCard.test.ts
+++ b/src/components/ProblemCard.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { ProblemCard } from './ProblemCard'
 
 describe('ProblemCard', () => {
-  it('drift 문제를 현재/목표 비교 박스와 설명으로 보여준다', () => {
+  it('drift 문제를 프로토타입형 현재/목표 비교와 설명으로 보여준다', () => {
     const html = renderToStaticMarkup(
       createElement(ProblemCard, {
         index: 0,
@@ -20,8 +20,8 @@ describe('ProblemCard', () => {
       }),
     )
 
-    expect(html).toContain('01 · 자산 배분')
-    expect(html).toContain('고위험')
+    expect(html).toContain('01 · 자산 편중')
+    expect(html).toContain('01 · 자산 편중')
     expect(html).toContain('현재')
     expect(html).toContain('50%')
     expect(html).toContain('목표')
@@ -29,7 +29,7 @@ describe('ProblemCard', () => {
     expect(html).toContain('현재 50%로 목표(35%)보다 15%p 높습니다.')
   })
 
-  it('집중 문제는 기준선 레이블과 설명을 보여준다', () => {
+  it('집중 문제는 상한 기준 레이블과 설명을 보여준다', () => {
     const html = renderToStaticMarkup(
       createElement(ProblemCard, {
         index: 1,
@@ -46,11 +46,11 @@ describe('ProblemCard', () => {
     )
 
     expect(html).toContain('02 · 섹터 집중')
-    expect(html).toContain('주의')
     expect(html).toContain('현재')
     expect(html).toContain('62%')
-    expect(html).toContain('기준선')
+    expect(html).toContain('적정 상한')
     expect(html).toContain('50%')
     expect(html).toContain('단일 섹터 50% 초과는 섹터 집중 위험입니다.')
+    expect(html).toContain('반도체 섹터가 62%입니다')
   })
 })

--- a/src/components/ProblemCard.tsx
+++ b/src/components/ProblemCard.tsx
@@ -8,19 +8,23 @@ interface Props {
 }
 
 function getCategoryLabel(problem: Problem): string {
-  if (problem.type === 'drift') return '자산 배분'
-  if (problem.type === 'concentration_stock') return '단일 종목'
+  if (problem.type === 'drift') return '자산 편중'
+  if (problem.type === 'concentration_stock') return '단일 종목 집중'
   return '섹터 집중'
 }
 
 function getTargetLabel(problem: Problem): string {
-  return problem.type === 'drift' ? '목표' : '기준선'
+  if (problem.type === 'drift') return '목표'
+  if (problem.type === 'concentration_stock') return '이하 권장'
+  return '적정 상한'
 }
 
 
 export function ProblemCard({ problem, index }: Props) {
   const num = String(index + 1).padStart(2, '0')
   const isRed = problem.severity === 'high'
+  const badgeClass = isRed ? styles.badgeHigh : styles.badgeMedium
+  const dotClass = isRed ? styles.dotHigh : styles.dotMedium
 
   return (
     <article
@@ -28,15 +32,11 @@ export function ProblemCard({ problem, index }: Props) {
       role="article"
       aria-label={`진단 항목 ${index + 1}`}
     >
-      <div className={styles.top}>
-        <div>
-          <div className={styles.num}>{num} · {getCategoryLabel(problem)}</div>
-          <div className={styles.title}>{problem.label}</div>
-        </div>
-        <span className={`${styles.severityBadge} ${isRed ? styles.severityHigh : styles.severityMedium}`}>
-          {isRed ? '고위험' : '주의'}
-        </span>
+      <div className={`${styles.badge} ${badgeClass}`}>
+        <span className={`${styles.dot} ${dotClass}`} aria-hidden="true" />
+        <span>{num} · {getCategoryLabel(problem)}</span>
       </div>
+      <div className={styles.title}>{problem.label}</div>
 
       <div className={styles.metrics}>
         <div className={styles.metric}>
@@ -45,7 +45,7 @@ export function ProblemCard({ problem, index }: Props) {
             {problem.current}%
           </strong>
         </div>
-        <div className={styles.metricDivider} />
+        <div className={styles.metricDivider} aria-hidden="true" />
         <div className={styles.metric}>
           <span className={styles.metricLabel}>{getTargetLabel(problem)}</span>
           <strong className={styles.metricValue}>{problem.target}%</strong>

--- a/src/components/SectorPieChart.module.css
+++ b/src/components/SectorPieChart.module.css
@@ -1,10 +1,10 @@
 .card {
-  background: var(--surface);
+  overflow: hidden;
   border: 1px solid var(--border);
-  border-radius: var(--radius-card);
+  border-radius: 18px;
+  background: var(--surface);
   padding: 18px;
-  display: grid;
-  gap: 18px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
 }
 
 .header {
@@ -12,151 +12,115 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
+  margin-bottom: 4px;
 }
 
 .eyebrow {
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.08em;
+  margin-bottom: 3px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 1px;
   text-transform: uppercase;
-  color: var(--text-3);
+  color: #bbb;
 }
 
 .title {
-  margin-top: 4px;
-  font-size: 18px;
+  font-size: 17px;
   font-weight: 800;
   letter-spacing: -0.03em;
-  color: var(--text-1);
+  color: #111;
 }
 
 .caption {
-  margin-top: 6px;
-  font-size: 13px;
-  line-height: 1.5;
-  color: var(--text-2);
+  margin-bottom: 14px;
+  font-size: 12px;
+  line-height: 1.55;
+  color: #999;
 }
 
 .topSector {
   flex-shrink: 0;
-  background: var(--bg);
-  border-radius: 999px;
-  padding: 8px 12px;
-  font-size: 12px;
+  border-radius: 99px;
+  background: rgba(226, 77, 77, 0.063);
+  padding: 4px 10px;
+  font-size: 10px;
   font-weight: 700;
-  color: var(--text-2);
+  color: #e24d4d;
   white-space: nowrap;
 }
 
 .content {
-  display: grid;
-  gap: 18px;
+  display: flex;
   align-items: center;
+  gap: 14px;
 }
 
 .chartWrap {
-  display: grid;
-  place-items: center;
+  flex-shrink: 0;
 }
 
 .chart {
-  width: 184px;
-  height: 184px;
-  border-radius: 50%;
-  background: conic-gradient(var(--chart-fill));
-  position: relative;
-  box-shadow: inset 0 0 0 1px rgba(17, 24, 39, 0.04);
-}
-
-.chart::after {
-  content: '';
-  position: absolute;
-  inset: 28px;
-  border-radius: 50%;
-  background: var(--surface);
-  box-shadow: inset 0 0 0 1px var(--border);
-}
-
-.chartCenter {
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-  display: grid;
-  place-items: center;
-  text-align: center;
-  padding: 0 42px;
-}
-
-.centerLabel {
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: var(--text-3);
-}
-
-.centerValue {
-  margin-top: 6px;
-  font-size: 28px;
-  font-weight: 800;
-  letter-spacing: -0.04em;
-  color: var(--text-1);
-}
-
-.centerDesc {
-  margin-top: 4px;
-  font-size: 12px;
-  line-height: 1.4;
-  color: var(--text-2);
+  flex-shrink: 0;
 }
 
 .legend {
-  display: grid;
-  gap: 10px;
+  flex: 1;
 }
 
 .legendItem {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
+  display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 7px;
+  margin-bottom: 9px;
+}
+
+.legendItem:last-child {
+  margin-bottom: 0;
 }
 
 .legendDot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
   background: var(--slice-color);
+  flex-shrink: 0;
 }
 
 .legendLabel {
-  min-width: 0;
-  font-size: 14px;
-  font-weight: 700;
-  color: var(--text-1);
+  flex: 1;
+  font-size: 12px;
+  font-weight: 500;
+  color: #444;
 }
 
 .legendMeta {
   display: flex;
-  align-items: baseline;
-  gap: 10px;
-  color: var(--text-2);
-  white-space: nowrap;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
 }
 
 .legendShare {
-  font-size: 14px;
-  font-weight: 800;
-  color: var(--text-1);
+  min-width: 36px;
+  font-size: 12px;
+  font-weight: 700;
+  text-align: right;
+  color: #111;
 }
 
 .legendValue {
-  font-size: 12px;
-  color: var(--text-3);
+  min-width: 42px;
+  font-size: 11px;
+  text-align: right;
+  color: #ccc;
 }
 
-@media (min-width: 720px) {
+@media (max-width: 420px) {
   .content {
-    grid-template-columns: 184px minmax(0, 1fr);
+    gap: 12px;
+  }
+
+  .legendMeta {
+    gap: 6px;
   }
 }

--- a/src/components/SectorPieChart.tsx
+++ b/src/components/SectorPieChart.tsx
@@ -2,7 +2,7 @@ import type { CSSProperties } from 'react'
 import type { SectorAllocationSlice } from '@/lib/sectorAllocation'
 import styles from './SectorPieChart.module.css'
 
-const SLICE_COLORS = ['#1A237E', '#3949AB', '#059669', '#D97706', '#E11D48']
+const SLICE_COLORS = ['#1C2B5E', '#E8A838', '#23B26D', '#E24D4D', '#9B8FD4']
 
 function formatAmount(value: number): string {
   return `${Math.round(value / 10_000).toLocaleString('ko-KR')}만원`
@@ -22,21 +22,21 @@ export function SectorPieChart({ slices }: SectorPieChartProps) {
     return null
   }
 
-  const totalValue = slices.reduce((sum, slice) => sum + slice.value, 0)
-  const chartFill = slices
-    .map((slice, index) => {
-      const startValue = slices
-        .slice(0, index)
-        .reduce((sum, current) => sum + current.value, 0)
-      const start = (startValue / totalValue) * 100
-      const end = ((startValue + slice.value) / totalValue) * 100
-      const color = SLICE_COLORS[index % SLICE_COLORS.length]
-
-      return `${color} ${start}% ${end}%`
-    })
-    .join(', ')
-
   const leadSlice = slices[0]
+  const radius = 44
+  const circumference = 2 * Math.PI * radius
+  const segments = slices.map((slice, index) => {
+    const cumulativeShare = slices
+      .slice(0, index)
+      .reduce((sum, current) => sum + current.share, 0)
+
+    return {
+      ...slice,
+      color: SLICE_COLORS[index % SLICE_COLORS.length],
+      dashLength: (slice.share / 100) * circumference,
+      dashOffset: circumference - (cumulativeShare / 100) * circumference,
+    }
+  })
 
   return (
     <section className={styles.card} aria-labelledby="sector-allocation-title">
@@ -44,27 +44,60 @@ export function SectorPieChart({ slices }: SectorPieChartProps) {
         <div>
           <div className={styles.eyebrow}>Sector Mix</div>
           <h2 id="sector-allocation-title" className={styles.title}>섹터 비중</h2>
-          <p className={styles.caption}>확정한 종목의 평가금액 기준으로 섹터 분산 상태를 한눈에 봅니다.</p>
+          <p className={styles.caption}>평가금액 기준으로 섹터 분산 상태를 한눈에 봅니다.</p>
         </div>
         <div className={styles.topSector}>최대 {leadSlice.sector}</div>
       </div>
 
       <div className={styles.content}>
         <div className={styles.chartWrap}>
-          <div
+          <svg
+            width="118"
+            height="118"
+            viewBox="0 0 120 120"
             className={styles.chart}
-            style={{ '--chart-fill': chartFill } as CSSProperties}
             role="img"
             aria-label={slices.map(slice => `${slice.sector} ${formatShare(slice.share)}`).join(', ')}
           >
-            <div className={styles.chartCenter}>
-              <div>
-                <div className={styles.centerLabel}>Top Sector</div>
-                <div className={styles.centerValue}>{formatShare(leadSlice.share)}</div>
-                <div className={styles.centerDesc}>{leadSlice.sector}</div>
-              </div>
-            </div>
-          </div>
+            {segments.map(slice => {
+              return (
+                <circle
+                  key={slice.sector}
+                  cx="60"
+                  cy="60"
+                  r={radius}
+                  fill="none"
+                  stroke={slice.color}
+                  strokeWidth="16"
+                  strokeDasharray={`${slice.dashLength} ${circumference - slice.dashLength}`}
+                  strokeDashoffset={slice.dashOffset}
+                  transform="rotate(-90 60 60)"
+                />
+              )
+            })}
+            <circle cx="60" cy="60" r="33" fill="white" />
+            <text
+              x="60"
+              y="53"
+              textAnchor="middle"
+              fontSize="12"
+              fontWeight="800"
+              fill="#1C2B5E"
+              fontFamily="Noto Sans KR"
+            >
+              {formatShare(leadSlice.share)}
+            </text>
+            <text
+              x="60"
+              y="68"
+              textAnchor="middle"
+              fontSize="8.5"
+              fill="#999"
+              fontFamily="Noto Sans KR"
+            >
+              {leadSlice.sector}
+            </text>
+          </svg>
         </div>
 
         <div className={styles.legend}>

--- a/src/lib/marketSignals.test.ts
+++ b/src/lib/marketSignals.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildMarketResponse,
+  calculateEntryAttractiveness,
+  calculateMarketHealth,
   extractSp500PeRatio,
   formatMacroStateLabel,
 } from './marketSignals'
@@ -49,6 +51,25 @@ describe('buildMarketResponse', () => {
 
     expect(response.macroState).toBe('risk_off')
     expect(response.macroScore).toBe(-1)
+    expect(response.overview.entry.label).toBe('신중한 관망')
+    expect(response.overview.health.label).toBe('불안')
+  })
+
+  it('프롬프트 기준 점수 체계로 진입 매력도와 시장 건강도를 계산한다', () => {
+    const response = buildMarketResponse({
+      equityRiskPremium: 3.2,
+      fearGreed: { label: 'Fear', score: 23 },
+      fetchedAt: '2026-04-19T00:00:00.000Z',
+      highYieldSpread: 4.2,
+      m2YearOverYear: 4.5,
+      treasury10YearRate: 4.1,
+      treasury2YearRate: 4.6,
+    })
+
+    expect(response.overview.entry.score).toBe(62)
+    expect(response.overview.entry.label).toBe('진입 검토 가능')
+    expect(response.overview.health.score).toBe(51)
+    expect(response.overview.health.label).toBe('중립')
   })
 })
 
@@ -62,5 +83,29 @@ describe('market signal helpers', () => {
   it('멀티플 HTML에서 S&P 500 PE 값을 파싱한다', () => {
     expect(extractSp500PeRatio('<div>Current S&P 500 PE Ratio is 30.62</div>')).toBe(30.62)
     expect(extractSp500PeRatio('<html>missing</html>')).toBeNull()
+  })
+
+  it('진입 매력도는 공포 기회와 패널티를 함께 반영한다', () => {
+    const score = calculateEntryAttractiveness({
+      equityRiskPremium: 3.5,
+      fearGreed: 20,
+      highYieldSpread: 4.1,
+      m2GrowthYoY: 5,
+      yieldSpread: -0.5,
+    })
+
+    expect(score).toBe(62)
+  })
+
+  it('시장 건강도는 가중 평균으로 계산한다', () => {
+    const score = calculateMarketHealth({
+      equityRiskPremium: 3.5,
+      fearGreed: 20,
+      highYieldSpread: 4.1,
+      m2GrowthYoY: 5,
+      yieldSpread: -0.5,
+    })
+
+    expect(score).toBe(51)
   })
 })

--- a/src/lib/marketSignals.ts
+++ b/src/lib/marketSignals.ts
@@ -36,6 +36,14 @@ export interface MarketResponse {
   overview: MarketOverview
 }
 
+export interface MarketInput {
+  equityRiskPremium: number | null
+  fearGreed: number | null
+  highYieldSpread: number | null
+  m2GrowthYoY: number | null
+  yieldSpread: number | null
+}
+
 interface MarketSnapshotInput {
   equityRiskPremium: number | null
   fearGreed: FearGreedSnapshot | null
@@ -111,7 +119,13 @@ export function buildMarketResponse(input: MarketSnapshotInput): MarketResponse 
     indicators,
     macroScore,
     macroState,
-    overview: buildOverview(indicators),
+    overview: buildOverview({
+      equityRiskPremium: input.equityRiskPremium,
+      fearGreed: input.fearGreed?.score ?? null,
+      highYieldSpread: input.highYieldSpread,
+      m2GrowthYoY: input.m2YearOverYear,
+      yieldSpread: yieldCurveSpread,
+    }),
   }
 }
 
@@ -490,106 +504,189 @@ function formatSignedNumber(value: number): string {
   return `${value >= 0 ? '+' : ''}${formatNumber(value)}`
 }
 
-function invertStatus(status: MarketIndicatorStatus): MarketIndicatorStatus {
-  if (status === 'positive') return 'negative'
-  if (status === 'negative') return 'positive'
-  return status
-}
-
-function computeKPIScore(
-  indicators: MarketIndicator[],
-  invertFearGreed: boolean,
-): number {
-  const scored = indicators.filter(i => i.status !== 'unavailable')
-  if (scored.length === 0) return 50
-
-  const total = scored.reduce((sum, i) => {
-    const status = (invertFearGreed && i.key === 'fearGreed')
-      ? invertStatus(i.status)
-      : i.status
-    return sum + scoreIndicator(status)
-  }, 0)
-
-  return Math.round(((total / scored.length) + 1) * 50)
-}
-
 function buildEntryKPI(score: number): MarketEntryKPI {
-  if (score >= 70) return {
-    guide: '새로운 자금을 분할 매수로 천천히 진입하거나 비중을 늘려볼 수 있는 환경이에요.',
-    label: '매력적인 환경',
+  if (score >= 75) return {
+    guide: '시장 리스크가 크지 않고 주식의 상대 매력도도 괜찮은 편이에요. 종목별로 분할 접근을 검토하기 좋은 구간이에요.',
+    label: '분할 진입 매력 높음',
     score,
-    summary: '주식 기대수익이 채권보다 높고 투자심리도 저점권에 있어 진입 매력도가 높아요.',
+    summary: '시장 리스크가 크지 않고 주식의 상대 매력도도 괜찮은 편이에요. 종목별로 분할 접근을 검토하기 좋은 구간이에요.',
   }
-  if (score >= 55) return {
-    guide: '기존 포트폴리오를 유지하면서 여유 자금은 조금씩 추가해볼 수 있어요.',
-    label: '우호적',
+  if (score >= 60) return {
+    guide: '시장 불안 요소가 일부 있지만, 분할로 접근하면 기회를 노려볼 수 있는 구간이에요.',
+    label: '진입 검토 가능',
     score,
-    summary: '시장 환경이 전반적으로 주식에 우호적인 구간이에요.',
+    summary: '시장 불안 요소가 일부 있지만, 분할로 접근하면 기회를 노려볼 수 있는 구간이에요.',
   }
   if (score >= 45) return {
-    guide: '현재 비중을 유지하면서 방향을 지켜보는 게 좋아요.',
-    label: '중립',
+    guide: '시장 방향이 뚜렷하지 않아 조금 더 지켜보는 전략이 좋아요.',
+    label: '신중한 관망',
     score,
-    summary: '매력도가 한쪽으로 크게 기울지 않아 서두를 이유가 없는 구간이에요.',
+    summary: '시장 방향이 뚜렷하지 않아 조금 더 지켜보는 전략이 좋아요.',
   }
   if (score >= 30) return {
-    guide: '무리한 추가 매수보다 현재 비중 유지나 일부 조정을 고려해보세요.',
-    label: '신중 필요',
+    guide: '변동성이 커질 수 있는 구간이라 신규 진입은 신중하게 접근하는 게 좋아요.',
+    label: '진입 부담 높음',
     score,
-    summary: '주식 매력도가 채권 대비 줄어들고 있어 신중한 접근이 필요해요.',
+    summary: '변동성이 커질 수 있는 구간이라 신규 진입은 신중하게 접근하는 게 좋아요.',
   }
   return {
-    guide: '주식 비중을 줄이거나 현금·채권 비중을 높이는 전략을 고려해보세요.',
-    label: '경계 구간',
+    guide: '시장 리스크가 높은 구간이에요. 지금은 기회보다 리스크 관리가 더 중요한 시점이에요.',
+    label: '리스크 우선 관리',
     score,
-    summary: '진입 매력도가 낮은 구간이에요. 방어적으로 접근하는 게 좋아요.',
+    summary: '시장 리스크가 높은 구간이에요. 지금은 기회보다 리스크 관리가 더 중요한 시점이에요.',
   }
 }
 
 function buildHealthKPI(score: number): MarketEntryKPI {
-  if (score >= 70) return {
-    guide: '',
-    label: '안정적',
+  if (score >= 75) return {
+    guide: '시장 환경이 전반적으로 안정적인 상태예요.',
+    label: '안정',
     score,
-    summary: '금리 구조와 신용·유동성 환경이 모두 양호해 시장 구조가 건강해요.',
+    summary: '시장 환경이 전반적으로 안정적인 상태예요.',
   }
-  if (score >= 55) return {
-    guide: '',
+  if (score >= 60) return {
+    guide: '시장 리스크는 크지 않지만 일부 변수는 확인이 필요해요.',
     label: '양호',
     score,
-    summary: '시장 구조 지표 대부분이 건강한 편이에요.',
+    summary: '시장 리스크는 크지 않지만 일부 변수는 확인이 필요해요.',
   }
   if (score >= 45) return {
-    guide: '',
+    guide: '시장 방향성이 뚜렷하지 않은 구간이에요.',
     label: '중립',
     score,
-    summary: '건강 지표들이 혼재되어 있어 중립적인 시장 환경이에요.',
+    summary: '시장 방향성이 뚜렷하지 않은 구간이에요.',
   }
   if (score >= 30) return {
-    guide: '',
-    label: '주의',
+    guide: '시장 변동성이 커지고 있는 구간이에요.',
+    label: '불안',
     score,
-    summary: '금리나 신용 환경 일부에서 경고 신호가 나오고 있어요.',
+    summary: '시장 변동성이 커지고 있는 구간이에요.',
   }
   return {
-    guide: '',
-    label: '경계',
+    guide: '시장 불안이 큰 상태로 리스크 관리가 중요한 구간이에요.',
+    label: '공포',
     score,
-    summary: '금리 역전, 신용 위험 등 구조적 경고가 복수로 나타나고 있어요.',
+    summary: '시장 불안이 큰 상태로 리스크 관리가 중요한 구간이에요.',
   }
 }
 
-function buildOverview(indicators: MarketIndicator[]): MarketOverview {
-  // 진입 매력도: ERP(주식 vs 채권) + Fear&Greed(역발상 — 공포일수록 매력)
-  const entryIndicators = indicators.filter(i => ['erp', 'fearGreed'].includes(i.key))
-  const entryScore = computeKPIScore(entryIndicators, true)
-
-  // 시장 건강도: 금리 구조 + 신용 환경 + 유동성
-  const healthIndicators = indicators.filter(i => ['yieldCurve', 'creditSpread', 'm2'].includes(i.key))
-  const healthScore = computeKPIScore(healthIndicators, false)
+function buildOverview(input: MarketInput): MarketOverview {
+  const entryScore = calculateEntryAttractiveness(input)
+  const healthScore = calculateMarketHealth(input)
 
   return {
     entry: buildEntryKPI(entryScore),
     health: buildHealthKPI(healthScore),
   }
+}
+
+export function calculateEntryAttractiveness(input: MarketInput): number {
+  const contrarian = scoreContrarian(input.fearGreed)
+  const equity = scoreERP(input.equityRiskPremium)
+  const safety = scoreCredit(input.highYieldSpread)
+  const liquidity = scoreLiquidity(input.m2GrowthYoY)
+
+  const base = (
+    contrarian * 0.35
+    + equity * 0.25
+    + safety * 0.25
+    + liquidity * 0.15
+  )
+
+  const penalty = getCyclePenalty(input.yieldSpread) + getOverheatingPenalty(input.fearGreed)
+  return clamp(Math.round(base - penalty), 0, 100)
+}
+
+export function calculateMarketHealth(input: MarketInput): number {
+  return weightedAverage([
+    [scoreFearGreed(input.fearGreed), 1.2],
+    [scoreYieldSpread(input.yieldSpread), 1.3],
+    [scoreERP(input.equityRiskPremium), 1.2],
+    [scoreCredit(input.highYieldSpread), 1.5],
+    [scoreLiquidity(input.m2GrowthYoY), 0.8],
+  ])
+}
+
+export function scoreContrarian(fg: number | null): number {
+  if (fg === null) return 50
+  if (fg < 10) return 70
+  if (fg < 25) return 85
+  if (fg < 40) return 75
+  if (fg < 60) return 55
+  if (fg < 75) return 35
+  return 20
+}
+
+export function scoreFearGreed(fg: number | null): number {
+  if (fg === null) return 50
+  if (fg < 10) return 15
+  if (fg < 25) return 25
+  if (fg < 40) return 40
+  if (fg < 60) return 55
+  if (fg < 75) return 75
+  return 90
+}
+
+export function scoreERP(erp: number | null): number {
+  if (erp === null) return 50
+  if (erp < 1) return 20
+  if (erp < 2.5) return 40
+  if (erp < 4) return 60
+  if (erp < 6) return 80
+  return 70
+}
+
+export function scoreCredit(spread: number | null): number {
+  if (spread === null) return 50
+  if (spread < 3.5) return 90
+  if (spread < 5) return 75
+  if (spread < 7) return 50
+  if (spread < 10) return 25
+  return 10
+}
+
+export function scoreLiquidity(m2: number | null): number {
+  if (m2 === null) return 50
+  if (m2 < 0) return 25
+  if (m2 < 3) return 45
+  if (m2 < 7) return 70
+  if (m2 < 12) return 80
+  return 65
+}
+
+export function scoreYieldSpread(spread: number | null): number {
+  if (spread === null) return 50
+  if (spread < -1) return 10
+  if (spread < -0.3) return 25
+  if (spread < 0.2) return 45
+  if (spread < 1) return 70
+  return 85
+}
+
+export function getCyclePenalty(spread: number | null): number {
+  if (spread === null) return 0
+  if (spread < -1) return 18
+  if (spread < -0.3) return 12
+  if (spread < 0.2) return 5
+  return 0
+}
+
+export function getOverheatingPenalty(fg: number | null): number {
+  if (fg === null) return 0
+  if (fg >= 85) return 25
+  if (fg >= 75) return 18
+  if (fg >= 65) return 8
+  return 0
+}
+
+function weightedAverage(entries: Array<[number, number]>): number {
+  const totalWeight = entries.reduce((sum, [, weight]) => sum + weight, 0)
+  if (totalWeight === 0) return 50
+
+  const weightedTotal = entries.reduce((sum, [score, weight]) => sum + (score * weight), 0)
+  return clamp(Math.round(weightedTotal / totalWeight), 0, 100)
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
 }


### PR DESCRIPTION
## What changed
- marketSignals의 진입 매력도와 시장 건강도를 정성 합산이 아니라 명시적 가중치와 패널티 규칙으로 계산하도록 고정했습니다.
- 새 점수 기준에 맞는 회귀 테스트를 추가했습니다.
- 사용자가 요청한 대로 market UI는 KPI 개편안을 싣지 않고 기존 레이아웃으로 되돌린 상태를 유지했습니다.

## Why
- 시장 점수 해석 기준을 코드와 테스트에서 명확히 잠가야 이후 threshold나 라벨 변경 시 기준점이 생깁니다.
- 이번 단계의 목적은 UI 개편이 아니라 비즈니스 로직 정리였기 때문에 표현 변경은 분리했습니다.

## Validation
- `COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm@9.15.4 verify`
- local dev server restart
- `curl -I http://127.0.0.1:3000/market`

## Notes
- Working tree has additional uncommitted UI edits that are not included in this PR.
