### PR TITLE
feat: DCF projection을 FCFF 성장에서 EBIT-first 방식으로 전환

### DIFF
--- a/src/lib/dcfValuation.test.ts
+++ b/src/lib/dcfValuation.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { calculateDcfValuation, type DcfInput, type FinancialLineItem, type FinancialMetric } from './dcfValuation'
+import {
+  calculateDcfValuation,
+  computeProjectedEbitSeries,
+  computeProjectedFcffFromEbit,
+  type DcfInput,
+  type FinancialLineItem,
+  type FinancialMetric,
+} from './dcfValuation'
 
 function makeMetric(overrides: FinancialMetric = {}): FinancialMetric {
   return {
@@ -69,11 +76,11 @@ describe('calculateDcfValuation', () => {
     }))).toBeNull()
   })
 
-  it('returns null when base fcff is not positive', () => {
+  it('returns null when base ebit is not positive', () => {
     expect(calculateDcfValuation(makeInput({
       lineItems: [
         makeLineItem({
-          ebit: 10,
+          ebit: 0,
           depreciationAndAmortization: 0,
           capitalExpenditure: -100,
           workingCapital: 180,
@@ -113,6 +120,23 @@ describe('calculateDcfValuation', () => {
 
     expect(result).not.toBeNull()
     expect(result!.assumptions.baseFcff).toBe(155)
+  })
+
+  it('allows negative base fcff when base ebit is still positive', () => {
+    const result = calculateDcfValuation(makeInput({
+      lineItems: [
+        makeLineItem({
+          ebit: 10,
+          depreciationAndAmortization: 0,
+          capitalExpenditure: -100,
+          workingCapital: 180,
+        }),
+        makeLineItem({ workingCapital: 90 }),
+      ],
+    }))
+
+    expect(result).not.toBeNull()
+    expect(result!.assumptions.baseFcff).toBeCloseTo(-182.1, 5)
   })
 
   it('marks delta working capital unavailable when only one period exists', () => {
@@ -221,6 +245,14 @@ describe('calculateDcfValuation', () => {
 
     expect(result).not.toBeNull()
     expect(result!.marginOfSafety).toBeGreaterThan(0)
+    expect(result!.projections).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          year: 1,
+          source: 'model',
+        }),
+      ]),
+    )
   })
 
   it('returns negative margin of safety for overvalued case', () => {
@@ -230,5 +262,36 @@ describe('calculateDcfValuation', () => {
 
     expect(result).not.toBeNull()
     expect(result!.marginOfSafety).toBeLessThan(0)
+  })
+})
+
+describe('computeProjectedEbitSeries', () => {
+  it('interpolates growth from base growth to terminal growth', () => {
+    const result = computeProjectedEbitSeries(100, 0.1, 0.02, 3)
+
+    expect(result).toHaveLength(3)
+    expect(result[0]).toEqual({ year: 1, ebit: 110.00000000000001, growth: 0.1, source: 'model' })
+    expect(result[1]).toMatchObject({ year: 2, source: 'model' })
+    expect(result[1].growth).toBeCloseTo(0.06, 10)
+    expect(result[1].ebit).toBeCloseTo(116.60000000000002, 10)
+    expect(result[2]).toMatchObject({ year: 3, source: 'model' })
+    expect(result[2].growth).toBeCloseTo(0.02, 10)
+    expect(result[2].ebit).toBeCloseTo(118.93200000000002, 10)
+  })
+
+  it('uses consensus ebit values when they are available', () => {
+    expect(computeProjectedEbitSeries(100, 0.08, 0.03, 3, [
+      { year: 2, ebit: 120 },
+    ])).toEqual([
+      { year: 1, ebit: 108, growth: 0.08, source: 'model' },
+      { year: 2, ebit: 120, growth: 0.11111111111111116, source: 'consensus' },
+      { year: 3, ebit: 123.60000000000001, growth: 0.03, source: 'model' },
+    ])
+  })
+})
+
+describe('computeProjectedFcffFromEbit', () => {
+  it('derives fcff from ebit and reinvestment inputs', () => {
+    expect(computeProjectedFcffFromEbit(100, 0.21, 10, 20, 5)).toBeCloseTo(64, 5)
   })
 })

--- a/src/lib/dcfValuation.test.ts
+++ b/src/lib/dcfValuation.test.ts
@@ -120,6 +120,31 @@ describe('calculateDcfValuation', () => {
 
     expect(result).not.toBeNull()
     expect(result!.assumptions.baseFcff).toBe(155)
+    expect(result!.projections[0]?.ebit).toBeNull()
+  })
+
+  it('keeps zero free cash flow fallback projections valid and marks ebit unavailable', () => {
+    const result = calculateDcfValuation(makeInput({
+      lineItems: [
+        makeLineItem({
+          ebit: undefined,
+          freeCashFlow: 0,
+          totalDebt: 0,
+          cashAndEquivalents: 0,
+        }),
+        makeLineItem({
+          ebit: undefined,
+          freeCashFlow: 0,
+          totalDebt: 0,
+          cashAndEquivalents: 0,
+        }),
+      ],
+    }))
+
+    expect(result).not.toBeNull()
+    expect(result!.assumptions.baseFcff).toBe(0)
+    expect(result!.enterpriseValue).toBe(0)
+    expect(result!.projections.every(projection => projection.ebit === null && projection.fcff === 0)).toBe(true)
   })
 
   it('allows negative base fcff when base ebit is still positive', () => {
@@ -270,7 +295,9 @@ describe('computeProjectedEbitSeries', () => {
     const result = computeProjectedEbitSeries(100, 0.1, 0.02, 3)
 
     expect(result).toHaveLength(3)
-    expect(result[0]).toEqual({ year: 1, ebit: 110.00000000000001, growth: 0.1, source: 'model' })
+    expect(result[0]).toMatchObject({ year: 1, source: 'model' })
+    expect(result[0].growth).toBeCloseTo(0.1, 10)
+    expect(result[0].ebit).toBeCloseTo(110.00000000000001, 10)
     expect(result[1]).toMatchObject({ year: 2, source: 'model' })
     expect(result[1].growth).toBeCloseTo(0.06, 10)
     expect(result[1].ebit).toBeCloseTo(116.60000000000002, 10)
@@ -280,13 +307,19 @@ describe('computeProjectedEbitSeries', () => {
   })
 
   it('uses consensus ebit values when they are available', () => {
-    expect(computeProjectedEbitSeries(100, 0.08, 0.03, 3, [
+    const result = computeProjectedEbitSeries(100, 0.08, 0.03, 3, [
       { year: 2, ebit: 120 },
-    ])).toEqual([
-      { year: 1, ebit: 108, growth: 0.08, source: 'model' },
-      { year: 2, ebit: 120, growth: 0.11111111111111116, source: 'consensus' },
-      { year: 3, ebit: 123.60000000000001, growth: 0.03, source: 'model' },
     ])
+
+    expect(result).toHaveLength(3)
+    expect(result[0]).toMatchObject({ year: 1, source: 'model' })
+    expect(result[0].growth).toBeCloseTo(0.08, 10)
+    expect(result[0].ebit).toBeCloseTo(108, 10)
+    expect(result[1]).toMatchObject({ year: 2, ebit: 120, source: 'consensus' })
+    expect(result[1].growth).toBeCloseTo(0.11111111111111116, 10)
+    expect(result[2]).toMatchObject({ year: 3, source: 'model' })
+    expect(result[2].growth).toBeCloseTo(0.03, 10)
+    expect(result[2].ebit).toBeCloseTo(123.60000000000001, 10)
   })
 })
 

--- a/src/lib/dcfValuation.ts
+++ b/src/lib/dcfValuation.ts
@@ -29,6 +29,11 @@ export interface DamodaranInputs {
   taxRate?: number
 }
 
+export interface EbitConsensusEstimate {
+  year: number
+  ebit: number
+}
+
 export interface DcfInput {
   metrics: FinancialMetric[]
   lineItems: FinancialLineItem[]
@@ -36,6 +41,7 @@ export interface DcfInput {
   damodaran: DamodaranInputs
   projectionYears?: number
   terminalGrowth?: number
+  consensusEbitEstimates?: EbitConsensusEstimate[]
 }
 
 export type DcfQuality =
@@ -73,10 +79,19 @@ export interface DcfResult {
   }
   projections: Array<{
     year: number
+    ebit: number
     growth: number
     fcff: number
     presentValue: number
+    source: 'consensus' | 'model'
   }>
+}
+
+export interface ProjectedEbitPoint {
+  year: number
+  ebit: number
+  growth: number
+  source: 'consensus' | 'model'
 }
 
 const DEFAULT_BASE_GROWTH = 0.04
@@ -107,9 +122,13 @@ export function calculateDcfValuation(input: DcfInput): DcfResult | null {
   }
 
   const deltaNwc = computeDeltaNwc(input.lineItems)
-  const baseFcff = computeBaseFcff(latestLineItem, taxRate, deltaNwc.value)
+  const baseProjection = computeBaseFcff(latestLineItem, taxRate, deltaNwc.value)
 
-  if (baseFcff === null || baseFcff <= 0) {
+  if (baseProjection.baseFcff === null) {
+    return null
+  }
+
+  if (baseProjection.baseEbit !== null && baseProjection.baseEbit <= 0) {
     return null
   }
 
@@ -142,11 +161,20 @@ export function calculateDcfValuation(input: DcfInput): DcfResult | null {
 
   const baseGrowth = computeBaseGrowth(input.metrics, input.lineItems)
   const projections = buildProjections({
-    baseFcff,
+    baseEbit: baseProjection.baseEbit,
+    baseFcff: baseProjection.baseFcff,
     baseGrowth,
+    baseDepreciationAndAmortization: Math.max(
+      toFiniteNumber(latestLineItem.depreciationAndAmortization) ?? 0,
+      0,
+    ),
+    baseCapitalExpenditure: Math.abs(toFiniteNumber(latestLineItem.capitalExpenditure) ?? 0),
+    baseDeltaNwc: deltaNwc.value,
     projectionYears,
     terminalGrowth,
+    taxRate,
     wacc,
+    consensusEbitEstimates: input.consensusEbitEstimates,
   })
 
   const pvExplicitFcff = sum(projections.map(projection => projection.presentValue))
@@ -165,7 +193,7 @@ export function calculateDcfValuation(input: DcfInput): DcfResult | null {
     intrinsicValuePerShare: equityValue / outstandingShares,
     marginOfSafety,
     assumptions: {
-      baseFcff,
+      baseFcff: baseProjection.baseFcff,
       baseGrowth,
       terminalGrowth,
       wacc,
@@ -196,30 +224,74 @@ export function calculateDcfValuation(input: DcfInput): DcfResult | null {
 }
 
 function buildProjections(input: {
+  baseEbit: number | null
   baseFcff: number
   baseGrowth: number
+  baseDepreciationAndAmortization: number
+  baseCapitalExpenditure: number
+  baseDeltaNwc: number
   projectionYears: number
   terminalGrowth: number
+  taxRate: number
   wacc: number
+  consensusEbitEstimates?: EbitConsensusEstimate[]
 }): DcfResult['projections'] {
-  let fcff = input.baseFcff
+  if (input.baseEbit === null) {
+    let projectedFcff = input.baseFcff
 
-  return Array.from({ length: input.projectionYears }, (_, index) => {
-    const year = index + 1
-    const growth = interpolateGrowth({
-      baseGrowth: input.baseGrowth,
-      projectionYears: input.projectionYears,
-      terminalGrowth: input.terminalGrowth,
-      year,
+    return Array.from({ length: input.projectionYears }, (_, index) => {
+      const year = index + 1
+      const growth = interpolateGrowth({
+        baseGrowth: input.baseGrowth,
+        projectionYears: input.projectionYears,
+        terminalGrowth: input.terminalGrowth,
+        year,
+      })
+
+      projectedFcff *= (1 + growth)
+
+      return {
+        year,
+        ebit: projectedFcff,
+        growth,
+        fcff: projectedFcff,
+        presentValue: projectedFcff / Math.pow(1 + input.wacc, year),
+        source: 'model',
+      }
     })
+  }
 
-    fcff *= (1 + growth)
+  const projectedEbitSeries = computeProjectedEbitSeries(
+    input.baseEbit,
+    input.baseGrowth,
+    input.terminalGrowth,
+    input.projectionYears,
+    input.consensusEbitEstimates,
+  )
+  let projectedDepreciationAndAmortization = input.baseDepreciationAndAmortization
+  let projectedCapitalExpenditure = input.baseCapitalExpenditure
+  let projectedDeltaNwc = input.baseDeltaNwc
+
+  return projectedEbitSeries.map(item => {
+    projectedDepreciationAndAmortization *= (1 + item.growth)
+    projectedCapitalExpenditure *= (1 + item.growth)
+    projectedDeltaNwc *= (1 + item.growth)
+
+    const fcff = computeProjectedFcffFromEbit(
+      item.ebit,
+      input.taxRate,
+      projectedDepreciationAndAmortization,
+      projectedCapitalExpenditure,
+      projectedDeltaNwc,
+    )
 
     return {
-      year,
-      growth,
+      year: item.year,
+      ebit: item.ebit,
+      growth: item.growth,
       fcff,
-      presentValue: fcff / Math.pow(1 + input.wacc, year),
+      presentValue: fcff / Math.pow(1 + input.wacc, item.year),
+      source: item.source,
     }
   })
 }
@@ -254,17 +326,75 @@ function computeBaseFcff(
   lineItem: FinancialLineItem,
   taxRate: number,
   deltaNwc: number,
-): number | null {
+): { baseEbit: number | null; baseFcff: number | null } {
   const ebit = toFiniteNumber(lineItem.ebit)
   const depreciationAndAmortization = toFiniteNumber(lineItem.depreciationAndAmortization)
   const capitalExpenditure = toFiniteNumber(lineItem.capitalExpenditure)
 
   if (ebit !== null && depreciationAndAmortization !== null && capitalExpenditure !== null) {
-    const nopat = ebit * (1 - taxRate)
-    return nopat + depreciationAndAmortization - Math.abs(capitalExpenditure) - deltaNwc
+    return {
+      baseEbit: ebit,
+      baseFcff: computeProjectedFcffFromEbit(
+        ebit,
+        taxRate,
+        depreciationAndAmortization,
+        Math.abs(capitalExpenditure),
+        deltaNwc,
+      ),
+    }
   }
 
-  return toFiniteNumber(lineItem.freeCashFlow)
+  return {
+    baseEbit: null,
+    baseFcff: toFiniteNumber(lineItem.freeCashFlow),
+  }
+}
+
+export function computeProjectedEbitSeries(
+  baseEbit: number,
+  fallbackBaseGrowth: number,
+  terminalGrowth: number,
+  projectionYears: number,
+  consensusEbitEstimates?: EbitConsensusEstimate[],
+): ProjectedEbitPoint[] {
+  let previousEbit = baseEbit
+
+  return Array.from({ length: projectionYears }, (_, index) => {
+    const year = index + 1
+    const consensusEstimate = consensusEbitEstimates?.find(item => item.year === year)
+    const growth = consensusEstimate === undefined
+      ? interpolateGrowth({
+        baseGrowth: fallbackBaseGrowth,
+        projectionYears,
+        terminalGrowth,
+        year,
+      })
+      : previousEbit === 0
+        ? 0
+        : (consensusEstimate.ebit / previousEbit) - 1
+    const ebit = consensusEstimate?.ebit ?? previousEbit * (1 + growth)
+    const source = consensusEstimate === undefined ? 'model' : 'consensus'
+
+    previousEbit = ebit
+
+    return {
+      year,
+      ebit,
+      growth,
+      source,
+    }
+  })
+}
+
+export function computeProjectedFcffFromEbit(
+  ebit: number,
+  taxRate: number,
+  dna: number,
+  capex: number,
+  deltaNwc: number,
+): number {
+  const nopat = ebit * (1 - taxRate)
+  return nopat + dna - capex - deltaNwc
 }
 
 function computeBaseGrowth(metrics: FinancialMetric[], lineItems: FinancialLineItem[]): number {

--- a/src/lib/dcfValuation.ts
+++ b/src/lib/dcfValuation.ts
@@ -79,7 +79,7 @@ export interface DcfResult {
   }
   projections: Array<{
     year: number
-    ebit: number
+    ebit: number | null
     growth: number
     fcff: number
     presentValue: number
@@ -252,7 +252,7 @@ function buildProjections(input: {
 
       return {
         year,
-        ebit: projectedFcff,
+        ebit: null,
         growth,
         fcff: projectedFcff,
         presentValue: projectedFcff / Math.pow(1 + input.wacc, year),


### PR DESCRIPTION
## Summary
- `buildProjections` 내부를 EBIT-first 구조로 전환: 연도별 EBIT 예측 후 D&A/CapEx/ΔWC를 연동해 FCFF 계산
- `computeProjectedEbitSeries`, `computeProjectedFcffFromEbit` 함수 추출 및 export
- `DcfInput`에 `consensusEbitEstimates?` 스캐폴딩 추가 (Issue B 준비)
- `DcfResult.projections`에 `ebit: number | null`, `source: 'consensus' | 'model'` 필드 추가
- `baseFcff <= 0` 가드를 `baseEbit <= 0` 기준으로 전환 (EBIT이 양수면 FCFF 음수여도 진행)
- freeCashFlow fallback 경로에서 `ebit: null` 명시

## Test plan
- [ ] `pnpm verify` 통과 (163 tests)
- [ ] 컨센서스 없는 경우 수치가 기존 대비 합리적 범위에서 변화하는 것 확인
- [ ] `freeCashFlow=0` fallback 엣지케이스 문서화 테스트 포함

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)