### PR TITLE
[codex] 시장 카드 프로토타입 톤과 실제 수치 노출 복구, 엔진 고도화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules/
 REVIEW*.md
 docs/superpowers/
+.gstack/

--- a/src/app/market/page.module.css
+++ b/src/app/market/page.module.css
@@ -47,151 +47,120 @@
 }
 
 .heroCard {
-  padding: 20px 18px 16px;
+  padding: 16px 18px 14px;
+  display: grid;
+  gap: 10px;
 }
 
-.sectionTitle {
-  margin-bottom: 4px;
-  font-size: 13px;
+/* KPI: 진입 매력도 */
+.entryBlock {
+  display: grid;
+  gap: 4px;
+}
+
+.kpiEyebrow {
+  font-size: 10px;
   font-weight: 700;
-  color: #111;
-}
-
-.heroIntro {
-  margin-bottom: 18px;
-  font-size: 12px;
-  line-height: 1.5;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: #aaa;
 }
 
-.heroBody {
+.kpiRow {
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: 10px;
 }
 
-.gauge {
-  width: 116px;
-  height: 66px;
+.kpiScore {
+  display: flex;
+  align-items: baseline;
+  gap: 2px;
+}
+
+.kpiScoreNum {
+  font-size: 38px;
+  font-weight: 900;
+  letter-spacing: -0.05em;
+  line-height: 1;
+  color: #1c2b5e;
+  font-variant-numeric: tabular-nums;
+}
+
+.kpiScoreUnit {
+  font-size: 14px;
+  font-weight: 700;
+  color: #ccc;
+}
+
+.kpiLabel {
+  font-size: 15px;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: #1c2b5e;
+}
+
+.kpiSummary {
+  font-size: 12px;
+  line-height: 1.6;
+  color: #888;
+}
+
+/* Sub KPI: 시장 건강도 */
+.healthChip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 12px;
+  border-radius: 10px;
+  background: #f4f6ff;
+  border: 1px solid #e0e4f0;
+}
+
+.healthEyebrow {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #aaa;
   flex-shrink: 0;
 }
 
-.gaugeLabel {
-  font-size: 11px;
+.healthLabel {
+  font-size: 13px;
   font-weight: 800;
-}
-
-.gaugeCaption {
-  font-size: 8px;
-  fill: #aaa;
-}
-
-.legend {
+  color: #333;
   flex: 1;
-  min-width: 0;
 }
 
-.legendItem {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  margin-bottom: 7px;
-}
-
-.legendItem:last-child {
-  margin-bottom: 0;
-}
-
-.legendDot {
-  width: 8px;
-  height: 8px;
-  border-radius: 2px;
-  background: #e8e8ec;
-}
-
-.legendLabel {
-  font-size: 12px;
-  font-weight: 400;
-  color: #bbb;
-}
-
-.legendActiveLabel {
+.healthScore {
   font-size: 12px;
   font-weight: 700;
-  color: #111;
+  color: #aaa;
+  font-variant-numeric: tabular-nums;
 }
 
-.accentGreen {
-  fill: #23b26d;
-  stroke: #23b26d;
-  background: #23b26d;
-  color: #23b26d;
+/* 투자 시사점 */
+.implication {
+  display: grid;
+  gap: 4px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(28, 43, 94, 0.04);
 }
 
-.accentNavy {
-  fill: #1c2b5e;
-  stroke: #1c2b5e;
-  background: #1c2b5e;
-  color: #1c2b5e;
+.implicationLabel {
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(28, 43, 94, 0.5);
 }
 
-.accentAmber {
-  fill: #e8a838;
-  stroke: #e8a838;
-  background: #e8a838;
-  color: #e8a838;
-}
-
-.accentRed {
-  fill: #e24d4d;
-  stroke: #e24d4d;
-  background: #e24d4d;
-  color: #e24d4d;
-}
-
-.callout {
-  margin-top: 14px;
-  border-radius: 12px;
-  padding: 10px 14px;
+.implicationText {
   font-size: 12px;
   line-height: 1.6;
-  color: #666;
-}
-
-.calloutLabel {
-  font-weight: 700;
-}
-
-.accentGreenBackground {
-  background: rgba(35, 178, 109, 0.08);
-}
-
-.accentGreenBackground .calloutLabel {
-  color: #23b26d;
-}
-
-.accentNavyBackground {
-  background: rgba(28, 43, 94, 0.08);
-}
-
-.accentNavyBackground .calloutLabel {
-  color: #1c2b5e;
-}
-
-.accentAmberBackground {
-  background: rgba(232, 168, 56, 0.08);
-}
-
-.accentAmberBackground .calloutLabel {
-  color: #e8a838;
-}
-
-.accentRedBackground {
-  background: rgba(226, 77, 77, 0.08);
-}
-
-.accentRedBackground .calloutLabel {
-  color: #e24d4d;
+  color: #555;
 }
 
 .sectionHeader {
@@ -261,24 +230,18 @@
   margin-top: 12px;
 }
 
-.heroSkeletonBody,
 .skeletonRow {
   display: flex;
   align-items: center;
 }
 
-.heroSkeletonBody {
-  gap: 20px;
-}
-
-.skeletonGauge,
-.skeletonTitle,
+.skeletonKpiEyebrow,
+.skeletonKpiRow,
+.skeletonKpiScore,
+.skeletonKpiLabel,
+.skeletonHealthChip,
 .skeletonLine,
-.skeletonLineLong,
 .skeletonTitleShort,
-.skeletonLegendRow,
-.skeletonLegendRowShort,
-.skeletonCallout,
 .skeletonIcon,
 .skeletonBadge {
   background: linear-gradient(90deg, #f2f3f7, #e7e9ef, #f2f3f7);
@@ -286,57 +249,42 @@
   animation: shimmer 1.4s linear infinite;
 }
 
-.skeletonTitle,
-.skeletonLine,
-.skeletonLineLong,
-.skeletonTitleShort,
-.skeletonLegendRow,
-.skeletonLegendRowShort {
+.skeletonKpiEyebrow {
+  width: 64px;
+  height: 10px;
   border-radius: 999px;
 }
 
-.skeletonTitle {
-  width: 92px;
-  height: 13px;
-  margin-bottom: 8px;
+.skeletonKpiRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: none;
+  animation: none;
 }
 
-.skeletonLineLong {
+.skeletonKpiScore {
+  width: 72px;
+  height: 38px;
+  border-radius: 8px;
+}
+
+.skeletonKpiLabel {
+  width: 90px;
+  height: 16px;
+  border-radius: 999px;
+}
+
+.skeletonLine {
   width: 180px;
-  height: 12px;
-  margin-bottom: 18px;
+  height: 11px;
+  border-radius: 999px;
 }
 
-.skeletonGauge {
-  width: 116px;
-  height: 66px;
-  border-radius: 16px;
-}
-
-.skeletonLegend {
-  flex: 1;
-}
-
-.skeletonLegendRow,
-.skeletonLegendRowShort {
-  height: 12px;
-  margin-bottom: 8px;
-}
-
-.skeletonLegendRow {
-  width: 76px;
-}
-
-.skeletonLegendRowShort {
-  width: 58px;
-  margin-bottom: 0;
-}
-
-.skeletonCallout {
+.skeletonHealthChip {
   width: 100%;
-  height: 44px;
-  border-radius: 12px;
-  margin-top: 14px;
+  height: 36px;
+  border-radius: 10px;
 }
 
 .skeletonCard {

--- a/src/app/market/page.test.ts
+++ b/src/app/market/page.test.ts
@@ -2,11 +2,11 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 describe('MarketPage source', () => {
-  it('시장 페이지를 경기 사이클 카드와 5가지 신호 상세 구조로 유지한다', () => {
+  it('시장 페이지를 KPI 상단과 5가지 신호 상세 구조로 유지한다', () => {
     const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
-    expect(source).toContain("const CYCLE_STAGES = ['회복', '확장', '둔화', '침체'] as const")
-    expect(source).toContain('경기 사이클 위치')
+    expect(source).toContain('진입 매력도')
+    expect(source).toContain('시장 건강도')
     expect(source).toContain('5가지 신호 상세')
     expect(source).toContain("const INDICATOR_ORDER = ['fearGreed', 'yieldCurve', 'erp', 'creditSpread', 'm2'] as const")
   })

--- a/src/app/market/page.test.ts
+++ b/src/app/market/page.test.ts
@@ -1,6 +1,5 @@
+import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
-import { deriveCycleStage } from '@/lib/cycleStage'
-import type { MarketResponse } from '@/lib/marketSignals'
 
 describe('MarketPage source', () => {
   it('시장 페이지를 KPI 상단과 5가지 신호 상세 구조로 유지한다', () => {
@@ -9,6 +8,7 @@ describe('MarketPage source', () => {
     expect(source).toContain('진입 매력도')
     expect(source).toContain('시장 건강도')
     expect(source).toContain('5가지 신호 상세')
+    expect(source).toContain('buildMarketInsight')
     expect(source).toContain("const INDICATOR_ORDER = ['fearGreed', 'yieldCurve', 'erp', 'creditSpread', 'm2'] as const")
   })
 })

--- a/src/app/market/page.tsx
+++ b/src/app/market/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react'
 import { BottomNav } from '@/components/BottomNav'
 import { MarketCard } from '@/components/MarketCard'
-import { deriveCycleStage, type CycleStage } from '@/lib/cycleStage'
+import { buildMarketInsight } from '@/lib/marketInsightTemplates'
 import type { MarketResponse } from '@/lib/marketSignals'
 import { loadMarketSignals } from '@/lib/marketSignalsClient'
 import styles from './page.module.css'
@@ -52,6 +52,9 @@ export default function MarketPage() {
 
   const entry = market?.overview.entry
   const health = market?.overview.health
+  const insight = market && entry && health
+    ? buildMarketInsight(entry.score, health.score)
+    : null
   const orderedIndicators = market
     ? [...market.indicators].sort(
       (left, right) => INDICATOR_ORDER.indexOf(left.key) - INDICATOR_ORDER.indexOf(right.key),
@@ -111,10 +114,10 @@ export default function MarketPage() {
                 <span className={styles.healthScore}>{health.score}/100</span>
               </div>
 
-              {entry.guide && (
+              {insight && (
                 <div className={styles.implication}>
-                  <div className={styles.implicationLabel}>투자 시사점</div>
-                  <p className={styles.implicationText}>{entry.guide}</p>
+                  <div className={styles.implicationLabel}>{insight.title}</div>
+                  <p className={styles.implicationText}>{insight.message}</p>
                 </div>
               )}
             </section>

--- a/src/app/market/page.tsx
+++ b/src/app/market/page.tsx
@@ -8,18 +8,7 @@ import { loadMarketSignals } from '@/lib/marketSignalsClient'
 import styles from './page.module.css'
 
 const SKELETON_COUNT = 5
-const CYCLE_STAGES = ['회복', '확장', '둔화', '침체'] as const
 const INDICATOR_ORDER = ['fearGreed', 'yieldCurve', 'erp', 'creditSpread', 'm2'] as const
-
-type CycleStage = {
-  accentClassName: string
-  caption: string
-  description: string
-  label: typeof CYCLE_STAGES[number]
-  point: { x: number; y: number }
-  progress: number
-  summary: string
-}
 
 export default function MarketPage() {
   const [market, setMarket] = useState<MarketResponse | null>(null)
@@ -60,7 +49,8 @@ export default function MarketPage() {
     }
   }
 
-  const cycle = market ? deriveCycleStage(market) : null
+  const entry = market?.overview.entry
+  const health = market?.overview.health
   const orderedIndicators = market
     ? [...market.indicators].sort(
       (left, right) => INDICATOR_ORDER.indexOf(left.key) - INDICATOR_ORDER.indexOf(right.key),
@@ -81,18 +71,13 @@ export default function MarketPage() {
         <main className={styles.content}>
           {loading && (
             <section className={styles.heroCard} aria-hidden="true">
-              <div className={styles.skeletonTitle} />
-              <div className={styles.skeletonLineLong} />
-              <div className={styles.heroSkeletonBody}>
-                <div className={styles.skeletonGauge} />
-                <div className={styles.skeletonLegend}>
-                  <div className={styles.skeletonLegendRow} />
-                  <div className={styles.skeletonLegendRow} />
-                  <div className={styles.skeletonLegendRow} />
-                  <div className={styles.skeletonLegendRowShort} />
-                </div>
+              <div className={styles.skeletonKpiEyebrow} />
+              <div className={styles.skeletonKpiRow}>
+                <div className={styles.skeletonKpiScore} />
+                <div className={styles.skeletonKpiLabel} />
               </div>
-              <div className={styles.skeletonCallout} />
+              <div className={styles.skeletonLine} />
+              <div className={styles.skeletonHealthChip} />
             </section>
           )}
 
@@ -105,46 +90,63 @@ export default function MarketPage() {
             </div>
           )}
 
-          {!loading && market && cycle && (
-            <>
-              <section className={styles.heroCard}>
-                <div className={styles.sectionTitle}>경기 사이클 위치</div>
-                <p className={styles.heroIntro}>{cycle.description}</p>
-
-                <div className={styles.heroBody}>
-                  <CycleGauge cycle={cycle} />
-
-                  <div className={styles.legend}>
-                    {CYCLE_STAGES.map(stage => {
-                      const active = stage === cycle.label
-
-                      return (
-                        <div key={stage} className={styles.legendItem}>
-                          <span
-                            className={`${styles.legendDot} ${active ? styles[cycle.accentClassName] : ''}`}
-                            aria-hidden="true"
-                          />
-                          <span className={active ? styles.legendActiveLabel : styles.legendLabel}>
-                            {stage}
-                          </span>
-                        </div>
-                      )
-                    })}
+          {!loading && market && entry && health && (
+            <section className={styles.heroCard}>
+              <div className={styles.entryBlock}>
+                <div className={styles.kpiEyebrow}>진입 매력도</div>
+                <div className={styles.kpiRow}>
+                  <div className={styles.kpiScore}>
+                    <span className={styles.kpiScoreNum}>{entry.score}</span>
+                    <span className={styles.kpiScoreUnit}>/100</span>
                   </div>
+                  <div className={styles.kpiLabel}>{entry.label}</div>
                 </div>
-
-                <div className={`${styles.callout} ${styles[`${cycle.accentClassName}Background`]}`}>
-                  <strong className={styles.calloutLabel}>투자 시사점:</strong> {cycle.summary}
-                </div>
-              </section>
-
-              <div className={styles.sectionHeader}>
-                <div className={styles.sectionEyebrow}>5가지 신호 상세</div>
-                <button className={styles.refreshButton} onClick={() => void handleRefresh()}>
-                  새로고침
-                </button>
+                <p className={styles.kpiSummary}>{entry.summary}</p>
               </div>
 
+              <div className={styles.healthChip}>
+                <span className={styles.healthEyebrow}>시장 건강도</span>
+                <span className={styles.healthLabel}>{health.label}</span>
+                <span className={styles.healthScore}>{health.score}/100</span>
+              </div>
+
+              {entry.guide && (
+                <div className={styles.implication}>
+                  <div className={styles.implicationLabel}>투자 시사점</div>
+                  <p className={styles.implicationText}>{entry.guide}</p>
+                </div>
+              )}
+            </section>
+          )}
+
+          <div className={styles.sectionHeader}>
+            <div className={styles.sectionEyebrow}>5가지 신호 상세</div>
+            {!loading && (
+              <button className={styles.refreshButton} onClick={() => void handleRefresh()}>
+                새로고침
+              </button>
+            )}
+          </div>
+
+          {loading && (
+            <div className={styles.cardList}>
+              {Array.from({ length: SKELETON_COUNT }, (_, index) => (
+                <div key={index} className={styles.skeletonCard} aria-hidden="true">
+                  <div className={styles.skeletonRow}>
+                    <div className={styles.skeletonIcon} />
+                    <div className={styles.skeletonText}>
+                      <div className={styles.skeletonTitleShort} />
+                      <div className={styles.skeletonLine} />
+                    </div>
+                    <div className={styles.skeletonBadge} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {!loading && market && (
+            <>
               <div className={styles.cardList}>
                 {orderedIndicators.map(indicator => (
                   <MarketCard key={indicator.key} indicator={indicator} />
@@ -161,111 +163,10 @@ export default function MarketPage() {
               <p className={styles.source}>데이터 출처: FRED, onoff.markets, multpl.com</p>
             </>
           )}
-
-          {loading && (
-            <>
-              <div className={styles.sectionHeader}>
-                <div className={styles.sectionEyebrow}>5가지 신호 상세</div>
-              </div>
-
-              <div className={styles.cardList}>
-                {Array.from({ length: SKELETON_COUNT }, (_, index) => (
-                  <div key={index} className={styles.skeletonCard} aria-hidden="true">
-                    <div className={styles.skeletonRow}>
-                      <div className={styles.skeletonIcon} />
-                      <div className={styles.skeletonText}>
-                        <div className={styles.skeletonTitleShort} />
-                        <div className={styles.skeletonLine} />
-                      </div>
-                      <div className={styles.skeletonBadge} />
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </>
-          )}
         </main>
       </div>
 
       <BottomNav />
     </div>
-  )
-}
-
-function deriveCycleStage(market: MarketResponse): CycleStage {
-  const healthScore = market.overview.health.score
-  const entryGuide = market.overview.entry.guide
-  const stageIndex = healthScore >= 75 ? 1 : healthScore >= 55 ? 0 : healthScore >= 35 ? 2 : 3
-  const label = CYCLE_STAGES[stageIndex]
-  const captions = ['회복 초입 국면', '확장 지속 국면', '둔화 초입 국면', '침체 방어 국면'] as const
-  const descriptions = [
-    '시장 구조가 서서히 회복되며 위험자산을 다시 점검해볼 수 있는 구간입니다.',
-    '시장 구조가 비교적 안정적이라 공격 자산이 힘을 받기 쉬운 구간입니다.',
-    '현재 시장은 둔화 초입 국면으로 추정됩니다.',
-    '시장 전반의 방어 심리가 강해 보수적인 비중 관리가 필요한 구간입니다.',
-  ] as const
-  const accentClassNames = ['accentGreen', 'accentNavy', 'accentAmber', 'accentRed'] as const
-  const progress = [0.22, 0.48, 0.74, 1] as const
-
-  return {
-    accentClassName: accentClassNames[stageIndex],
-    caption: captions[stageIndex],
-    description: descriptions[stageIndex],
-    label,
-    point: polarToCartesian(progress[stageIndex]),
-    progress: progress[stageIndex],
-    summary: entryGuide,
-  }
-}
-
-function polarToCartesian(progress: number) {
-  const clamped = Math.min(Math.max(progress, 0), 1)
-  const radius = 48
-  const centerX = 58
-  const centerY = 58
-  const angle = Math.PI * (1 - clamped)
-
-  return {
-    x: centerX + (radius * Math.cos(angle)),
-    y: centerY - (radius * Math.sin(angle)),
-  }
-}
-
-function CycleGauge({ cycle }: { cycle: CycleStage }) {
-  const dashLength = 151
-  const progressLength = dashLength * cycle.progress
-
-  return (
-    <svg className={styles.gauge} viewBox="0 0 116 66" aria-label={`현재 경기 사이클은 ${cycle.label}`}>
-      <path
-        d="M 10,58 A 48,48 0 0 1 106,58"
-        fill="none"
-        stroke="#f0f0f5"
-        strokeWidth="10"
-        strokeLinecap="round"
-      />
-      <path
-        d="M 10,58 A 48,48 0 0 1 106,58"
-        fill="none"
-        className={styles[cycle.accentClassName]}
-        strokeWidth="10"
-        strokeLinecap="round"
-        strokeDasharray={`${progressLength} ${dashLength}`}
-      />
-      <circle
-        cx={cycle.point.x}
-        cy={cycle.point.y}
-        r="6"
-        className={styles[cycle.accentClassName]}
-        stroke="white"
-        strokeWidth="2"
-      />
-      <text x="58" y="52" textAnchor="middle" className={`${styles.gaugeLabel} ${styles[cycle.accentClassName]}`}>
-        {cycle.label}
-      </text>
-      <text x="58" y="63" textAnchor="middle" className={styles.gaugeCaption}>
-        {cycle.caption}
-      </text>
-    </svg>
   )
 }

--- a/src/components/MarketCard.module.css
+++ b/src/components/MarketCard.module.css
@@ -1,95 +1,133 @@
 .card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 20px;
+  margin: 0 16px 8px;
   overflow: hidden;
-  box-shadow: 0 14px 28px rgba(18, 24, 88, 0.06);
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
 }
 
 .toggle {
   width: 100%;
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 16px 18px;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 12px;
+  border: none;
+  background: none;
+  padding: 14px 16px;
   text-align: left;
   font-family: inherit;
 }
 
-.toggle:active {
-  background: rgba(26, 35, 126, 0.03);
-}
-
-.toggleLeft {
-  flex: 1;
+.copy {
   min-width: 0;
+  flex: 1;
 }
 
-.toggleRight {
+.iconWrap {
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+}
+
+.iconWrap_positive {
+  background: rgba(35, 178, 109, 0.07);
+}
+
+.iconWrap_negative {
+  background: rgba(226, 77, 77, 0.07);
+}
+
+.iconWrap_neutral,
+.iconWrap_unavailable {
+  background: transparent;
+}
+
+.icon {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+}
+
+.icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.icon_positive {
+  color: #23b26d;
+}
+
+.icon_negative {
+  color: #e24d4d;
+}
+
+.icon_neutral,
+.icon_unavailable {
+  color: #aaa;
+}
+
+.title {
+  margin-bottom: 2px;
+  font-size: 13px;
+  font-weight: 700;
+  color: #111;
+}
+
+.description {
+  display: -webkit-box;
+  overflow: hidden;
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: #888;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+}
+
+.right {
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 8px;
-}
-
-.title {
-  font-size: 15px;
-  font-weight: 800;
-  letter-spacing: -0.02em;
-  color: var(--text-1);
-  margin-bottom: 6px;
-}
-
-.summary {
-  font-size: 13px;
-  line-height: 1.6;
-  color: var(--text-2);
-}
-
-.summaryClamp {
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+  gap: 5px;
 }
 
 .badge {
   border-radius: 999px;
-  padding: 5px 10px;
+  padding: 3px 9px;
   font-size: 11px;
-  font-weight: 800;
+  font-weight: 700;
 }
 
 .badge_positive {
-  background: var(--green-bg);
-  color: var(--green);
-}
-
-.badge_neutral {
-  background: var(--amber-bg);
-  color: var(--amber);
+  background: rgba(35, 178, 109, 0.07);
+  color: #23b26d;
 }
 
 .badge_negative {
-  background: var(--red-bg);
-  color: var(--red);
+  background: rgba(226, 77, 77, 0.07);
+  color: #e24d4d;
+}
+
+.badge_neutral {
+  background: transparent;
+  color: #aaa;
 }
 
 .badge_unavailable {
-  background: rgba(232, 234, 246, 0.85);
-  color: var(--navy);
+  background: transparent;
+  color: #bbb;
 }
 
 .arrow {
-  font-size: 12px;
-  color: var(--text-3);
-  transition: transform 0.2s;
   display: inline-block;
-  margin-top: 2px;
+  font-size: 10px;
+  color: #ccc;
+  transition: transform 0.25s;
 }
 
 .arrowOpen {
@@ -97,52 +135,64 @@
 }
 
 .body {
-  border-top: 1px solid rgba(26, 35, 126, 0.08);
-  padding: 14px 18px 16px;
   display: grid;
   gap: 12px;
+  padding: 0 16px 16px;
+  border-top: 1px solid #f3f3f5;
 }
 
-.guide {
-  font-size: 13px;
+.note {
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: #f6f7fa;
+}
+
+.noteText {
+  font-size: 12px;
   line-height: 1.65;
-  color: var(--text-2);
+  color: #666;
 }
 
-.techToggle {
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0;
+.detailToggle {
   display: flex;
   align-items: center;
-  gap: 5px;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-3);
+  gap: 4px;
+  border: none;
+  background: none;
+  padding: 0;
   font-family: inherit;
+  font-size: 11px;
+  color: #bbb;
 }
 
-.techArrow {
-  font-size: 10px;
-  transition: transform 0.2s;
+.detailArrow {
   display: inline-block;
+  width: 10px;
 }
 
-.techArrowOpen {
-  transform: rotate(90deg);
-}
-
-.techBox {
-  background: rgba(232, 234, 246, 0.45);
+.metricBox {
   border-radius: 12px;
-  padding: 12px 14px;
+  padding: 10px 12px;
+  background: #f8f8fc;
 }
 
-.techValue {
-  font-size: 20px;
-  font-weight: 900;
-  letter-spacing: -0.04em;
-  color: var(--navy-dark);
-  font-variant-numeric: tabular-nums;
+.metricTitle {
+  margin-bottom: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  color: #888;
+}
+
+.metricSource {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+  font-size: 11px;
+  line-height: 1.5;
+  color: #aaa;
+}
+
+.metricValue {
+  margin-top: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  color: #555;
 }

--- a/src/components/MarketCard.test.ts
+++ b/src/components/MarketCard.test.ts
@@ -1,0 +1,39 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { MARKET_CARD_TITLES, MarketCard } from './MarketCard'
+
+describe('MarketCard', () => {
+  it('닫힌 상태에서 프로토타입형 헤더를 렌더링한다', () => {
+    const html = renderToStaticMarkup(
+      createElement(MarketCard, {
+        indicator: {
+          detailSource: '출처: multpl.com + FRED | Earnings Yield 3.2% − DGS10 4.3% = -1.1%p',
+          detailTitle: 'ERP (주식−채권 상대매력)',
+          detailValue: '실제 값: -1.1%p',
+          guide: '분할 접근보다 방어 자산 비중을 점검해보세요.',
+          key: 'erp',
+          label: 'ERP',
+          status: 'negative',
+          summary: '채권 금리 매력이 더 커 보여 주식에 높은 점수를 주기 어려운 구간이에요.',
+          value: '-0.7%p',
+        },
+      }),
+    )
+
+    expect(html).toContain('주식 vs 채권 매력도')
+    expect(html).toContain('지금 주식이 채권보다 더 매력적인가요?')
+    expect(html).toContain('주의')
+    expect(html).toContain('aria-expanded="false"')
+  })
+
+  it('프로토타입에 맞는 5개 카드 타이틀을 모두 유지한다', () => {
+    expect(MARKET_CARD_TITLES).toEqual({
+      fearGreed: '시장 심리',
+      yieldCurve: '경기 신호등',
+      erp: '주식 vs 채권 매력도',
+      creditSpread: '기업 부도 위험',
+      m2: '시중 돈의 양',
+    })
+  })
+})

--- a/src/components/MarketCard.tsx
+++ b/src/components/MarketCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { JSX } from 'react'
 import { useState } from 'react'
 import type { MarketIndicator, MarketIndicatorStatus } from '@/lib/marketSignals'
 import styles from './MarketCard.module.css'
@@ -8,32 +9,125 @@ interface MarketCardProps {
   indicator: MarketIndicator
 }
 
+type IndicatorContent = {
+  description: string
+  icon: JSX.Element
+  title: string
+}
+
 const STATUS_LABEL: Record<MarketIndicatorStatus, string> = {
-  negative: '경계',
-  neutral: '중립',
-  positive: '우호',
+  negative: '주의',
+  neutral: '보통',
+  positive: '긍정',
   unavailable: '대기',
+}
+
+const INDICATOR_CONTENT: Record<MarketIndicator['key'], IndicatorContent> = {
+  fearGreed: {
+    description: '지금 투자자들이 겁먹고 있나요, 아니면 과하게 낙관하고 있나요?',
+    icon: (
+      <svg viewBox="0 0 20 20" aria-hidden="true">
+        <path
+          d="M10 3C10 3 4 7 4 12A6 6 0 0 0 16 12C16 7 10 3 10 3Z"
+          stroke="currentColor"
+          strokeWidth="1.6"
+          fill="none"
+          strokeLinejoin="round"
+        />
+        <path d="M7 13S8 11 10 11S13 13 13 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        <circle cx="8" cy="11" r="1" fill="currentColor" />
+        <circle cx="12" cy="11" r="1" fill="currentColor" />
+      </svg>
+    ),
+    title: '시장 심리',
+  },
+  yieldCurve: {
+    description: '앞으로 경기가 좋아질까요, 나빠질까요?',
+    icon: (
+      <svg viewBox="0 0 20 20" aria-hidden="true">
+        <circle cx="10" cy="10" r="7" stroke="currentColor" strokeWidth="1.6" fill="none" />
+        <rect x="9" y="5" width="2" height="6" rx="1" fill="currentColor" />
+        <rect x="9" y="13" width="2" height="2" rx="1" fill="currentColor" />
+      </svg>
+    ),
+    title: '경기 신호등',
+  },
+  erp: {
+    description: '지금 주식이 채권보다 더 매력적인가요?',
+    icon: (
+      <svg viewBox="0 0 20 20" aria-hidden="true">
+        <path d="M10 4V16M4 10H16" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+        <rect x="3" y="13" width="5" height="3" rx="1" fill="rgba(226,77,77,0.18)" stroke="currentColor" strokeWidth="1.2" />
+        <rect x="12" y="10" width="5" height="6" rx="1" fill="rgba(226,77,77,0.18)" stroke="currentColor" strokeWidth="1.2" />
+      </svg>
+    ),
+    title: '주식 vs 채권 매력도',
+  },
+  creditSpread: {
+    description: '기업들이 돈을 갚지 못할 위험이 높아지고 있나요?',
+    icon: (
+      <svg viewBox="0 0 20 20" aria-hidden="true">
+        <path
+          d="M10 3L17 7V12C17 15 14 17 10 18C6 17 3 15 3 12V7L10 3Z"
+          stroke="currentColor"
+          strokeWidth="1.6"
+          fill="none"
+          strokeLinejoin="round"
+        />
+        <path d="M7 10L9 12L13 8" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    ),
+    title: '기업 부도 위험',
+  },
+  m2: {
+    description: '시장에 돈이 충분히 돌고 있나요?',
+    icon: (
+      <svg viewBox="0 0 20 20" aria-hidden="true">
+        <circle cx="10" cy="11" r="6" stroke="currentColor" strokeWidth="1.6" fill="none" />
+        <path d="M10 5V3M7 6L5.5 4.5M13 6L14.5 4.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+        <path
+          d="M8 11C8 9.9 8.9 9 10 9S12 9.9 12 11S11.1 12 10 12S8 12.1 8 13C8 14.1 8.9 15 10 15S12 14.1 12 13"
+          stroke="currentColor"
+          strokeWidth="1.4"
+          strokeLinecap="round"
+        />
+      </svg>
+    ),
+    title: '시중 돈의 양',
+  },
+}
+
+export const MARKET_CARD_TITLES: Record<MarketIndicator['key'], string> = {
+  fearGreed: INDICATOR_CONTENT.fearGreed.title,
+  yieldCurve: INDICATOR_CONTENT.yieldCurve.title,
+  erp: INDICATOR_CONTENT.erp.title,
+  creditSpread: INDICATOR_CONTENT.creditSpread.title,
+  m2: INDICATOR_CONTENT.m2.title,
 }
 
 export function MarketCard({ indicator }: MarketCardProps) {
   const [open, setOpen] = useState(false)
-  const [techOpen, setTechOpen] = useState(false)
+  const [detailOpen, setDetailOpen] = useState(false)
+  const content = INDICATOR_CONTENT[indicator.key]
 
   return (
     <article className={styles.card}>
       <button
         type="button"
         className={styles.toggle}
-        onClick={() => setOpen(o => !o)}
+        onClick={() => setOpen(prev => !prev)}
         aria-expanded={open}
       >
-        <div className={styles.toggleLeft}>
-          <h2 className={styles.title}>{indicator.label}</h2>
-          <p className={`${styles.summary} ${open ? '' : styles.summaryClamp}`}>
-            {indicator.summary}
-          </p>
+        <div className={`${styles.iconWrap} ${styles[`iconWrap_${indicator.status}`]}`}>
+          <span className={`${styles.icon} ${styles[`icon_${indicator.status}`]}`}>{content.icon}</span>
         </div>
-        <div className={styles.toggleRight}>
+
+        <div className={styles.copy}>
+          <h2 className={styles.title}>{content.title}</h2>
+          <p className={styles.description}>{content.description}</p>
+        </div>
+
+        <div className={styles.right}>
           <span className={`${styles.badge} ${styles[`badge_${indicator.status}`]}`}>
             {STATUS_LABEL[indicator.status]}
           </span>
@@ -43,18 +137,25 @@ export function MarketCard({ indicator }: MarketCardProps) {
 
       {open && (
         <div className={styles.body}>
-          <p className={styles.guide}>{indicator.guide}</p>
+          <div className={styles.note}>
+            <p className={styles.noteText}>{indicator.summary}</p>
+          </div>
+
           <button
             type="button"
-            className={styles.techToggle}
-            onClick={() => setTechOpen(o => !o)}
+            className={styles.detailToggle}
+            onClick={() => setDetailOpen(prev => !prev)}
+            aria-expanded={detailOpen}
           >
-            <span className={`${styles.techArrow} ${techOpen ? styles.techArrowOpen : ''}`}>▸</span>
-            <span>실제 지표 수치 보기 (금리차, 스프레드 등)</span>
+            <span className={styles.detailArrow}>{detailOpen ? '▾' : '▸'}</span>
+            <span>실제 지표 수치 보기</span>
           </button>
-          {techOpen && (
-            <div className={styles.techBox}>
-              <div className={styles.techValue}>{indicator.value}</div>
+
+          {detailOpen && (
+            <div className={styles.metricBox}>
+              <div className={styles.metricTitle}>{indicator.detailTitle}</div>
+              <div className={styles.metricSource}>{indicator.detailSource}</div>
+              <div className={styles.metricValue}>{indicator.detailValue}</div>
             </div>
           )}
         </div>

--- a/src/lib/marketInsightTemplates.test.ts
+++ b/src/lib/marketInsightTemplates.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { buildMarketInsight, getMarketZone } from './marketInsightTemplates'
+
+describe('marketInsightTemplates', () => {
+  it('진입/건강 점수 조합에 따라 존을 분류한다', () => {
+    expect(getMarketZone(80, 80)).toBe('ideal_entry')
+    expect(getMarketZone(70, 25)).toBe('risk_but_opportunity')
+    expect(getMarketZone(20, 20)).toBe('risk_first')
+    expect(getMarketZone(20, 80)).toBe('overheated')
+    expect(getMarketZone(65, 50)).toBe('cautious_opportunity')
+  })
+
+  it('존에 맞는 제목과 메시지를 반환한다', () => {
+    const insight = buildMarketInsight(67, 38)
+
+    expect(insight.zone).toBe('risk_but_opportunity')
+    expect(insight.title).toBe('위험하지만 기회 있음')
+    expect(insight.message).toContain('시장')
+  })
+})

--- a/src/lib/marketInsightTemplates.ts
+++ b/src/lib/marketInsightTemplates.ts
@@ -1,0 +1,159 @@
+export type MarketZone =
+  | 'ideal_entry'
+  | 'risk_but_opportunity'
+  | 'risk_first'
+  | 'stable_but_expensive'
+  | 'cautious_opportunity'
+  | 'early_risk'
+  | 'overheated'
+  | 'neutral'
+  | 'mixed'
+
+export type MarketInsightResult = {
+  zone: MarketZone
+  title: string
+  message: string
+}
+
+type TemplateSet = {
+  title: string
+  messages: string[]
+}
+
+const MARKET_INSIGHT_TEMPLATES: Record<MarketZone, TemplateSet> = {
+  ideal_entry: {
+    title: '분할 진입 검토',
+    messages: [
+      '시장 환경이 안정적이고 가격 매력도도 괜찮은 상태예요. 종목별로 분할 진입을 검토하기 좋은 구간이에요.',
+      '리스크가 크지 않으면서 투자 기회도 있는 구간이에요. 무리하지 않는 선에서 천천히 접근해볼 수 있어요.',
+      '시장 흐름이 안정적인 가운데 일부 종목은 매력적인 가격대를 보이고 있어요. 점진적으로 접근하기 좋아요.',
+    ],
+  },
+  risk_but_opportunity: {
+    title: '위험하지만 기회 있음',
+    messages: [
+      '시장은 불안하지만 가격 매력은 올라온 상태예요. 좋은 종목을 나눠서 접근해볼 수 있는 구간이에요.',
+      '시장 변동성은 크지만 일부 지표는 기회를 보여주고 있어요. 한 번에 들어가기보다 분할 전략이 어울려요.',
+      '시장 분위기는 좋지 않지만 장기적으로는 기회를 만들 수 있는 구간이에요. 서두르지 말고 천천히 접근해보세요.',
+    ],
+  },
+  risk_first: {
+    title: '리스크 관리 우선',
+    messages: [
+      '시장 불안이 크고 가격 매력도도 부족한 상태예요. 지금은 기회보다 리스크 관리가 더 중요한 구간이에요.',
+      '시장과 가격 모두 부담이 있는 구간이에요. 성급한 진입보다는 관망이 더 나은 선택일 수 있어요.',
+      '변동성과 리스크가 동시에 높은 상태예요. 신규 투자보다는 상황을 지켜보는 게 좋아요.',
+    ],
+  },
+  stable_but_expensive: {
+    title: '안정적이지만 가격 부담',
+    messages: [
+      '시장은 안정적이지만 가격 부담이 있는 구간이에요. 추격 매수보다는 신중한 접근이 필요해요.',
+      '시장 분위기는 나쁘지 않지만 이미 많이 반영된 상태일 수 있어요. 진입 타이밍은 조금 더 기다려도 좋아요.',
+      '리스크는 크지 않지만 기대가 많이 반영된 상태예요. 무리한 진입은 피하는 게 좋아요.',
+    ],
+  },
+  cautious_opportunity: {
+    title: '조심스러운 기회',
+    messages: [
+      '시장 방향은 아직 뚜렷하지 않지만 가격 매력은 있는 상태예요. 분할 접근으로 기회를 노려볼 수 있어요.',
+      '시장 흐름은 애매하지만 일부 종목은 매력적인 가격대에 있어요. 신중하게 접근해보세요.',
+      '확실한 상승장은 아니지만 진입 매력은 조금씩 생기고 있어요. 작은 비중부터 살펴볼 수 있어요.',
+    ],
+  },
+  early_risk: {
+    title: '신중한 관망',
+    messages: [
+      '시장 흐름이 불안정해지는 초기 구간이에요. 지금은 서두르기보다 상황을 지켜보는 게 좋아요.',
+      '가격 매력도 부족하고 시장도 방향이 애매한 상태예요. 무리한 진입은 피하는 게 좋아요.',
+      '아직 유리한 진입 구간으로 보기는 어려워요. 리스크가 더 커지는지 확인이 필요해요.',
+    ],
+  },
+  overheated: {
+    title: '과열 주의',
+    messages: [
+      '시장이 과하게 낙관적인 상태예요. 가격 부담이 큰 구간이라 추격 매수는 주의가 필요해요.',
+      '시장 기대감이 많이 반영된 상태예요. 지금은 진입보다 리스크를 점검하는 게 좋아요.',
+      '상승 흐름은 있지만 과열 가능성이 높은 구간이에요. 신중하게 접근해야 해요.',
+    ],
+  },
+  neutral: {
+    title: '중립 구간',
+    messages: [
+      '시장과 가격 모두 뚜렷한 방향이 보이지 않는 구간이에요. 조금 더 흐름을 확인하는 게 좋아요.',
+      '지금은 특별히 유리하거나 불리하지 않은 상태예요. 종목별로 신중하게 접근하는 게 중요해요.',
+      '전체 시장보다는 개별 종목의 가격 위치와 추세를 더 꼼꼼히 보는 게 좋아요.',
+    ],
+  },
+  mixed: {
+    title: '혼합 신호',
+    messages: [
+      '시장과 가격이 서로 엇갈린 신호를 보이고 있어요. 조금 더 명확한 흐름이 나올 때까지 기다려도 좋아요.',
+      '지표들이 같은 방향을 가리키지 않는 구간이에요. 성급한 판단은 피하는 게 좋아요.',
+      '일부 지표는 긍정적이지만 다른 지표는 아직 조심스럽다는 신호를 보내고 있어요.',
+    ],
+  },
+}
+
+function pickDeterministic<T>(items: T[], seed: number): T {
+  const index = Math.abs(Math.round(seed)) % items.length
+  return items[index]
+}
+
+export function getMarketZone(entryScore: number, healthScore: number): MarketZone {
+  const entryHigh = entryScore >= 75
+  const entryGood = entryScore >= 60
+  const entryNeutral = entryScore >= 45
+  const entryLow = entryScore < 45
+  const entryVeryLow = entryScore < 30
+  const healthHigh = healthScore >= 75
+  const healthGood = healthScore >= 60
+  const healthNeutral = healthScore >= 45
+  const healthLow = healthScore < 45
+  const healthVeryLow = healthScore < 30
+
+  if ((healthHigh || healthGood) && (entryHigh || entryGood)) {
+    return 'ideal_entry'
+  }
+
+  if ((healthLow || healthVeryLow) && (entryHigh || entryGood)) {
+    return 'risk_but_opportunity'
+  }
+
+  if ((healthLow || healthVeryLow) && entryLow) {
+    return 'risk_first'
+  }
+
+  if ((healthHigh || healthGood) && entryLow) {
+    if (entryVeryLow) return 'overheated'
+    return 'stable_but_expensive'
+  }
+
+  if (healthNeutral && (entryHigh || entryGood)) {
+    return 'cautious_opportunity'
+  }
+
+  if (healthNeutral && entryLow) {
+    return 'early_risk'
+  }
+
+  if (entryNeutral && healthNeutral) {
+    return 'neutral'
+  }
+
+  return 'mixed'
+}
+
+export function buildMarketInsight(entryScore: number, healthScore: number): MarketInsightResult {
+  const zone = getMarketZone(entryScore, healthScore)
+  const template = MARKET_INSIGHT_TEMPLATES[zone]
+
+  return {
+    zone,
+    title: template.title,
+    message: pickDeterministic(
+      template.messages,
+      entryScore * 13 + healthScore * 7,
+    ),
+  }
+}

--- a/src/lib/marketSignals.test.ts
+++ b/src/lib/marketSignals.test.ts
@@ -20,8 +20,9 @@ describe('buildMarketResponse', () => {
     })
 
     expect(response.macroState).toBe('risk_on')
-    expect(response.macroScore).toBe(1)
-    expect(response.indicators.every(indicator => indicator.status === 'positive')).toBe(true)
+    expect(response.macroScore).toBe(0.8)
+    expect(response.indicators.find(indicator => indicator.key === 'erp')?.status).toBe('neutral')
+    expect(response.indicators.filter(indicator => indicator.status === 'positive')).toHaveLength(4)
   })
 
   it('모든 외부 지표를 못 받으면 중립으로 fallback 한다', () => {
@@ -50,7 +51,7 @@ describe('buildMarketResponse', () => {
     })
 
     expect(response.macroState).toBe('risk_off')
-    expect(response.macroScore).toBe(-1)
+    expect(response.macroScore).toBe(-0.8)
     expect(response.overview.entry.label).toBe('신중한 관망')
     expect(response.overview.health.label).toBe('불안')
   })

--- a/src/lib/marketSignals.ts
+++ b/src/lib/marketSignals.ts
@@ -7,6 +7,9 @@ export interface FearGreedSnapshot {
 }
 
 export interface MarketIndicator {
+  detailSource: string
+  detailTitle: string
+  detailValue: string
   guide: string
   key: 'yieldCurve' | 'creditSpread' | 'm2' | 'fearGreed' | 'erp'
   label: string
@@ -46,6 +49,7 @@ export interface MarketInput {
 
 interface MarketSnapshotInput {
   equityRiskPremium: number | null
+  peRatio?: number | null
   fearGreed: FearGreedSnapshot | null
   fetchedAt?: string
   highYieldSpread: number | null
@@ -81,6 +85,7 @@ export async function fetchMarketSignals(): Promise<MarketResponse> {
 
   return buildMarketResponse({
     equityRiskPremium,
+    peRatio: await fetchPeRatio().catch(() => null),
     fearGreed,
     highYieldSpread: fredData.highYieldSpread,
     m2YearOverYear: fredData.m2YearOverYear,
@@ -95,11 +100,11 @@ export function buildMarketResponse(input: MarketSnapshotInput): MarketResponse 
     : null
 
   const indicators: MarketIndicator[] = [
-    buildYieldCurveIndicator(yieldCurveSpread),
+    buildYieldCurveIndicator(yieldCurveSpread, input.treasury10YearRate, input.treasury2YearRate),
     buildCreditSpreadIndicator(input.highYieldSpread),
     buildM2Indicator(input.m2YearOverYear),
     buildFearGreedIndicator(input.fearGreed),
-    buildEquityRiskPremiumIndicator(input.equityRiskPremium),
+    buildEquityRiskPremiumIndicator(input.equityRiskPremium, input.peRatio ?? null, input.treasury10YearRate),
   ]
 
   const scoredIndicators = indicators.filter(indicator => indicator.status !== 'unavailable')
@@ -206,6 +211,14 @@ async function fetchFredSeries(seriesId: string, apiKey: string, limit: number):
 async function fetchEquityRiskPremium(treasury10YearRate: number | null): Promise<number | null> {
   if (treasury10YearRate === null) return null
 
+  const peRatio = await fetchPeRatio()
+  if (peRatio === null || peRatio <= 0) return null
+
+  const earningsYield = 100 / peRatio
+  return roundToTwo(earningsYield - treasury10YearRate)
+}
+
+async function fetchPeRatio(): Promise<number | null> {
   const response = await fetch('https://www.multpl.com/s-p-500-pe-ratio', {
     headers: MARKET_HEADERS,
   })
@@ -215,10 +228,7 @@ async function fetchEquityRiskPremium(treasury10YearRate: number | null): Promis
   }
 
   const peRatio = extractSp500PeRatio(await response.text())
-  if (peRatio === null || peRatio <= 0) return null
-
-  const earningsYield = 100 / peRatio
-  return roundToTwo(earningsYield - treasury10YearRate)
+  return peRatio === null || peRatio <= 0 ? null : peRatio
 }
 
 function getLatestNumericValue(observations: FredObservation[]): number | null {
@@ -250,7 +260,11 @@ function computeM2YearOverYear(observations: FredObservation[]): number | null {
   return roundToTwo(((latest.value - oneYearAgo.value) / oneYearAgo.value) * 100)
 }
 
-function buildYieldCurveIndicator(spread: number | null): MarketIndicator {
+function buildYieldCurveIndicator(
+  spread: number | null,
+  treasury10YearRate: number | null,
+  treasury2YearRate: number | null,
+): MarketIndicator {
   if (spread === null) {
     return buildUnavailableIndicator(
       'yieldCurve',
@@ -265,7 +279,14 @@ function buildYieldCurveIndicator(spread: number | null): MarketIndicator {
       key: 'yieldCurve',
       label: '장단기 금리차',
       status: 'negative',
-      summary: '장단기 금리가 뒤집혀 있어 경기 둔화 경고가 커진 구간으로 읽혀요.',
+      summary: spread < -0.5
+        ? '단기 금리가 장기 금리보다 높아요. 과거에는 경기 둔화 전에 자주 나타났던 신호예요. 시장 전반의 리스크를 조금 더 신중하게 보는 게 좋아요.'
+        : '금리 구조가 일부 뒤집힌 상태예요. 경기 흐름에 대한 불확실성이 있는 구간이에요. 지금은 공격적인 투자보다는 안정적인 접근이 어울려요.',
+      ...buildDetailBox(
+        '장단기 금리차 (10Y−2Y)',
+        `출처: FRED | DGS10 ${formatPercent(treasury10YearRate)} − DGS2 ${formatPercent(treasury2YearRate)} = ${formatSignedNumber(spread)}%p`,
+        `실제 값: ${formatSignedNumber(spread)}%p`,
+      ),
       value: `${formatSignedNumber(spread)}%p`,
     }
   }
@@ -276,7 +297,14 @@ function buildYieldCurveIndicator(spread: number | null): MarketIndicator {
       key: 'yieldCurve',
       label: '장단기 금리차',
       status: 'positive',
-      summary: '장기금리가 단기금리보다 충분히 높아 경기 침체 경고는 약한 편이에요.',
+      summary: spread > 1.5
+        ? '금리 차이가 크게 벌어진 상태예요. 경기 기대가 반영된 흐름이에요. 다만 금리 부담도 함께 커질 수 있어 주의가 필요해요.'
+        : '장기 금리가 단기 금리보다 높아 정상적인 구조예요. 경기 흐름도 비교적 안정적인 편이에요. 시장 전반의 리스크는 크지 않은 상태로 볼 수 있어요.',
+      ...buildDetailBox(
+        '장단기 금리차 (10Y−2Y)',
+        `출처: FRED | DGS10 ${formatPercent(treasury10YearRate)} − DGS2 ${formatPercent(treasury2YearRate)} = ${formatSignedNumber(spread)}%p`,
+        `실제 값: ${formatSignedNumber(spread)}%p`,
+      ),
       value: `${formatSignedNumber(spread)}%p`,
     }
   }
@@ -286,7 +314,12 @@ function buildYieldCurveIndicator(spread: number | null): MarketIndicator {
     key: 'yieldCurve',
     label: '장단기 금리차',
     status: 'neutral',
-    summary: '금리차가 플러스이긴 하지만 크진 않아 경기를 더 지켜볼 구간이에요.',
+    summary: '장단기 금리 차이가 거의 없는 상태예요. 시장이 방향을 잡는 중일 수 있어요. 조금 더 지켜보면서 대응하는 게 좋아요.',
+    ...buildDetailBox(
+      '장단기 금리차 (10Y−2Y)',
+      `출처: FRED | DGS10 ${formatPercent(treasury10YearRate)} − DGS2 ${formatPercent(treasury2YearRate)} = ${formatSignedNumber(spread)}%p`,
+      `실제 값: ${formatSignedNumber(spread)}%p`,
+    ),
     value: `${formatSignedNumber(spread)}%p`,
   }
 }
@@ -306,7 +339,16 @@ function buildCreditSpreadIndicator(spread: number | null): MarketIndicator {
       key: 'creditSpread',
       label: '하이일드 스프레드',
       status: 'negative',
-      summary: '위험한 회사채 금리가 많이 벌어져 시장이 리스크를 크게 경계하는 모습이에요.',
+      summary: spread > 10
+        ? '기업 신용 위험이 크게 확대된 상태예요. 시장이 위기 상황을 반영하고 있어요. 지금은 기회보다 리스크 관리가 중요한 구간이에요.'
+        : spread >= 7
+          ? '기업 부도 위험이 높아지고 있는 상태예요. 시장 리스크를 우선적으로 관리하는 것이 중요해요.'
+          : '기업 신용에 대한 불안이 조금씩 반영되고 있어요. 시장 변동성이 커질 수 있는 구간이에요.',
+      ...buildDetailBox(
+        '하이일드 스프레드',
+        `출처: FRED | BAMLH0A0HYM2 ${formatNumber(spread)}%p`,
+        `실제 값: ${formatNumber(spread)}%p`,
+      ),
       value: `${formatNumber(spread)}%p`,
     }
   }
@@ -317,7 +359,12 @@ function buildCreditSpreadIndicator(spread: number | null): MarketIndicator {
       key: 'creditSpread',
       label: '하이일드 스프레드',
       status: 'positive',
-      summary: '스프레드가 낮아 위험자산을 받아들이는 심리가 비교적 편안한 편이에요.',
+      summary: '기업 신용 위험이 낮은 상태예요. 시장이 안정적으로 평가되고 있어요. 리스크 부담은 크지 않은 구간이에요.',
+      ...buildDetailBox(
+        '하이일드 스프레드',
+        `출처: FRED | BAMLH0A0HYM2 ${formatNumber(spread)}%p`,
+        `실제 값: ${formatNumber(spread)}%p`,
+      ),
       value: `${formatNumber(spread)}%p`,
     }
   }
@@ -327,7 +374,12 @@ function buildCreditSpreadIndicator(spread: number | null): MarketIndicator {
     key: 'creditSpread',
     label: '하이일드 스프레드',
     status: 'neutral',
-    summary: '스프레드가 살짝 올라와 있어 낙관과 경계가 섞인 구간으로 보여요.',
+    summary: '기업 부도 위험이 크게 높지 않은 상태예요. 시장 전반은 비교적 안정적인 흐름을 보이고 있어요.',
+    ...buildDetailBox(
+      '하이일드 스프레드',
+      `출처: FRED | BAMLH0A0HYM2 ${formatNumber(spread)}%p`,
+      `실제 값: ${formatNumber(spread)}%p`,
+    ),
     value: `${formatNumber(spread)}%p`,
   }
 }
@@ -347,7 +399,12 @@ function buildM2Indicator(yearOverYear: number | null): MarketIndicator {
       key: 'm2',
       label: 'M2 증가율',
       status: 'negative',
-      summary: '시중 유동성이 작년보다 줄어 위험자산에 우호적인 돈의 흐름은 약한 편이에요.',
+      summary: '시중에 도는 돈이 줄어들고 있어요. 시장 유동성이 위축된 상태예요. 위험자산에는 부담이 될 수 있어요.',
+      ...buildDetailBox(
+        'M2 증가율 (YoY)',
+        `출처: FRED | M2SL 전년동월 대비 ${formatSignedNumber(yearOverYear)}%`,
+        `실제 값: ${formatSignedNumber(yearOverYear)}%`,
+      ),
       value: `${formatSignedNumber(yearOverYear)}%`,
     }
   }
@@ -358,7 +415,16 @@ function buildM2Indicator(yearOverYear: number | null): MarketIndicator {
       key: 'm2',
       label: 'M2 증가율',
       status: 'positive',
-      summary: '시중 유동성이 다시 늘어나는 흐름이라 주식시장에 숨통이 트일 수 있어요.',
+      summary: yearOverYear >= 12
+        ? '유동성이 과도하게 증가한 상태예요. 시장에 자금이 많이 풀린 구간이에요. 장기적으로는 인플레이션 부담도 함께 고려해야 해요.'
+        : yearOverYear >= 7
+          ? '시장에 돈이 비교적 충분히 공급되고 있어요. 위험자산에 우호적인 환경이에요.'
+          : '시중 유동성이 안정적인 수준이에요. 시장에 특별한 부담이나 과열 신호는 없어요.',
+      ...buildDetailBox(
+        'M2 증가율 (YoY)',
+        `출처: FRED | M2SL 전년동월 대비 ${formatSignedNumber(yearOverYear)}%`,
+        `실제 값: ${formatSignedNumber(yearOverYear)}%`,
+      ),
       value: `${formatSignedNumber(yearOverYear)}%`,
     }
   }
@@ -368,7 +434,12 @@ function buildM2Indicator(yearOverYear: number | null): MarketIndicator {
     key: 'm2',
     label: 'M2 증가율',
     status: 'neutral',
-    summary: '유동성이 줄진 않지만 강하게 늘지도 않아 중립적인 자금 환경으로 보여요.',
+    summary: '유동성 증가가 둔화된 상태예요. 시장에 자금 유입이 제한적이에요. 상승 동력이 약해질 수 있어요.',
+    ...buildDetailBox(
+      'M2 증가율 (YoY)',
+      `출처: FRED | M2SL 전년동월 대비 ${formatSignedNumber(yearOverYear)}%`,
+      `실제 값: ${formatSignedNumber(yearOverYear)}%`,
+    ),
     value: `${formatSignedNumber(yearOverYear)}%`,
   }
 }
@@ -388,7 +459,14 @@ function buildFearGreedIndicator(snapshot: FearGreedSnapshot | null): MarketIndi
       key: 'fearGreed',
       label: 'Fear&Greed',
       status: 'negative',
-      summary: `심리가 ${snapshot.label} 쪽이라 투자자들이 방어적으로 움직이는 분위기예요.`,
+      summary: snapshot.score <= 20
+        ? '투자자들이 많이 위축된 상태예요. 시장에 대한 불안이 큰 구간이에요. 이런 시기에는 단기 변동성이 크지만, 장기적으로는 기회가 생기기도 해요.'
+        : '투자자들이 조심스럽게 움직이고 있어요. 시장에 대한 불안이 남아 있는 상태예요. 지금은 서두르기보다 천천히 접근하는 전략이 어울려요.',
+      ...buildDetailBox(
+        'Fear & Greed Index',
+        `출처: onoff.markets | ${snapshot.label} ${formatNumber(snapshot.score)}`,
+        `실제 값: ${snapshot.label} ${formatNumber(snapshot.score)}`,
+      ),
       value: `${snapshot.label} ${formatNumber(snapshot.score)}`,
     }
   }
@@ -399,7 +477,14 @@ function buildFearGreedIndicator(snapshot: FearGreedSnapshot | null): MarketIndi
       key: 'fearGreed',
       label: 'Fear&Greed',
       status: 'positive',
-      summary: `심리가 ${snapshot.label} 쪽이라 위험자산을 받아들이는 흐름이 살아 있어요.`,
+      summary: snapshot.score >= 80
+        ? '투자자들이 과하게 낙관적인 상태예요. 시장이 많이 달아오른 구간이에요. 이런 시기에는 추격 매수보다 과열 여부를 꼭 점검해야 해요.'
+        : '투자자들이 점점 낙관적으로 바뀌고 있어요. 시장에 기대감이 커지고 있어요. 너무 빠르게 오른 종목은 단기 부담을 함께 확인하는 게 좋아요.',
+      ...buildDetailBox(
+        'Fear & Greed Index',
+        `출처: onoff.markets | ${snapshot.label} ${formatNumber(snapshot.score)}`,
+        `실제 값: ${snapshot.label} ${formatNumber(snapshot.score)}`,
+      ),
       value: `${snapshot.label} ${formatNumber(snapshot.score)}`,
     }
   }
@@ -409,12 +494,21 @@ function buildFearGreedIndicator(snapshot: FearGreedSnapshot | null): MarketIndi
     key: 'fearGreed',
     label: 'Fear&Greed',
     status: 'neutral',
-    summary: '심리가 한쪽으로 크게 치우치지 않아 시장 참여자들이 서로 눈치를 보는 구간이에요.',
+    summary: '투자 심리가 크게 치우치지 않은 상태예요. 낙관도 비관도 강하지 않아요. 이런 구간에서는 종목별 흐름이 더 중요해요.',
+    ...buildDetailBox(
+      'Fear & Greed Index',
+      `출처: onoff.markets | ${snapshot.label} ${formatNumber(snapshot.score)}`,
+      `실제 값: ${snapshot.label} ${formatNumber(snapshot.score)}`,
+    ),
     value: `${snapshot.label} ${formatNumber(snapshot.score)}`,
   }
 }
 
-function buildEquityRiskPremiumIndicator(equityRiskPremium: number | null): MarketIndicator {
+function buildEquityRiskPremiumIndicator(
+  equityRiskPremium: number | null,
+  peRatio: number | null,
+  treasury10YearRate: number | null,
+): MarketIndicator {
   if (equityRiskPremium === null) {
     return buildUnavailableIndicator(
       'erp',
@@ -429,7 +523,12 @@ function buildEquityRiskPremiumIndicator(equityRiskPremium: number | null): Mark
       key: 'erp',
       label: 'ERP',
       status: 'negative',
-      summary: '채권 금리 매력이 더 커 보여 주식에 높은 점수를 주기 어려운 구간이에요.',
+      summary: '주식이 채권이나 예금 대비 충분히 매력적이지 않은 구간이에요. 지금은 무리하게 주식 비중을 늘리기보다 신중한 접근이 좋아요.',
+      ...buildDetailBox(
+        'ERP (주식−채권 상대매력)',
+        buildErpSourceLine(peRatio, treasury10YearRate, equityRiskPremium),
+        `실제 값: ${formatSignedNumber(equityRiskPremium)}%p`,
+      ),
       value: `${formatSignedNumber(equityRiskPremium)}%p`,
     }
   }
@@ -440,7 +539,16 @@ function buildEquityRiskPremiumIndicator(equityRiskPremium: number | null): Mark
       key: 'erp',
       label: 'ERP',
       status: 'positive',
-      summary: '주식 기대수익이 채권보다 충분히 높아 상대가치 측면에선 주식이 괜찮아 보여요.',
+      summary: equityRiskPremium >= 6
+        ? '주식의 기대 수익이 크게 높은 구간이에요. 시장이 리스크를 반영하고 있을 수 있어요. 기회가 있을 수 있지만, 리스크도 함께 확인하는 게 중요해요.'
+        : equityRiskPremium >= 4
+          ? '주식이 채권보다 더 높은 보상을 기대할 수 있는 구간이에요. 분할로 접근해볼 수 있는 환경이에요.'
+          : '주식과 채권의 매력도가 크게 차이나지 않는 구간이에요. 종목 선택이 중요한 시기예요.',
+      ...buildDetailBox(
+        'ERP (주식−채권 상대매력)',
+        buildErpSourceLine(peRatio, treasury10YearRate, equityRiskPremium),
+        `실제 값: ${formatSignedNumber(equityRiskPremium)}%p`,
+      ),
       value: `${formatSignedNumber(equityRiskPremium)}%p`,
     }
   }
@@ -450,7 +558,14 @@ function buildEquityRiskPremiumIndicator(equityRiskPremium: number | null): Mark
     key: 'erp',
     label: 'ERP',
     status: 'neutral',
-    summary: '주식과 채권 매력 차이가 크지 않아 밸류에이션만으로 방향을 정하긴 어려워요.',
+    summary: equityRiskPremium < 1
+      ? '주식이 채권이나 예금 대비 충분히 매력적이지 않은 구간이에요. 지금은 무리하게 주식 비중을 늘리기보다 신중한 접근이 좋아요.'
+      : '주식의 상대 매력도가 다소 낮은 상태예요. 가격 부담을 함께 고려하면서 투자하는 게 좋아요.',
+    ...buildDetailBox(
+      'ERP (주식−채권 상대매력)',
+      buildErpSourceLine(peRatio, treasury10YearRate, equityRiskPremium),
+      `실제 값: ${formatSignedNumber(equityRiskPremium)}%p`,
+    ),
     value: `${formatSignedNumber(equityRiskPremium)}%p`,
   }
 }
@@ -461,6 +576,9 @@ function buildUnavailableIndicator(
   guide: string,
 ): MarketIndicator {
   return {
+    detailSource: '출처: 외부 데이터 연결 실패',
+    detailTitle: label,
+    detailValue: '실제 값: 데이터 없음',
     guide,
     key,
     label,
@@ -502,6 +620,10 @@ function formatNumber(value: number): string {
 
 function formatSignedNumber(value: number): string {
   return `${value >= 0 ? '+' : ''}${formatNumber(value)}`
+}
+
+function formatPercent(value: number | null): string {
+  return value === null ? '-' : `${formatNumber(value)}%`
 }
 
 function buildEntryKPI(score: number): MarketEntryKPI {
@@ -689,4 +811,18 @@ function weightedAverage(entries: Array<[number, number]>): number {
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max)
+}
+
+function buildErpSourceLine(peRatio: number | null, treasury10YearRate: number | null, erp: number): string {
+  const earningsYield = peRatio && peRatio > 0 ? roundToTwo(100 / peRatio) : null
+
+  return `출처: multpl.com + FRED | Earnings Yield ${formatPercent(earningsYield)} − DGS10 ${formatPercent(treasury10YearRate)} = ${formatSignedNumber(erp)}%p`
+}
+
+function buildDetailBox(detailTitle: string, detailSource: string, detailValue: string) {
+  return {
+    detailSource,
+    detailTitle,
+    detailValue,
+  }
 }

--- a/src/lib/marketSignals.ts
+++ b/src/lib/marketSignals.ts
@@ -808,6 +808,78 @@ function buildHealthKPI(score: number): MarketEntryKPI {
   }
 }
 
+type KPIBand = 'high' | 'midHigh' | 'mid' | 'midLow' | 'low'
+
+function buildEntryKPIContent(band: KPIBand): Pick<MarketEntryKPI, 'guide' | 'summary'> {
+  if (band === 'high') {
+    return {
+      guide: '천천히 분할로 접근해도 좋아요.',
+      summary: '시장 리스크가 크지 않고 주식의 상대 매력도도 괜찮은 편이에요. 종목별로 분할 접근을 검토하기 좋은 구간이에요.',
+    }
+  }
+
+  if (band === 'midHigh') {
+    return {
+      guide: '분할 진입을 전제로만 살펴보세요.',
+      summary: '시장 불안 요소가 일부 있지만, 분할로 접근하면 기회를 노려볼 수 있는 구간이에요.',
+    }
+  }
+
+  if (band === 'mid') {
+    return {
+      guide: '한 템포 지켜보는 편이 좋아요.',
+      summary: '시장 방향이 뚜렷하지 않아 조금 더 지켜보는 전략이 좋아요.',
+    }
+  }
+
+  if (band === 'midLow') {
+    return {
+      guide: '신규 진입은 속도를 늦추세요.',
+      summary: '변동성이 커질 수 있는 구간이라 신규 진입은 신중하게 접근하는 게 좋아요.',
+    }
+  }
+
+  return {
+    guide: '지금은 리스크 관리가 먼저예요.',
+    summary: '시장 리스크가 높은 구간이에요. 지금은 기회보다 리스크 관리가 더 중요한 시점이에요.',
+  }
+}
+
+function buildHealthKPIContent(band: KPIBand): Pick<MarketEntryKPI, 'guide' | 'summary'> {
+  if (band === 'high') {
+    return {
+      guide: '시장 환경을 안정적으로 볼 수 있어요.',
+      summary: '시장 환경이 전반적으로 안정적인 상태예요.',
+    }
+  }
+
+  if (band === 'midHigh') {
+    return {
+      guide: '일부 변수는 계속 확인하세요.',
+      summary: '시장 리스크는 크지 않지만 일부 변수는 확인이 필요해요.',
+    }
+  }
+
+  if (band === 'mid') {
+    return {
+      guide: '방향이 잡힐 때까지 기다려도 돼요.',
+      summary: '시장 방향성이 뚜렷하지 않은 구간이에요.',
+    }
+  }
+
+  if (band === 'midLow') {
+    return {
+      guide: '변동성 확대를 먼저 의식하세요.',
+      summary: '시장 변동성이 커지고 있는 구간이에요.',
+    }
+  }
+
+  return {
+    guide: '방어적으로 보는 편이 맞아요.',
+    summary: '시장 불안이 큰 상태로 리스크 관리가 중요한 구간이에요.',
+  }
+}
+
 function buildOverview(input: MarketInput): MarketOverview {
   const entryScore = calculateEntryAttractiveness(input)
   const healthScore = calculateMarketHealth(input)

--- a/src/lib/marketSignals.ts
+++ b/src/lib/marketSignals.ts
@@ -275,15 +275,13 @@ function buildYieldCurveIndicator(
     )
   }
 
-  if (spread < 0) {
+  if (spread < -0.5) {
     return {
       guide: '장기금리가 단기금리보다 높으면 보통 경기 기대가 더 건강하다고 봐요.',
       key: 'yieldCurve',
       label: '장단기 금리차',
       status: 'negative',
-      summary: spread < -0.5
-        ? '단기 금리가 장기 금리보다 높아요. 과거에는 경기 둔화 전에 자주 나타났던 신호예요. 시장 전반의 리스크를 조금 더 신중하게 보는 게 좋아요.'
-        : '금리 구조가 일부 뒤집힌 상태예요. 경기 흐름에 대한 불확실성이 있는 구간이에요. 지금은 공격적인 투자보다는 안정적인 접근이 어울려요.',
+      summary: '단기 금리가 장기 금리보다 높아요. 과거에는 경기 둔화 전에 자주 나타났던 신호예요. 시장 전반의 리스크를 조금 더 신중하게 보는 게 좋아요.',
       ...buildDetailBox(
         '장단기 금리차 (10Y−2Y)',
         `출처: FRED | DGS10 ${formatPercent(treasury10YearRate)} − DGS2 ${formatPercent(treasury2YearRate)} = ${formatSignedNumber(spread)}%p`,
@@ -293,15 +291,45 @@ function buildYieldCurveIndicator(
     }
   }
 
-  if (spread >= 0.5) {
+  if (spread < 0) {
+    return {
+      guide: '장기금리가 단기금리보다 높으면 보통 경기 기대가 더 건강하다고 봐요.',
+      key: 'yieldCurve',
+      label: '장단기 금리차',
+      status: 'negative',
+      summary: '금리 구조가 일부 뒤집힌 상태예요. 경기 흐름에 대한 불확실성이 있는 구간이에요. 지금은 공격적인 투자보다는 안정적인 접근이 어울려요.',
+      ...buildDetailBox(
+        '장단기 금리차 (10Y−2Y)',
+        `출처: FRED | DGS10 ${formatPercent(treasury10YearRate)} − DGS2 ${formatPercent(treasury2YearRate)} = ${formatSignedNumber(spread)}%p`,
+        `실제 값: ${formatSignedNumber(spread)}%p`,
+      ),
+      value: `${formatSignedNumber(spread)}%p`,
+    }
+  }
+
+  if (spread < 0.5) {
+    return {
+      guide: '장기금리가 단기금리보다 높으면 보통 경기 기대가 더 건강하다고 봐요.',
+      key: 'yieldCurve',
+      label: '장단기 금리차',
+      status: 'neutral',
+      summary: '장단기 금리 차이가 거의 없는 상태예요. 시장이 방향을 잡는 중일 수 있어요. 조금 더 지켜보면서 대응하는 게 좋아요.',
+      ...buildDetailBox(
+        '장단기 금리차 (10Y−2Y)',
+        `출처: FRED | DGS10 ${formatPercent(treasury10YearRate)} − DGS2 ${formatPercent(treasury2YearRate)} = ${formatSignedNumber(spread)}%p`,
+        `실제 값: ${formatSignedNumber(spread)}%p`,
+      ),
+      value: `${formatSignedNumber(spread)}%p`,
+    }
+  }
+
+  if (spread < 1.5) {
     return {
       guide: '장기금리가 단기금리보다 높으면 보통 경기 기대가 더 건강하다고 봐요.',
       key: 'yieldCurve',
       label: '장단기 금리차',
       status: 'positive',
-      summary: spread > 1.5
-        ? '금리 차이가 크게 벌어진 상태예요. 경기 기대가 반영된 흐름이에요. 다만 금리 부담도 함께 커질 수 있어 주의가 필요해요.'
-        : '장기 금리가 단기 금리보다 높아 정상적인 구조예요. 경기 흐름도 비교적 안정적인 편이에요. 시장 전반의 리스크는 크지 않은 상태로 볼 수 있어요.',
+      summary: '장기 금리가 단기 금리보다 높아 정상적인 구조예요. 경기 흐름도 비교적 안정적인 편이에요. 시장 전반의 리스크는 크지 않은 상태로 볼 수 있어요.',
       ...buildDetailBox(
         '장단기 금리차 (10Y−2Y)',
         `출처: FRED | DGS10 ${formatPercent(treasury10YearRate)} − DGS2 ${formatPercent(treasury2YearRate)} = ${formatSignedNumber(spread)}%p`,
@@ -315,8 +343,8 @@ function buildYieldCurveIndicator(
     guide: '장기금리가 단기금리보다 높으면 보통 경기 기대가 더 건강하다고 봐요.',
     key: 'yieldCurve',
     label: '장단기 금리차',
-    status: 'neutral',
-    summary: '장단기 금리 차이가 거의 없는 상태예요. 시장이 방향을 잡는 중일 수 있어요. 조금 더 지켜보면서 대응하는 게 좋아요.',
+    status: 'positive',
+    summary: '금리 차이가 크게 벌어진 상태예요. 경기 기대가 반영된 흐름이에요. 다만 금리 부담도 함께 커질 수 있어 주의가 필요해요.',
     ...buildDetailBox(
       '장단기 금리차 (10Y−2Y)',
       `출처: FRED | DGS10 ${formatPercent(treasury10YearRate)} − DGS2 ${formatPercent(treasury2YearRate)} = ${formatSignedNumber(spread)}%p`,
@@ -335,27 +363,7 @@ function buildCreditSpreadIndicator(spread: number | null): MarketIndicator {
     )
   }
 
-  if (spread > 5.5) {
-    return {
-      guide: '위험한 회사채 금리가 국채보다 얼마나 더 비싼지 보면 시장 긴장을 알 수 있어요.',
-      key: 'creditSpread',
-      label: '하이일드 스프레드',
-      status: 'negative',
-      summary: spread > 10
-        ? '기업 신용 위험이 크게 확대된 상태예요. 시장이 위기 상황을 반영하고 있어요. 지금은 기회보다 리스크 관리가 중요한 구간이에요.'
-        : spread >= 7
-          ? '기업 부도 위험이 높아지고 있는 상태예요. 시장 리스크를 우선적으로 관리하는 것이 중요해요.'
-          : '기업 신용에 대한 불안이 조금씩 반영되고 있어요. 시장 변동성이 커질 수 있는 구간이에요.',
-      ...buildDetailBox(
-        '하이일드 스프레드',
-        `출처: FRED | BAMLH0A0HYM2 ${formatNumber(spread)}%p`,
-        `실제 값: ${formatNumber(spread)}%p`,
-      ),
-      value: `${formatNumber(spread)}%p`,
-    }
-  }
-
-  if (spread <= 3.5) {
+  if (spread < 3.5) {
     return {
       guide: '위험한 회사채 금리가 국채보다 얼마나 더 비싼지 보면 시장 긴장을 알 수 있어요.',
       key: 'creditSpread',
@@ -371,12 +379,60 @@ function buildCreditSpreadIndicator(spread: number | null): MarketIndicator {
     }
   }
 
+  if (spread < 5) {
+    return {
+      guide: '위험한 회사채 금리가 국채보다 얼마나 더 비싼지 보면 시장 긴장을 알 수 있어요.',
+      key: 'creditSpread',
+      label: '하이일드 스프레드',
+      status: 'positive',
+      summary: '기업 부도 위험이 크게 높지 않은 상태예요. 시장 전반은 비교적 안정적인 흐름을 보이고 있어요.',
+      ...buildDetailBox(
+        '하이일드 스프레드',
+        `출처: FRED | BAMLH0A0HYM2 ${formatNumber(spread)}%p`,
+        `실제 값: ${formatNumber(spread)}%p`,
+      ),
+      value: `${formatNumber(spread)}%p`,
+    }
+  }
+
+  if (spread < 7) {
+    return {
+      guide: '위험한 회사채 금리가 국채보다 얼마나 더 비싼지 보면 시장 긴장을 알 수 있어요.',
+      key: 'creditSpread',
+      label: '하이일드 스프레드',
+      status: 'neutral',
+      summary: '기업 신용에 대한 불안이 조금씩 반영되고 있어요. 시장 변동성이 커질 수 있는 구간이에요.',
+      ...buildDetailBox(
+        '하이일드 스프레드',
+        `출처: FRED | BAMLH0A0HYM2 ${formatNumber(spread)}%p`,
+        `실제 값: ${formatNumber(spread)}%p`,
+      ),
+      value: `${formatNumber(spread)}%p`,
+    }
+  }
+
+  if (spread < 10) {
+    return {
+      guide: '위험한 회사채 금리가 국채보다 얼마나 더 비싼지 보면 시장 긴장을 알 수 있어요.',
+      key: 'creditSpread',
+      label: '하이일드 스프레드',
+      status: 'negative',
+      summary: '기업 부도 위험이 높아지고 있는 상태예요. 시장 리스크를 우선적으로 관리하는 것이 중요해요.',
+      ...buildDetailBox(
+        '하이일드 스프레드',
+        `출처: FRED | BAMLH0A0HYM2 ${formatNumber(spread)}%p`,
+        `실제 값: ${formatNumber(spread)}%p`,
+      ),
+      value: `${formatNumber(spread)}%p`,
+    }
+  }
+
   return {
     guide: '위험한 회사채 금리가 국채보다 얼마나 더 비싼지 보면 시장 긴장을 알 수 있어요.',
     key: 'creditSpread',
     label: '하이일드 스프레드',
-    status: 'neutral',
-    summary: '기업 부도 위험이 크게 높지 않은 상태예요. 시장 전반은 비교적 안정적인 흐름을 보이고 있어요.',
+    status: 'negative',
+    summary: '기업 신용 위험이 크게 확대된 상태예요. 시장이 위기 상황을 반영하고 있어요. 지금은 기회보다 리스크 관리가 중요한 구간이에요.',
     ...buildDetailBox(
       '하이일드 스프레드',
       `출처: FRED | BAMLH0A0HYM2 ${formatNumber(spread)}%p`,
@@ -411,17 +467,29 @@ function buildM2Indicator(yearOverYear: number | null): MarketIndicator {
     }
   }
 
-  if (yearOverYear >= 2) {
+  if (yearOverYear < 3) {
+    return {
+      guide: '시중 돈이 늘면 주식시장에 들어올 유동성도 늘 수 있어요.',
+      key: 'm2',
+      label: 'M2 증가율',
+      status: 'neutral',
+      summary: '유동성 증가가 둔화된 상태예요. 시장에 자금 유입이 제한적이에요. 상승 동력이 약해질 수 있어요.',
+      ...buildDetailBox(
+        'M2 증가율 (YoY)',
+        `출처: FRED | M2SL 전년동월 대비 ${formatSignedNumber(yearOverYear)}%`,
+        `실제 값: ${formatSignedNumber(yearOverYear)}%`,
+      ),
+      value: `${formatSignedNumber(yearOverYear)}%`,
+    }
+  }
+
+  if (yearOverYear < 7) {
     return {
       guide: '시중 돈이 늘면 주식시장에 들어올 유동성도 늘 수 있어요.',
       key: 'm2',
       label: 'M2 증가율',
       status: 'positive',
-      summary: yearOverYear >= 12
-        ? '유동성이 과도하게 증가한 상태예요. 시장에 자금이 많이 풀린 구간이에요. 장기적으로는 인플레이션 부담도 함께 고려해야 해요.'
-        : yearOverYear >= 7
-          ? '시장에 돈이 비교적 충분히 공급되고 있어요. 위험자산에 우호적인 환경이에요.'
-          : '시중 유동성이 안정적인 수준이에요. 시장에 특별한 부담이나 과열 신호는 없어요.',
+      summary: '시중 유동성이 안정적인 수준이에요. 시장에 특별한 부담이나 과열 신호는 없어요.',
       ...buildDetailBox(
         'M2 증가율 (YoY)',
         `출처: FRED | M2SL 전년동월 대비 ${formatSignedNumber(yearOverYear)}%`,
@@ -435,8 +503,10 @@ function buildM2Indicator(yearOverYear: number | null): MarketIndicator {
     guide: '시중 돈이 늘면 주식시장에 들어올 유동성도 늘 수 있어요.',
     key: 'm2',
     label: 'M2 증가율',
-    status: 'neutral',
-    summary: '유동성 증가가 둔화된 상태예요. 시장에 자금 유입이 제한적이에요. 상승 동력이 약해질 수 있어요.',
+    status: 'positive',
+    summary: yearOverYear < 12
+      ? '시장에 돈이 비교적 충분히 공급되고 있어요. 위험자산에 우호적인 환경이에요.'
+      : '유동성이 과도하게 증가한 상태예요. 시장에 자금이 많이 풀린 구간이에요. 장기적으로는 인플레이션 부담도 함께 고려해야 해요.',
     ...buildDetailBox(
       'M2 증가율 (YoY)',
       `출처: FRED | M2SL 전년동월 대비 ${formatSignedNumber(yearOverYear)}%`,
@@ -455,15 +525,13 @@ function buildFearGreedIndicator(snapshot: FearGreedSnapshot | null): MarketIndi
     )
   }
 
-  if (snapshot.score <= 40) {
+  if (snapshot.score < 20) {
     return {
       guide: '시장 참여자들이 공격적인지 방어적인지 보여주는 심리 지표예요.',
       key: 'fearGreed',
       label: 'Fear&Greed',
       status: 'negative',
-      summary: snapshot.score <= 20
-        ? '투자자들이 많이 위축된 상태예요. 시장에 대한 불안이 큰 구간이에요. 이런 시기에는 단기 변동성이 크지만, 장기적으로는 기회가 생기기도 해요.'
-        : '투자자들이 조심스럽게 움직이고 있어요. 시장에 대한 불안이 남아 있는 상태예요. 지금은 서두르기보다 천천히 접근하는 전략이 어울려요.',
+      summary: '투자자들이 많이 위축된 상태예요. 시장에 대한 불안이 큰 구간이에요. 이런 시기에는 단기 변동성이 크지만, 장기적으로는 기회가 생기기도 해요.',
       ...buildDetailBox(
         'Fear & Greed Index',
         `출처: onoff.markets | ${snapshot.label} ${formatNumber(snapshot.score)}`,
@@ -473,15 +541,45 @@ function buildFearGreedIndicator(snapshot: FearGreedSnapshot | null): MarketIndi
     }
   }
 
-  if (snapshot.score >= 60) {
+  if (snapshot.score < 40) {
+    return {
+      guide: '시장 참여자들이 공격적인지 방어적인지 보여주는 심리 지표예요.',
+      key: 'fearGreed',
+      label: 'Fear&Greed',
+      status: 'negative',
+      summary: '투자자들이 조심스럽게 움직이고 있어요. 시장에 대한 불안이 남아 있는 상태예요. 지금은 서두르기보다 천천히 접근하는 전략이 어울려요.',
+      ...buildDetailBox(
+        'Fear & Greed Index',
+        `출처: onoff.markets | ${snapshot.label} ${formatNumber(snapshot.score)}`,
+        `실제 값: ${snapshot.label} ${formatNumber(snapshot.score)}`,
+      ),
+      value: `${snapshot.label} ${formatNumber(snapshot.score)}`,
+    }
+  }
+
+  if (snapshot.score < 60) {
+    return {
+      guide: '시장 참여자들이 공격적인지 방어적인지 보여주는 심리 지표예요.',
+      key: 'fearGreed',
+      label: 'Fear&Greed',
+      status: 'neutral',
+      summary: '투자 심리가 크게 치우치지 않은 상태예요. 낙관도 비관도 강하지 않아요. 이런 구간에서는 종목별 흐름이 더 중요해요.',
+      ...buildDetailBox(
+        'Fear & Greed Index',
+        `출처: onoff.markets | ${snapshot.label} ${formatNumber(snapshot.score)}`,
+        `실제 값: ${snapshot.label} ${formatNumber(snapshot.score)}`,
+      ),
+      value: `${snapshot.label} ${formatNumber(snapshot.score)}`,
+    }
+  }
+
+  if (snapshot.score < 80) {
     return {
       guide: '시장 참여자들이 공격적인지 방어적인지 보여주는 심리 지표예요.',
       key: 'fearGreed',
       label: 'Fear&Greed',
       status: 'positive',
-      summary: snapshot.score >= 80
-        ? '투자자들이 과하게 낙관적인 상태예요. 시장이 많이 달아오른 구간이에요. 이런 시기에는 추격 매수보다 과열 여부를 꼭 점검해야 해요.'
-        : '투자자들이 점점 낙관적으로 바뀌고 있어요. 시장에 기대감이 커지고 있어요. 너무 빠르게 오른 종목은 단기 부담을 함께 확인하는 게 좋아요.',
+      summary: '투자자들이 점점 낙관적으로 바뀌고 있어요. 시장에 기대감이 커지고 있어요. 너무 빠르게 오른 종목은 단기 부담을 함께 확인하는 게 좋아요.',
       ...buildDetailBox(
         'Fear & Greed Index',
         `출처: onoff.markets | ${snapshot.label} ${formatNumber(snapshot.score)}`,
@@ -495,8 +593,8 @@ function buildFearGreedIndicator(snapshot: FearGreedSnapshot | null): MarketIndi
     guide: '시장 참여자들이 공격적인지 방어적인지 보여주는 심리 지표예요.',
     key: 'fearGreed',
     label: 'Fear&Greed',
-    status: 'neutral',
-    summary: '투자 심리가 크게 치우치지 않은 상태예요. 낙관도 비관도 강하지 않아요. 이런 구간에서는 종목별 흐름이 더 중요해요.',
+    status: 'positive',
+    summary: '투자자들이 과하게 낙관적인 상태예요. 시장이 많이 달아오른 구간이에요. 이런 시기에는 추격 매수보다 과열 여부를 꼭 점검해야 해요.',
     ...buildDetailBox(
       'Fear & Greed Index',
       `출처: onoff.markets | ${snapshot.label} ${formatNumber(snapshot.score)}`,
@@ -519,7 +617,7 @@ function buildEquityRiskPremiumIndicator(
     )
   }
 
-  if (equityRiskPremium < 0) {
+  if (equityRiskPremium < 1) {
     return {
       guide: '주식 기대수익이 채권보다 얼마나 더 매력적인지 보는 값이에요.',
       key: 'erp',
@@ -535,17 +633,45 @@ function buildEquityRiskPremiumIndicator(
     }
   }
 
-  if (equityRiskPremium >= 2.5) {
+  if (equityRiskPremium < 2.5) {
+    return {
+      guide: '주식 기대수익이 채권보다 얼마나 더 매력적인지 보는 값이에요.',
+      key: 'erp',
+      label: 'ERP',
+      status: 'neutral',
+      summary: '주식의 상대 매력도가 다소 낮은 상태예요. 가격 부담을 함께 고려하면서 투자하는 게 좋아요.',
+      ...buildDetailBox(
+        'ERP (주식−채권 상대매력)',
+        buildErpSourceLine(peRatio, treasury10YearRate, equityRiskPremium),
+        `실제 값: ${formatSignedNumber(equityRiskPremium)}%p`,
+      ),
+      value: `${formatSignedNumber(equityRiskPremium)}%p`,
+    }
+  }
+
+  if (equityRiskPremium < 4) {
+    return {
+      guide: '주식 기대수익이 채권보다 얼마나 더 매력적인지 보는 값이에요.',
+      key: 'erp',
+      label: 'ERP',
+      status: 'neutral',
+      summary: '주식과 채권의 매력도가 크게 차이나지 않는 구간이에요. 종목 선택이 중요한 시기예요.',
+      ...buildDetailBox(
+        'ERP (주식−채권 상대매력)',
+        buildErpSourceLine(peRatio, treasury10YearRate, equityRiskPremium),
+        `실제 값: ${formatSignedNumber(equityRiskPremium)}%p`,
+      ),
+      value: `${formatSignedNumber(equityRiskPremium)}%p`,
+    }
+  }
+
+  if (equityRiskPremium < 6) {
     return {
       guide: '주식 기대수익이 채권보다 얼마나 더 매력적인지 보는 값이에요.',
       key: 'erp',
       label: 'ERP',
       status: 'positive',
-      summary: equityRiskPremium >= 6
-        ? '주식의 기대 수익이 크게 높은 구간이에요. 시장이 리스크를 반영하고 있을 수 있어요. 기회가 있을 수 있지만, 리스크도 함께 확인하는 게 중요해요.'
-        : equityRiskPremium >= 4
-          ? '주식이 채권보다 더 높은 보상을 기대할 수 있는 구간이에요. 분할로 접근해볼 수 있는 환경이에요.'
-          : '주식과 채권의 매력도가 크게 차이나지 않는 구간이에요. 종목 선택이 중요한 시기예요.',
+      summary: '주식이 채권보다 더 높은 보상을 기대할 수 있는 구간이에요. 분할로 접근해볼 수 있는 환경이에요.',
       ...buildDetailBox(
         'ERP (주식−채권 상대매력)',
         buildErpSourceLine(peRatio, treasury10YearRate, equityRiskPremium),
@@ -559,10 +685,8 @@ function buildEquityRiskPremiumIndicator(
     guide: '주식 기대수익이 채권보다 얼마나 더 매력적인지 보는 값이에요.',
     key: 'erp',
     label: 'ERP',
-    status: 'neutral',
-    summary: equityRiskPremium < 1
-      ? '주식이 채권이나 예금 대비 충분히 매력적이지 않은 구간이에요. 지금은 무리하게 주식 비중을 늘리기보다 신중한 접근이 좋아요.'
-      : '주식의 상대 매력도가 다소 낮은 상태예요. 가격 부담을 함께 고려하면서 투자하는 게 좋아요.',
+    status: 'positive',
+    summary: '주식의 기대 수익이 크게 높은 구간이에요. 시장이 리스크를 반영하고 있을 수 있어요. 기회가 있을 수 있지만, 리스크도 함께 확인하는 게 중요해요.',
     ...buildDetailBox(
       'ERP (주식−채권 상대매력)',
       buildErpSourceLine(peRatio, treasury10YearRate, equityRiskPremium),

--- a/src/lib/marketSignalsClient.ts
+++ b/src/lib/marketSignalsClient.ts
@@ -4,6 +4,7 @@ import { SESSION_KEYS } from './types'
 import { type MarketResponse } from './marketSignals'
 
 const MARKET_CACHE_SECONDS = 86_400
+const EXPECTED_MARKET_KEYS = ['fearGreed', 'yieldCurve', 'erp', 'creditSpread', 'm2'] as const
 
 interface CachedMarketResponse {
   data: MarketResponse
@@ -27,8 +28,12 @@ export async function loadMarketSignals(forceRefresh = false): Promise<MarketRes
   const cached = readMarketCache()
   const now = Date.now()
 
-  if (!forceRefresh && cached && (now - cached.savedAt) < MARKET_CACHE_SECONDS * 1000) {
+  if (!forceRefresh && cached && isFreshMarketCache(cached, now)) {
     return cached.data
+  }
+
+  if (!forceRefresh && cached && typeof window !== 'undefined') {
+    sessionStorage.removeItem(SESSION_KEYS.MARKET)
   }
 
   const response = await fetch('/api/market')
@@ -37,6 +42,10 @@ export async function loadMarketSignals(forceRefresh = false): Promise<MarketRes
   }
 
   const data = await response.json() as MarketResponse
+  if (!isMarketResponseShape(data)) {
+    throw new Error('market response shape invalid')
+  }
+
   writeMarketCache({
     data,
     savedAt: now,
@@ -52,4 +61,30 @@ export async function prefetchMarketSignals(): Promise<void> {
 function writeMarketCache(cache: CachedMarketResponse) {
   if (typeof window === 'undefined') return
   sessionStorage.setItem(SESSION_KEYS.MARKET, JSON.stringify(cache))
+}
+
+function isFreshMarketCache(cache: CachedMarketResponse, now: number): boolean {
+  return (now - cache.savedAt) < MARKET_CACHE_SECONDS * 1000 && isMarketResponseShape(cache.data)
+}
+
+function isMarketResponseShape(value: MarketResponse): boolean {
+  if (!value || !Array.isArray(value.indicators) || value.indicators.length !== EXPECTED_MARKET_KEYS.length) {
+    return false
+  }
+
+  const keys = value.indicators.map(indicator => indicator.key).sort()
+  const expectedKeys = [...EXPECTED_MARKET_KEYS].sort()
+  if (keys.length !== expectedKeys.length || keys.some((key, index) => key !== expectedKeys[index])) {
+    return false
+  }
+
+  return value.indicators.every(indicator => (
+    typeof indicator.detailSource === 'string'
+    && typeof indicator.detailTitle === 'string'
+    && typeof indicator.detailValue === 'string'
+    && typeof indicator.guide === 'string'
+    && typeof indicator.summary === 'string'
+    && typeof indicator.label === 'string'
+    && typeof indicator.value === 'string'
+  ))
 }


### PR DESCRIPTION
## Summary
- MarketCard를 프로토타입 기준의 제목/설명/배지/실제 수치 박스 구조로 복구했습니다.
- summary는 초보자 친화적 해석 문장으로 유지하고, detail box에는 출처/계산식/실제 값을 노출합니다.
- 시장 페이지의 KPI 상단 구조와 5개 상세 카드 흐름은 유지합니다.

## Validation
- `COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm@9.15.4 verify`

## Notes
- FRED, onoff.markets, multpl 기반 데이터가 들어오는 경우에만 상세 수치를 채우고, 실패 시에는 데이터 없음 상태를 유지합니다.