### PR TITLE
feat: FMP 애널리스트 컨센서스 EBIT을 DCF 입력으로 연동한다

### DIFF
--- a/src/app/api/dcf/route.ts
+++ b/src/app/api/dcf/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import damodaranBetas from '@/data/damodaranBetas.json'
 import { calculateDcfValuation } from '@/lib/dcfValuation'
 import { fetchImpliedErp } from '@/lib/damodaranErp'
-import { fetchFmpDcfSnapshot, toDcfInput } from '@/lib/fmpAdapter'
+import { fetchAnalystEbitEstimates, fetchFmpDcfSnapshot, toDcfInput } from '@/lib/fmpAdapter'
 
 const CACHE_HEADERS = {
   'Cache-Control': 'public, max-age=0, s-maxage=86400, stale-while-revalidate=86400',
@@ -28,19 +28,23 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const [fmpSnapshot, equityRiskPremium] = await Promise.all([
+    const [fmpSnapshot, equityRiskPremium, consensusEbitEstimates] = await Promise.all([
       fetchFmpDcfSnapshot(ticker),
       fetchImpliedErp(),
+      fetchAnalystEbitEstimates(ticker),
     ])
 
     const industryUnleveredBeta = getIndustryUnleveredBeta(fmpSnapshot.sector)
-    const valuation = calculateDcfValuation(toDcfInput(fmpSnapshot, {
-      riskFreeRate: 0.043,
-      equityRiskPremium,
-      companyBeta: fmpSnapshot.companyBeta,
-      industryUnleveredBeta,
-      taxRate: 0.21,
-    }))
+    const valuation = calculateDcfValuation({
+      ...toDcfInput(fmpSnapshot, {
+        riskFreeRate: 0.043,
+        equityRiskPremium,
+        companyBeta: fmpSnapshot.companyBeta,
+        industryUnleveredBeta,
+        taxRate: 0.21,
+      }),
+      consensusEbitEstimates,
+    })
 
     if (valuation === null) {
       return NextResponse.json(
@@ -49,7 +53,13 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    return NextResponse.json(valuation, { headers: CACHE_HEADERS })
+    return NextResponse.json(
+      {
+        ...valuation,
+        consensusYears: valuation.diagnostics.consensusYears,
+      },
+      { headers: CACHE_HEADERS },
+    )
   } catch (error) {
     console.error('dcf route failed', error)
 

--- a/src/lib/dcfValuation.test.ts
+++ b/src/lib/dcfValuation.test.ts
@@ -288,6 +288,21 @@ describe('calculateDcfValuation', () => {
     expect(result).not.toBeNull()
     expect(result!.marginOfSafety).toBeLessThan(0)
   })
+
+  it('tracks consensus-backed projection years in diagnostics', () => {
+    const result = calculateDcfValuation(makeInput({
+      consensusEbitEstimates: [
+        { year: 1, ebit: 280 },
+        { year: 2, ebit: 320 },
+      ],
+    }))
+
+    expect(result).not.toBeNull()
+    expect(result!.diagnostics.consensusYears).toBe(2)
+    expect(result!.projections[0]).toMatchObject({ year: 1, source: 'consensus', ebit: 280 })
+    expect(result!.projections[1]).toMatchObject({ year: 2, source: 'consensus', ebit: 320 })
+    expect(result!.projections[2]).toMatchObject({ year: 3, source: 'model' })
+  })
 })
 
 describe('computeProjectedEbitSeries', () => {

--- a/src/lib/dcfValuation.ts
+++ b/src/lib/dcfValuation.ts
@@ -72,6 +72,7 @@ export interface DcfResult {
     pvExplicitFcff: number
     pvTerminalValue: number
     terminalValueWeight: number
+    consensusYears: number
     quality: DcfQuality
     waccClamped: boolean
     deltaNwcUnavailable: boolean
@@ -185,6 +186,7 @@ export function calculateDcfValuation(input: DcfInput): DcfResult | null {
   const equityValue = enterpriseValue - totalDebt + cashAndEquivalents
   const marginOfSafety = (equityValue - input.marketCap) / input.marketCap
   const negativeEquity = equityValue < 0
+  const consensusYears = projections.filter(projection => projection.source === 'consensus').length
   const terminalValueWeight = enterpriseValue === 0 ? 0 : pvTerminalValue / enterpriseValue
 
   return {
@@ -208,6 +210,7 @@ export function calculateDcfValuation(input: DcfInput): DcfResult | null {
       pvExplicitFcff,
       pvTerminalValue,
       terminalValueWeight,
+      consensusYears,
       quality: classifyQuality({
         baseGrowth,
         terminalValueWeight,

--- a/src/lib/fmpAdapter.test.ts
+++ b/src/lib/fmpAdapter.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchAnalystEbitEstimates } from './fmpAdapter'
+
+const REAL_DATE = Date
+
+function mockDate(isoDate: string) {
+  class MockDate extends Date {
+    constructor(value?: string | number | Date) {
+      super(value ?? isoDate)
+    }
+
+    static override now() {
+      return new REAL_DATE(isoDate).getTime()
+    }
+  }
+
+  vi.stubGlobal('Date', MockDate)
+}
+
+describe('fetchAnalystEbitEstimates', () => {
+  beforeEach(() => {
+    process.env.FMP_API_KEY = 'test-key'
+    mockDate('2026-04-27T00:00:00.000Z')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    delete process.env.FMP_API_KEY
+  })
+
+  it('maps future positive analyst ebit estimates into Y1/Y2 consensus', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { date: '2026-12-31', estimatedEbitAvg: 1200 },
+        { date: '2027-12-31', ebitAvg: 1500 },
+        { date: '2028-12-31', ebitAvg: 1800 },
+        { date: '2027-06-30', ebitAvg: -5 },
+        { date: '2026-01-01', ebitAvg: 900 },
+      ],
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    await expect(fetchAnalystEbitEstimates('nvda')).resolves.toEqual([
+      { year: 1, ebit: 1200 },
+      { year: 2, ebit: 1500 },
+    ])
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://financialmodelingprep.com/stable/analyst-estimates?symbol=NVDA&period=annual&page=0&limit=10&apikey=test-key',
+      { next: { revalidate: 86_400 } },
+    )
+  })
+
+  it('returns an empty array when the endpoint returns no estimates', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    }))
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await expect(fetchAnalystEbitEstimates('msft')).resolves.toEqual([])
+  })
+
+  it('warns and returns an empty array when EBIT consensus fields are missing', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { date: '2026-12-31', estimatedRevenueAvg: 999 },
+      ],
+    }))
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await expect(fetchAnalystEbitEstimates('aapl')).resolves.toEqual([])
+    expect(warnSpy).toHaveBeenCalledWith('FMP analyst-estimates missing EBIT consensus field for AAPL')
+  })
+})

--- a/src/lib/fmpAdapter.ts
+++ b/src/lib/fmpAdapter.ts
@@ -1,4 +1,9 @@
-import type { DcfInput, FinancialLineItem, FinancialMetric } from '@/lib/dcfValuation'
+import type {
+  DcfInput,
+  EbitConsensusEstimate,
+  FinancialLineItem,
+  FinancialMetric,
+} from '@/lib/dcfValuation'
 
 interface FmpIncomeStatement {
   operatingIncome?: number | null
@@ -27,6 +32,12 @@ interface FmpProfile {
   sector?: string | null
 }
 
+interface FmpAnalystEstimate {
+  date?: string | null
+  ebitAvg?: number | null
+  estimatedEbitAvg?: number | null
+}
+
 export interface FmpDcfSnapshot {
   companyBeta?: number
   lineItems: FinancialLineItem[]
@@ -36,7 +47,75 @@ export interface FmpDcfSnapshot {
 }
 
 const FMP_BASE_URL = 'https://financialmodelingprep.com/api/v3'
+const FMP_STABLE_BASE_URL = 'https://financialmodelingprep.com/stable'
 const FMP_STATEMENT_LIMIT = 4
+
+export async function fetchAnalystEbitEstimates(ticker: string): Promise<EbitConsensusEstimate[]> {
+  try {
+    const apiKey = process.env.FMP_API_KEY?.trim()
+
+    if (!apiKey) {
+      throw new Error('FMP_API_KEY is not configured')
+    }
+
+    const normalizedTicker = ticker.toUpperCase()
+    const encodedTicker = encodeURIComponent(normalizedTicker)
+    const estimates = await fetchFmpStableJson<FmpAnalystEstimate[]>(
+      `analyst-estimates?symbol=${encodedTicker}&period=annual&page=0&limit=10&apikey=${apiKey}`,
+    )
+    const today = new Date()
+    const yearOneMaxDate = new Date(today)
+    yearOneMaxDate.setFullYear(today.getFullYear() + 1)
+    const maxDate = new Date(today)
+    maxDate.setFullYear(today.getFullYear() + 2)
+
+    if (estimates.length > 0) {
+      const sample = estimates[0]
+
+      console.info('FMP analyst-estimates response shape', {
+        ticker: encodedTicker,
+        keys: sample ? Object.keys(sample) : [],
+      })
+    }
+
+    if (!estimates.some(estimate => getAnalystEstimateEbit(estimate) !== undefined)) {
+      console.warn(`FMP analyst-estimates missing EBIT consensus field for ${normalizedTicker}`)
+      return []
+    }
+
+    const result = new Map<number, EbitConsensusEstimate>()
+    const sortedEstimates = [...estimates].sort((left, right) => {
+      const leftTime = Date.parse(left.date ?? '')
+      const rightTime = Date.parse(right.date ?? '')
+
+      return leftTime - rightTime
+    })
+
+    for (const estimate of sortedEstimates) {
+      const date = estimate.date ? new Date(estimate.date) : null
+      if (date === null || Number.isNaN(date.getTime()) || date <= today || date > maxDate) {
+        continue
+      }
+
+      const ebit = getAnalystEstimateEbit(estimate)
+      if (ebit === undefined || ebit <= 0) {
+        continue
+      }
+
+      const year = date <= yearOneMaxDate ? 1 : 2
+      if (!result.has(year)) {
+        result.set(year, { year, ebit })
+      }
+    }
+
+    return [1, 2]
+      .map(year => result.get(year))
+      .filter((estimate): estimate is EbitConsensusEstimate => estimate !== undefined)
+  } catch (error) {
+    console.error(`Failed to fetch analyst EBIT estimates for ${ticker.toUpperCase()}`, error)
+    return []
+  }
+}
 
 export async function fetchFmpDcfSnapshot(ticker: string): Promise<FmpDcfSnapshot> {
   const apiKey = process.env.FMP_API_KEY?.trim()
@@ -120,15 +199,27 @@ export function toDcfInput(
 }
 
 async function fetchFmpJson<T>(path: string): Promise<T> {
-  const response = await fetch(`${FMP_BASE_URL}/${path}`, {
+  return await fetchJson<T>(`${FMP_BASE_URL}/${path}`)
+}
+
+async function fetchFmpStableJson<T>(path: string): Promise<T> {
+  return await fetchJson<T>(`${FMP_STABLE_BASE_URL}/${path}`)
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url, {
     next: { revalidate: 86_400 },
   })
 
   if (!response.ok) {
-    throw new Error(`FMP request failed (${response.status}) for ${path}`)
+    throw new Error(`FMP request failed (${response.status}) for ${url}`)
   }
 
   return await response.json() as T
+}
+
+function getAnalystEstimateEbit(estimate: FmpAnalystEstimate): number | undefined {
+  return toNullableNumber(estimate.estimatedEbitAvg) ?? toNullableNumber(estimate.ebitAvg)
 }
 
 function toNullableNumber(value: number | null | undefined): number | undefined {


### PR DESCRIPTION
## Summary
- `fetchAnalystEbitEstimates` 추가: FMP `/stable/analyst-estimates` → Y1/Y2 `EbitConsensusEstimate[]` 변환
- `estimatedEbitAvg` / `ebitAvg` 이중 필드 처리, 날짜 정렬·연도별 첫 유효값 취득, graceful fallback
- `api/dcf/route.ts`에서 컨센서스 데이터를 `calculateDcfValuation`에 주입
- `DcfResult.diagnostics.consensusYears` 추가 (UI 배지 표시용)
- `fetchJson` 공통 추출로 FMP 요청 레이어 정리

## Test plan
- [ ] `pnpm verify` 통과 (168 tests)
- [ ] `fetchAnalystEbitEstimates`: 정상 응답, 빈 응답, EBIT 필드 없음 케이스 테스트 포함
- [ ] `diagnostics.consensusYears`가 projections source 반영하는 것 확인

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)