### PR TITLE
시장 보조 로직과 테스트 결합도를 낮춰 리뷰 지적을 정리한다

### DIFF
--- a/src/app/market/page.test.ts
+++ b/src/app/market/page.test.ts
@@ -1,13 +1,37 @@
-import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
+import { deriveCycleStage } from '@/lib/cycleStage'
+import type { MarketResponse } from '@/lib/marketSignals'
 
-describe('MarketPage source', () => {
-  it('시장 페이지를 경기 사이클 카드와 5가지 신호 상세 구조로 유지한다', () => {
-    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+function createMarketResponse(healthScore: number): MarketResponse {
+  return {
+    fetchedAt: '2026-04-25T00:00:00.000Z',
+    headline: 'test',
+    indicators: [],
+    macroScore: 0,
+    macroState: 'neutral',
+    overview: {
+      entry: {
+        guide: '분할 접근을 검토해도 되는 구간이에요.',
+        label: '진입 검토 가능',
+        score: 62,
+        summary: '시장 불안 요소가 일부 있지만, 진입 기회를 살펴볼 수 있는 구간이에요.',
+      },
+      health: {
+        guide: '좋은 신호와 나쁜 신호가 섞여 있어 한쪽으로 단정하기 어려워요.',
+        label: '중립',
+        score: healthScore,
+        summary: '시장 방향성이 뚜렷하지 않은 구간이에요.',
+      },
+    },
+  }
+}
 
-    expect(source).toContain("const CYCLE_STAGES = ['회복', '확장', '둔화', '침체'] as const")
-    expect(source).toContain('경기 사이클 위치')
-    expect(source).toContain('5가지 신호 상세')
-    expect(source).toContain("const INDICATOR_ORDER = ['fearGreed', 'yieldCurve', 'erp', 'creditSpread', 'm2'] as const")
+describe('Market cycle stage', () => {
+  it('시장 페이지에서 쓰는 경기 사이클 분류를 lib helper로 계산한다', () => {
+    const stage = deriveCycleStage(createMarketResponse(52))
+
+    expect(stage.label).toBe('둔화')
+    expect(stage.caption).toBe('둔화 초입 국면')
+    expect(stage.summary).toContain('분할 접근')
   })
 })

--- a/src/app/market/page.tsx
+++ b/src/app/market/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { BottomNav } from '@/components/BottomNav'
 import { MarketCard } from '@/components/MarketCard'
+import { deriveCycleStage, type CycleStage } from '@/lib/cycleStage'
 import type { MarketResponse } from '@/lib/marketSignals'
 import { loadMarketSignals } from '@/lib/marketSignalsClient'
 import styles from './page.module.css'
@@ -10,16 +11,6 @@ import styles from './page.module.css'
 const SKELETON_COUNT = 5
 const CYCLE_STAGES = ['회복', '확장', '둔화', '침체'] as const
 const INDICATOR_ORDER = ['fearGreed', 'yieldCurve', 'erp', 'creditSpread', 'm2'] as const
-
-type CycleStage = {
-  accentClassName: string
-  caption: string
-  description: string
-  label: typeof CYCLE_STAGES[number]
-  point: { x: number; y: number }
-  progress: number
-  summary: string
-}
 
 export default function MarketPage() {
   const [market, setMarket] = useState<MarketResponse | null>(null)
@@ -190,45 +181,6 @@ export default function MarketPage() {
       <BottomNav />
     </div>
   )
-}
-
-function deriveCycleStage(market: MarketResponse): CycleStage {
-  const healthScore = market.overview.health.score
-  const entryGuide = market.overview.entry.guide
-  const stageIndex = healthScore >= 75 ? 1 : healthScore >= 55 ? 0 : healthScore >= 35 ? 2 : 3
-  const label = CYCLE_STAGES[stageIndex]
-  const captions = ['회복 초입 국면', '확장 지속 국면', '둔화 초입 국면', '침체 방어 국면'] as const
-  const descriptions = [
-    '시장 구조가 서서히 회복되며 위험자산을 다시 점검해볼 수 있는 구간입니다.',
-    '시장 구조가 비교적 안정적이라 공격 자산이 힘을 받기 쉬운 구간입니다.',
-    '현재 시장은 둔화 초입 국면으로 추정됩니다.',
-    '시장 전반의 방어 심리가 강해 보수적인 비중 관리가 필요한 구간입니다.',
-  ] as const
-  const accentClassNames = ['accentGreen', 'accentNavy', 'accentAmber', 'accentRed'] as const
-  const progress = [0.22, 0.48, 0.74, 1] as const
-
-  return {
-    accentClassName: accentClassNames[stageIndex],
-    caption: captions[stageIndex],
-    description: descriptions[stageIndex],
-    label,
-    point: polarToCartesian(progress[stageIndex]),
-    progress: progress[stageIndex],
-    summary: entryGuide,
-  }
-}
-
-function polarToCartesian(progress: number) {
-  const clamped = Math.min(Math.max(progress, 0), 1)
-  const radius = 48
-  const centerX = 58
-  const centerY = 58
-  const angle = Math.PI * (1 - clamped)
-
-  return {
-    x: centerX + (radius * Math.cos(angle)),
-    y: centerY - (radius * Math.sin(angle)),
-  }
 }
 
 function CycleGauge({ cycle }: { cycle: CycleStage }) {

--- a/src/components/SectorPieChart.module.css
+++ b/src/components/SectorPieChart.module.css
@@ -63,6 +63,17 @@
   flex-shrink: 0;
 }
 
+.chartValue {
+  font-size: 12px;
+  font-weight: 800;
+  fill: #1c2b5e;
+}
+
+.chartLabel {
+  font-size: 8.5px;
+  fill: #999;
+}
+
 .legend {
   flex: 1;
 }

--- a/src/components/SectorPieChart.tsx
+++ b/src/components/SectorPieChart.tsx
@@ -80,10 +80,7 @@ export function SectorPieChart({ slices }: SectorPieChartProps) {
               x="60"
               y="53"
               textAnchor="middle"
-              fontSize="12"
-              fontWeight="800"
-              fill="#1C2B5E"
-              fontFamily="Noto Sans KR"
+              className={styles.chartValue}
             >
               {formatShare(leadSlice.share)}
             </text>
@@ -91,9 +88,7 @@ export function SectorPieChart({ slices }: SectorPieChartProps) {
               x="60"
               y="68"
               textAnchor="middle"
-              fontSize="8.5"
-              fill="#999"
-              fontFamily="Noto Sans KR"
+              className={styles.chartLabel}
             >
               {leadSlice.sector}
             </text>

--- a/src/lib/cycleStage.test.ts
+++ b/src/lib/cycleStage.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { deriveCycleStage } from './cycleStage'
+import type { MarketResponse } from './marketSignals'
+
+function createMarketResponse(healthScore: number): MarketResponse {
+  return {
+    fetchedAt: '2026-04-25T00:00:00.000Z',
+    headline: 'test',
+    indicators: [],
+    macroScore: 0,
+    macroState: 'neutral',
+    overview: {
+      entry: {
+        guide: '분할로 접근할 수 있어요.',
+        label: '중립',
+        score: 50,
+        summary: 'entry summary',
+      },
+      health: {
+        guide: 'health guide',
+        label: '중립',
+        score: healthScore,
+        summary: 'health summary',
+      },
+    },
+  }
+}
+
+describe('deriveCycleStage', () => {
+  it('health score가 높으면 확장 국면으로 분류한다', () => {
+    const stage = deriveCycleStage(createMarketResponse(78))
+
+    expect(stage.label).toBe('확장')
+    expect(stage.accentClassName).toBe('accentNavy')
+    expect(stage.summary).toBe('분할로 접근할 수 있어요.')
+  })
+
+  it('health score가 낮으면 침체 국면으로 분류한다', () => {
+    const stage = deriveCycleStage(createMarketResponse(24))
+
+    expect(stage.label).toBe('침체')
+    expect(stage.accentClassName).toBe('accentRed')
+  })
+})

--- a/src/lib/cycleStage.ts
+++ b/src/lib/cycleStage.ts
@@ -1,0 +1,52 @@
+import type { MarketResponse } from './marketSignals'
+
+const CYCLE_STAGES = ['회복', '확장', '둔화', '침체'] as const
+
+export type CycleStage = {
+  accentClassName: 'accentGreen' | 'accentNavy' | 'accentAmber' | 'accentRed'
+  caption: string
+  description: string
+  label: typeof CYCLE_STAGES[number]
+  point: { x: number; y: number }
+  progress: number
+  summary: string
+}
+
+export function deriveCycleStage(market: MarketResponse): CycleStage {
+  const healthScore = market.overview.health.score
+  const entryGuide = market.overview.entry.guide
+  const stageIndex = healthScore >= 75 ? 1 : healthScore >= 55 ? 0 : healthScore >= 35 ? 2 : 3
+  const label = CYCLE_STAGES[stageIndex]
+  const captions = ['회복 초입 국면', '확장 지속 국면', '둔화 초입 국면', '침체 방어 국면'] as const
+  const descriptions = [
+    '시장 구조가 서서히 회복되며 위험자산을 다시 점검해볼 수 있는 구간입니다.',
+    '시장 구조가 비교적 안정적이라 공격 자산이 힘을 받기 쉬운 구간입니다.',
+    '현재 시장은 둔화 초입 국면으로 추정됩니다.',
+    '시장 전반의 방어 심리가 강해 보수적인 비중 관리가 필요한 구간입니다.',
+  ] as const
+  const accentClassNames = ['accentGreen', 'accentNavy', 'accentAmber', 'accentRed'] as const
+  const progress = [0.22, 0.48, 0.74, 1] as const
+
+  return {
+    accentClassName: accentClassNames[stageIndex],
+    caption: captions[stageIndex],
+    description: descriptions[stageIndex],
+    label,
+    point: polarToCartesian(progress[stageIndex]),
+    progress: progress[stageIndex],
+    summary: entryGuide,
+  }
+}
+
+function polarToCartesian(progress: number) {
+  const clamped = Math.min(Math.max(progress, 0), 1)
+  const radius = 48
+  const centerX = 58
+  const centerY = 58
+  const angle = Math.PI * (1 - clamped)
+
+  return {
+    x: centerX + (radius * Math.cos(angle)),
+    y: centerY - (radius * Math.sin(angle)),
+  }
+}

--- a/src/lib/marketSignals.test.ts
+++ b/src/lib/marketSignals.test.ts
@@ -70,6 +70,8 @@ describe('buildMarketResponse', () => {
     expect(response.overview.entry.label).toBe('진입 검토 가능')
     expect(response.overview.health.score).toBe(51)
     expect(response.overview.health.label).toBe('중립')
+    expect(response.overview.entry.guide).not.toBe(response.overview.entry.summary)
+    expect(response.overview.health.guide).not.toBe(response.overview.health.summary)
   })
 })
 

--- a/src/lib/marketSignals.ts
+++ b/src/lib/marketSignals.ts
@@ -44,6 +44,8 @@ export interface MarketInput {
   yieldSpread: number | null
 }
 
+type MarketKPIContent = Pick<MarketEntryKPI, 'guide' | 'summary'>
+
 interface MarketSnapshotInput {
   equityRiskPremium: number | null
   fearGreed: FearGreedSnapshot | null
@@ -506,67 +508,57 @@ function formatSignedNumber(value: number): string {
 
 function buildEntryKPI(score: number): MarketEntryKPI {
   if (score >= 75) return {
-    guide: '시장 리스크가 크지 않고 주식의 상대 매력도도 괜찮은 편이에요. 종목별로 분할 접근을 검토하기 좋은 구간이에요.',
+    ...buildEntryKPIContent('high'),
     label: '분할 진입 매력 높음',
     score,
-    summary: '시장 리스크가 크지 않고 주식의 상대 매력도도 괜찮은 편이에요. 종목별로 분할 접근을 검토하기 좋은 구간이에요.',
   }
   if (score >= 60) return {
-    guide: '시장 불안 요소가 일부 있지만, 분할로 접근하면 기회를 노려볼 수 있는 구간이에요.',
+    ...buildEntryKPIContent('midHigh'),
     label: '진입 검토 가능',
     score,
-    summary: '시장 불안 요소가 일부 있지만, 분할로 접근하면 기회를 노려볼 수 있는 구간이에요.',
   }
   if (score >= 45) return {
-    guide: '시장 방향이 뚜렷하지 않아 조금 더 지켜보는 전략이 좋아요.',
+    ...buildEntryKPIContent('mid'),
     label: '신중한 관망',
     score,
-    summary: '시장 방향이 뚜렷하지 않아 조금 더 지켜보는 전략이 좋아요.',
   }
   if (score >= 30) return {
-    guide: '변동성이 커질 수 있는 구간이라 신규 진입은 신중하게 접근하는 게 좋아요.',
+    ...buildEntryKPIContent('midLow'),
     label: '진입 부담 높음',
     score,
-    summary: '변동성이 커질 수 있는 구간이라 신규 진입은 신중하게 접근하는 게 좋아요.',
   }
   return {
-    guide: '시장 리스크가 높은 구간이에요. 지금은 기회보다 리스크 관리가 더 중요한 시점이에요.',
+    ...buildEntryKPIContent('low'),
     label: '리스크 우선 관리',
     score,
-    summary: '시장 리스크가 높은 구간이에요. 지금은 기회보다 리스크 관리가 더 중요한 시점이에요.',
   }
 }
 
 function buildHealthKPI(score: number): MarketEntryKPI {
   if (score >= 75) return {
-    guide: '시장 환경이 전반적으로 안정적인 상태예요.',
+    ...buildHealthKPIContent('high'),
     label: '안정',
     score,
-    summary: '시장 환경이 전반적으로 안정적인 상태예요.',
   }
   if (score >= 60) return {
-    guide: '시장 리스크는 크지 않지만 일부 변수는 확인이 필요해요.',
+    ...buildHealthKPIContent('midHigh'),
     label: '양호',
     score,
-    summary: '시장 리스크는 크지 않지만 일부 변수는 확인이 필요해요.',
   }
   if (score >= 45) return {
-    guide: '시장 방향성이 뚜렷하지 않은 구간이에요.',
+    ...buildHealthKPIContent('mid'),
     label: '중립',
     score,
-    summary: '시장 방향성이 뚜렷하지 않은 구간이에요.',
   }
   if (score >= 30) return {
-    guide: '시장 변동성이 커지고 있는 구간이에요.',
+    ...buildHealthKPIContent('midLow'),
     label: '불안',
     score,
-    summary: '시장 변동성이 커지고 있는 구간이에요.',
   }
   return {
-    guide: '시장 불안이 큰 상태로 리스크 관리가 중요한 구간이에요.',
+    ...buildHealthKPIContent('low'),
     label: '공포',
     score,
-    summary: '시장 불안이 큰 상태로 리스크 관리가 중요한 구간이에요.',
   }
 }
 
@@ -689,4 +681,74 @@ function weightedAverage(entries: Array<[number, number]>): number {
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max)
+}
+
+function buildEntryKPIContent(tier: 'high' | 'midHigh' | 'mid' | 'midLow' | 'low'): MarketKPIContent {
+  if (tier === 'high') {
+    return {
+      guide: '종목별로 분할 접근을 검토해도 괜찮은 구간이에요.',
+      summary: '시장 리스크가 크지 않고 주식의 상대 매력도도 괜찮은 편이에요.',
+    }
+  }
+
+  if (tier === 'midHigh') {
+    return {
+      guide: '한 번에 진입하기보다 분할로 기회를 노리는 접근이 좋아요.',
+      summary: '시장 불안 요소가 일부 있지만, 진입 기회를 살펴볼 수 있는 구간이에요.',
+    }
+  }
+
+  if (tier === 'mid') {
+    return {
+      guide: '지금은 신규 진입보다 방향을 조금 더 확인하는 편이 안전해요.',
+      summary: '시장 방향이 뚜렷하지 않아 서두를 이유가 크지 않아요.',
+    }
+  }
+
+  if (tier === 'midLow') {
+    return {
+      guide: '신규 진입은 신중하게 보고, 비중을 크게 늘리진 않는 편이 좋아요.',
+      summary: '변동성이 커질 수 있어 공격적으로 들어가기엔 부담이 있는 구간이에요.',
+    }
+  }
+
+  return {
+    guide: '지금은 기회보다 리스크 관리에 더 무게를 두는 편이 좋아요.',
+    summary: '시장 리스크가 높은 구간이라 방어적으로 대응하는 게 우선이에요.',
+  }
+}
+
+function buildHealthKPIContent(tier: 'high' | 'midHigh' | 'mid' | 'midLow' | 'low'): MarketKPIContent {
+  if (tier === 'high') {
+    return {
+      guide: '시장 전반의 구조가 비교적 안정적이라 큰 경계 신호는 적은 편이에요.',
+      summary: '시장 환경이 전반적으로 안정적인 상태예요.',
+    }
+  }
+
+  if (tier === 'midHigh') {
+    return {
+      guide: '전반 흐름은 양호하지만 세부 변수는 계속 확인할 필요가 있어요.',
+      summary: '시장 리스크는 크지 않지만 일부 변수는 확인이 필요해요.',
+    }
+  }
+
+  if (tier === 'mid') {
+    return {
+      guide: '좋은 신호와 나쁜 신호가 섞여 있어 한쪽으로 단정하기 어려워요.',
+      summary: '시장 방향성이 뚜렷하지 않은 구간이에요.',
+    }
+  }
+
+  if (tier === 'midLow') {
+    return {
+      guide: '경계 신호가 늘고 있어 변동성 확대 가능성을 염두에 두는 게 좋아요.',
+      summary: '시장 변동성이 커지고 있는 구간이에요.',
+    }
+  }
+
+  return {
+    guide: '리스크 신호가 강해 방어적인 자산 배분이 더 중요해지는 구간이에요.',
+    summary: '시장 불안이 큰 상태로 리스크 관리가 중요한 구간이에요.',
+  }
 }


### PR DESCRIPTION
market KPI의 summary와 guide가 같은 문장을 반복하던 구조를 정리해 상태 설명과 행동 가이드를 분리했다. 경기 사이클 계산은 page 컴포넌트 밖으로 추출해 단위 테스트 가능하게 만들고, SectorPieChart의 SVG 폰트 하드코딩도 제거해 디자인 시스템과 맞췄다.

Constraint: keep diagnosis/page source-sniff test untouched for now because replacing it cleanly needs broader mocking setup
Rejected: Leave review P2 items as-is because verdict is already approved | low-cost cleanup improves maintainability before merge
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: keep market page display helpers outside client page components when they affect rendering decisions
Tested: COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm@9.15.4 verify; curl -I http://127.0.0.1:3000/market; curl -I http://127.0.0.1:3000/diagnosis
Not-tested: diagnosis source-sniff test replacement with full render/mocking coverage